### PR TITLE
Rename Theta as requested in #42

### DIFF
--- a/gap/SemilinearMatrixGroups.gi
+++ b/gap/SemilinearMatrixGroups.gi
@@ -42,7 +42,8 @@ end);
 # Return a block matrix where the block in place (i, j) is A ^ k if and only if
 # the entry M[i, j] is omega ^ k (if M[i, j] = 0 then the corresponding block
 # is zero as well).
-Theta := function(M, A, omega)
+# This is the function Theta(...) from [HR05].
+MapGammaLToGL := function(M, A, omega)
     local result, i, j, exponent, dimensionOfA;
 
     if not NumberRows(A) = NumberColumns(A) then
@@ -117,8 +118,8 @@ function(n, q, s)
     fi;
 
     zeta := PrimitiveElement(GF(q ^ s));
-    A := Theta(SL(m, q ^ s).1, As, zeta);
-    B := Theta(SL(m, q ^ s).2, As, zeta);
+    A := MapGammaLToGL(SL(m, q ^ s).1, As, zeta);
+    B := MapGammaLToGL(SL(m, q ^ s).2, As, zeta);
     C := IdentityMat(n, F);
     C{[1..s]}{[1..s]} := Cs;
     D := IdentityMat(n, F);
@@ -182,10 +183,10 @@ function(d, q, s)
 
     omega := PrimitiveElement(GF(q ^ (2 * s)));
     # The following two matrices generate SU(m, q ^ s) as a subgroup of SU(d, q)
-    A := Theta(SU(m, q ^ s).1, As, omega);
-    B := Theta(SU(m, q ^ s).2, As, omega);
+    A := MapGammaLToGL(SU(m, q ^ s).1, As, omega);
+    B := MapGammaLToGL(SU(m, q ^ s).2, As, omega);
     # Note that GUMinusSU(m, q ^ s) ^ (q + 1) has determinant 1.
-    C := Theta(GUMinusSU(m, q ^ s) ^ (q + 1), As, omega);
+    C := MapGammaLToGL(GUMinusSU(m, q ^ s) ^ (q + 1), As, omega);
     # det(D) = 1
     D := IdentityMat(d, GF(q));
     for i in [0..m - 1] do


### PR DESCRIPTION
Fixes #42. 

## Checklist for the reviewer
### General
- [ ] All functions have unit tests

### Functions constructing generators of maximal subgroups
- [ ] The code which computes and then stores the sizes is correct. To do this one confers to the tables referenced by the code. Tests for the group size should use `RECOG.TestGroup` from the recog package.
- [ ] The test suite checks whether all constructed generators are sensible. That is it tests the generators'
  - [ ] determinants (and if applicable also the spinor norms are correct), and
  - [ ] compatibility with the correct form,
  - [ ] `DefaultFieldOfMatrixGroup` returns the correct field.

### Functions assembling the list of all maximal subgroups of a certain group
- [ ] The code agrees with the tables in section 8.2 of the book "The Maximal Subgroups of the Low-dimensional Finite Classical Groups".

The reviewer doesn't need to compare our results to magma's results. That's the job of the person implementing the code.
