### PR TITLE
Update references in ClassicalMaximals.gi as requested in #31

### DIFF
--- a/gap/ClassicalMaximals.gi
+++ b/gap/ClassicalMaximals.gi
@@ -1,14 +1,7 @@
 #
 # ClassicalMaximals: Maximal subgroups of classical groups
 #
-# Code along the lines of:
-# [BHR13]   J. M. Bray, D. F. Holt, C. M. Roney-Dougal. "The Maximal Subgroups of the
-#           Low-Dimensional Finite Classical Groups." Cambridge UP, 2013.
-# [HR05]       D. F. Holt, C. M. Roney-Dougal. "Constructing Maximal Subgroups of
-#           Classical Groups." LMS Journal of Computation and Mathematics, vol. 8,
-#           2005, pp. 46-79.
-# [KL90]       P. Kleidman, M. Liebeck. "The Subgroup Structure of the Finite
-#           Classical Groups." Cambridge UP, 1990.
+# Code along the lines of [BHR13], [HR05] and [KL90].
 #
 # Implementations
 #

--- a/gap/ClassicalMaximals.gi
+++ b/gap/ClassicalMaximals.gi
@@ -2,13 +2,13 @@
 # ClassicalMaximals: Maximal subgroups of classical groups
 #
 # Code along the lines of:
-# [1]   J. M. Bray, D. F. Holt, C. M. Roney-Dougal. "The Maximal Subgroups of the
-#       Low-Dimensional Finite Classical Groups." Cambridge UP, 2013.
-# [2]   D. F. Holt, C. M. Roney-Dougal. "Constructing Maximal Subgroups of
-#       Classical Groups." LMS Journal of Computation and Mathematics, vol. 8,
-#       2005, pp. 46-79.
-# [3]   P. Kleidman, M. Liebeck. "The Subgroup Structure of the Finite
-#       Classical Groups." Cambridge UP, 1990.
+# [BHR13]   J. M. Bray, D. F. Holt, C. M. Roney-Dougal. "The Maximal Subgroups of the
+#           Low-Dimensional Finite Classical Groups." Cambridge UP, 2013.
+# [HR05]       D. F. Holt, C. M. Roney-Dougal. "Constructing Maximal Subgroups of
+#           Classical Groups." LMS Journal of Computation and Mathematics, vol. 8,
+#           2005, pp. 46-79.
+# [KL90]       P. Kleidman, M. Liebeck. "The Subgroup Structure of the Finite
+#           Classical Groups." Cambridge UP, 1990.
 #
 # Implementations
 #
@@ -62,7 +62,7 @@ C2SubgroupsSpecialLinearGroupGeneric := function(n, q)
     result := [];
     for t in divisors{[2..Length(divisors)]} do
         # not maximal or considered in class C_1 or C_8 by Proposition
-        # 2.3.6 of [1]
+        # 2.3.6 of [BHR13]
         if (n > 2 and t = n and q <= 4) or (t = n / 2 and q = 2) then
             continue;  
         fi;
@@ -91,7 +91,7 @@ C4SubgroupsSpecialLinearGroupGeneric := function(n, q)
     generatorGLMinusSL := GLMinusSL(n, q);
     for n1 in divisorListOfn do
         tensorProductSubgroup := TensorProductStabilizerInSL(n1, QuoInt(n, n1), q);
-        # Cf. Tables 3.5.A and 3.5.G in [3]
+        # Cf. Tables 3.5.A and 3.5.G in [KL90]
         numberOfConjugates := Gcd([q - 1, n1, QuoInt(n, n1)]);
         result := Concatenation(result,
                                 ConjugatesInGeneralGroup(tensorProductSubgroup, 
@@ -116,7 +116,7 @@ C5SubgroupsSpecialLinearGroupGeneric := function(n, q)
     for degreeOfExtension in primeDivisorsOfe do
         f := QuoInt(e, degreeOfExtension);
         subfieldGroup := SubfieldSL(n, p, e, f);
-        # Cf. Tables 3.5.A and 3.5.G in [3]
+        # Cf. Tables 3.5.A and 3.5.G in [KL90]
         numberOfConjugates := Gcd(n, QuoInt(q - 1, p ^ f - 1));
         result := Concatenation(result,
                                 ConjugatesInGeneralGroup(subfieldGroup, 
@@ -144,11 +144,11 @@ C6SubgroupsSpecialLinearGroupGeneric := function(n, q)
     m := factorisationOfn[2];
     generatorGLMinusSL := GLMinusSL(n, q);
 
-    # Cf. Table 4.6.B and the corresponding definition in [3]
+    # Cf. Table 4.6.B and the corresponding definition in [KL90]
     if IsOddInt(r) then
         if IsOddInt(e) and e = OrderMod(p, r) then
             extraspecialNormalizerSubgroup := ExtraspecialNormalizerInSL(r, m, q);
-            # Cf. Tables 3.5.A and 3.5.G in [3]
+            # Cf. Tables 3.5.A and 3.5.G in [KL90]
             numberOfConjugates := Gcd(n, q - 1);
             if n = 3 and ((q - 4) mod 9 = 0 or (q - 7) mod 9 = 0) then
                 numberOfConjugates := 1;
@@ -162,7 +162,7 @@ C6SubgroupsSpecialLinearGroupGeneric := function(n, q)
         # n = 2 ^ m >= 4
         if e = 1 and (q - 1) mod 4 = 0 then
             extraspecialNormalizerSubgroup := ExtraspecialNormalizerInSL(2, m, q);
-            # Cf. Tables 3.5.A and 3.5.G in [3]
+            # Cf. Tables 3.5.A and 3.5.G in [KL90]
             numberOfConjugates := Gcd(n, q - 1);
             if n = 4 and (q - 5) mod 8 = 0 then
                 numberOfConjugates := 2;
@@ -177,7 +177,7 @@ C6SubgroupsSpecialLinearGroupGeneric := function(n, q)
         if e = 1 and (q - 1) mod 2 = 0 then
             extraspecialNormalizerSubgroup := ExtraspecialNormalizerInSL(2, 1, q);
             if (q - 1) mod 8 = 0 or (q - 7) mod 8 = 0 then
-                # Cf. Tables 3.5.A and 3.5.G in [3]
+                # Cf. Tables 3.5.A and 3.5.G in [KL90]
                 numberOfConjugates := Gcd(n, q - 1);
                 result := Concatenation(result,
                                         ConjugatesInGeneralGroup(extraspecialNormalizerSubgroup,
@@ -215,7 +215,7 @@ C7SubgroupsSpecialLinearGroupGeneric := function(n, q)
             continue;
         fi;
         tensorInducedSubgroup := TensorInducedDecompositionStabilizerInSL(m, t, q);
-        # Cf. Tables 3.5.A and 3.5.G in [3]
+        # Cf. Tables 3.5.A and 3.5.G in [KL90]
         numberOfConjugates := Gcd(q - 1, m ^ (t - 1));
         if m mod 4 = 2 and t = 2 and q mod 4 = 3 then
             numberOfConjugates := Gcd(q - 1, m) / 2;
@@ -242,7 +242,7 @@ C8SubgroupsSpecialLinearGroupGeneric := function(n, q)
 
     if IsEvenInt(n) then
         symplecticSubgroup := SymplecticNormalizerInSL(n, q);
-        # Cf. Tables 3.5.A and 3.5.G in [3]
+        # Cf. Tables 3.5.A and 3.5.G in [KL90]
         numberOfConjugatesSymplectic := Gcd(q - 1, QuoInt(n, 2));
         result := Concatenation(result,
                                 ConjugatesInGeneralGroup(symplecticSubgroup, 
@@ -252,7 +252,7 @@ C8SubgroupsSpecialLinearGroupGeneric := function(n, q)
 
     if IsEvenInt(e) then
         unitarySubgroup := UnitaryNormalizerInSL(n, q);
-        # Cf. Tables 3.5.A and 3.5.G in [3]
+        # Cf. Tables 3.5.A and 3.5.G in [KL90]
         numberOfConjugatesUnitary := Gcd(p ^ QuoInt(e, 2) - 1, n);
         result := Concatenation(result,
                                 ConjugatesInGeneralGroup(unitarySubgroup,
@@ -263,7 +263,7 @@ C8SubgroupsSpecialLinearGroupGeneric := function(n, q)
     if IsOddInt(q) then
         if IsOddInt(n) then
             orthogonalSubgroup := OrthogonalNormalizerInSL(0, n, q);
-            # Cf. Tables 3.5.A and 3.5.G in [3]
+            # Cf. Tables 3.5.A and 3.5.G in [KL90]
             numberOfConjugatesOrthogonal := Gcd(q - 1, n);
             result := Concatenation(result,
                                     ConjugatesInGeneralGroup(orthogonalSubgroup,
@@ -272,7 +272,7 @@ C8SubgroupsSpecialLinearGroupGeneric := function(n, q)
         else
             for epsilon in [1, -1] do
                 orthogonalSubgroup := OrthogonalNormalizerInSL(epsilon, n, q);
-                # Cf. Tables 3.5.A. and 3.5.G in [3]
+                # Cf. Tables 3.5.A. and 3.5.G in [KL90]
                 numberOfConjugatesOrthogonal := QuoInt(Gcd(q - 1, n), 2);
                 result := Concatenation(result,
                                         ConjugatesInGeneralGroup(orthogonalSubgroup,
@@ -314,7 +314,7 @@ function(n, q, classes...)
         # Cf. Propositions 3.1.2 (n = 2), 3.2.1 (n = 3), 3.3.1 (n = 4), 
         #                  3.4.1 (n = 5), 3.5.1 (n = 6), 3.6.1 (n = 7), 
         #                  3.7.1 (n = 8), 3.8.1 (n = 9), 3.9.1 (n = 10), 
-        #                  3.10.1 (n = 11), 3.11.1 (n = 12) in [1]
+        #                  3.10.1 (n = 11), 3.11.1 (n = 12) in [BHR13]
         maximalSubgroups := Concatenation(maximalSubgroups,
                                           C1SubgroupsSpecialLinearGroupGeneric(n, q));
     fi;
@@ -326,25 +326,25 @@ function(n, q, classes...)
             #                  3.5.2, 3.5.3, 3.5.4 all (n = 6), 3.6.2 (n = 7),
             #                  3.7.2, 3.7.3, 3.7.4 (all n = 8), 3.8.2 (n = 9),
             #                  3.9.2, 3.9.3, 3.9.4 (all n = 10), 3.10.2 (n = 11),
-            #                  3.11.2, 3.11.3, 3.11.4, 3.11.5, 3.11.6 (n = 12) in [1]
+            #                  3.11.2, 3.11.3, 3.11.4, 3.11.5, 3.11.6 (n = 12) in [BHR13]
             # The exceptions mentioned in these propositions are all general
             # exceptions and are dealt with directly in the function
             # C2SubgroupsSpecialLinearGeneric
             maximalSubgroups := Concatenation(maximalSubgroups,
                                               C2SubgroupsSpecialLinearGroupGeneric(n, q));
         elif n = 2 then
-            # Cf. Lemma 3.1.3 and Theorem 6.3.10 in [1]
+            # Cf. Lemma 3.1.3 and Theorem 6.3.10 in [BHR13]
             if not q in [5, 7, 9, 11] then
                 Add(maximalSubgroups, ImprimitivesMeetSL(2, q, 2));
             fi;
         else
             # n = 4
 
-            # Cf. Proposition 3.3.2 in [1]
+            # Cf. Proposition 3.3.2 in [BHR13]
             if q >= 7 then
                 Add(maximalSubgroups, ImprimitivesMeetSL(4, q, 4));
             fi;
-            # Cf. Proposition 3.3.3 in [1]
+            # Cf. Proposition 3.3.3 in [BHR13]
             if q > 3 then
                 Add(maximalSubgroups, ImprimitivesMeetSL(4, q, 2));
             fi;
@@ -355,12 +355,12 @@ function(n, q, classes...)
         # Class C3 subgroups ######################################################
         # Cf. Propositions 3.3.4 (n = 4), 3.4.3 (n = 5), 3.5.5 (n = 6), 
         #                  3.6.3 (n = 7), 3.7.5 (n = 8), 3.8.3 (n = 9),
-        #                  3.9.5 (n = 10), 3.10.3 (n = 11), 3.11.7 (n = 12) in [1]
+        #                  3.9.5 (n = 10), 3.10.3 (n = 11), 3.11.7 (n = 12) in [BHR13]
         if not n in [2, 3] then
             maximalSubgroups := Concatenation(maximalSubgroups, 
                                               C3SubgroupsSpecialLinearGroupGeneric(n, q));
         elif n = 2 then
-            # Cf. Lemma 3.1.4 and Theorem 6.3.10 in [1]
+            # Cf. Lemma 3.1.4 and Theorem 6.3.10 in [BHR13]
             if not q in [7, 9] then
                 maximalSubgroups := Concatenation(maximalSubgroups, 
                                                   C3SubgroupsSpecialLinearGroupGeneric(2, q));
@@ -368,7 +368,7 @@ function(n, q, classes...)
         else 
             # n = 3
 
-            # Cf. Proposition 3.2.3 in [1]
+            # Cf. Proposition 3.2.3 in [BHR13]
             if q <> 4 then
                 maximalSubgroups := Concatenation(maximalSubgroups, 
                                                   C3SubgroupsSpecialLinearGroupGeneric(3, q));
@@ -379,7 +379,7 @@ function(n, q, classes...)
     if 4 in classes then
         # Class C4 subgroups ######################################################
         # Cf. Propositions 3.5.6 (n = 6), 3.7.7 (n = 8), 3.9.6 (n = 10), 
-        #                  3.11.8 (n = 12) in [1]
+        #                  3.11.8 (n = 12) in [BHR13]
         # For all other n, class C4 is empty.
         maximalSubgroups := Concatenation(maximalSubgroups,
                                           C4SubgroupsSpecialLinearGroupGeneric(n, q));
@@ -390,14 +390,14 @@ function(n, q, classes...)
         # Cf. Propositions 3.2.4 (n = 3), 3.3.5 (n = 4), 3.4.3 (n = 5), 
         #                  3.5.7 (n = 6), 3.6.3 (n = 7), 3.7.8 (n = 8),
         #                  3.8.4 (n = 9), 3.9.7 (n = 10), 3.10.3 (n = 11),
-        #                  3.11.9 (n = 12) in [1]
+        #                  3.11.9 (n = 12) in [BHR13]
         if n <> 2 then
             maximalSubgroups := Concatenation(maximalSubgroups,
                                               C5SubgroupsSpecialLinearGroupGeneric(n, q));
         else
             # n = 2
 
-            # Cf. Lemma 3.1.5 in [1]
+            # Cf. Lemma 3.1.5 in [BHR13]
             if  p <> 2 or not IsPrimeInt(e) then
                 maximalSubgroups := Concatenation(maximalSubgroups,
                                                   C5SubgroupsSpecialLinearGroupGeneric(2, q));
@@ -410,10 +410,10 @@ function(n, q, classes...)
         # Cf. Lemma 3.1.6 (n = 2) and Propositions 3.2.5 (n = 3), 3.3.6 (n = 4),
         #                                          3.4.3 (n = 5), 3.6.3 (n = 7),
         #                                          3.7.9 (n = 8), 3.8.5 (n = 9), 
-        #                                          3.10.3 (n = 11) in [1]
+        #                                          3.10.3 (n = 11) in [BHR13]
         # For all other n, class C6 is empty.
 
-        # Cf. Theorem 6.3.10 in [1]
+        # Cf. Theorem 6.3.10 in [BHR13]
         if n <> 2 or not q mod 40 in [11, 19, 21, 29] then 
             maximalSubgroups := Concatenation(maximalSubgroups,
                                               C6SubgroupsSpecialLinearGroupGeneric(n, q));
@@ -422,7 +422,7 @@ function(n, q, classes...)
 
     if 7 in classes then
         # Class C7 subgroups ######################################################
-        # Cf. Proposition 3.8.6 (n = 9) in [1]
+        # Cf. Proposition 3.8.6 (n = 9) in [BHR13]
         # For all other n, class C7 is empty.
         maximalSubgroups := Concatenation(maximalSubgroups,
                                           C7SubgroupsSpecialLinearGroupGeneric(n, q));
@@ -434,7 +434,7 @@ function(n, q, classes...)
         #                                          3.4.3 (n = 5), 3.5.8 (n = 6),
         #                                          3.6.3 (n = 7), 3.7.11 (n = 8),
         #                                          3.8.7 (n = 9), 3.9.8 (n = 10),
-        #                                          3.10.3 (n = 11), 3.11.10 (n = 12) in [1]
+        #                                          3.10.3 (n = 11), 3.11.10 (n = 12) in [BHR13]
         if n <> 2 then
             maximalSubgroups := Concatenation(maximalSubgroups,
                                               C8SubgroupsSpecialLinearGroupGeneric(n, q));
@@ -478,7 +478,7 @@ C2SubgroupsSpecialUnitaryGroupGeneric := function(n, q)
     
     divisorListOfn := List(DivisorsInt(n));
     Remove(divisorListOfn, 1);
-    # Cf. Proposition 2.3.6 in [1]
+    # Cf. Proposition 2.3.6 in [BHR13]
     if q = 2 and 2 in divisorListOfn then
         RemoveSet(divisorListOfn, 2);
     fi;
@@ -509,7 +509,7 @@ C4SubgroupsSpecialUnitaryGroupGeneric := function(n, q)
     generatorGUMinusSU := GUMinusSU(n, q);
     for n1 in divisorListOfn do
         tensorProductSubgroup := TensorProductStabilizerInSU(n1, QuoInt(n, n1), q);
-        # Cf. Tables 3.5.B and 3.5.G in [3]
+        # Cf. Tables 3.5.B and 3.5.G in [KL90]
         numberOfConjugates := Gcd([q + 1, n1, QuoInt(n, n1)]);
         result := Concatenation(result,
                                 ConjugatesInGeneralGroup(tensorProductSubgroup, 
@@ -543,7 +543,7 @@ C5SubgroupsSpecialUnitaryGroupGeneric := function(n, q)
         fi;
         f := QuoInt(e, degreeOfExtension);
         subfieldGroup := SubfieldSL(n, p, e, f);
-        # Cf. Tables 3.5.B and 3.5.G in [3]
+        # Cf. Tables 3.5.B and 3.5.G in [KL90]
         numberOfConjugates := Gcd(n, QuoInt(q + 1, p ^ f + 1));
         result := Concatenation(result,
                                 ConjugatesInGeneralGroup(subfieldGroup, 
@@ -555,7 +555,7 @@ C5SubgroupsSpecialUnitaryGroupGeneric := function(n, q)
     if IsOddInt(q) then
         if IsOddInt(n) then 
             subfieldGroup := OrthogonalSubfieldSU(0, n, q);
-            # Cf. Tables 3.5.B and 3.5.G in [3]
+            # Cf. Tables 3.5.B and 3.5.G in [KL90]
             numberOfConjugates := Gcd(n, q + 1);
             result := Concatenation(result, 
                                     ConjugatesInGeneralGroup(subfieldGroup,
@@ -564,7 +564,7 @@ C5SubgroupsSpecialUnitaryGroupGeneric := function(n, q)
         else 
             for epsilon in [-1, 1] do
                 subfieldGroup := OrthogonalSubfieldSU(epsilon, n, q);
-                # Cf. Tables 3.5.B and 3.5.G in [3]
+                # Cf. Tables 3.5.B and 3.5.G in [KL90]
                 numberOfConjugates := QuoInt(Gcd(q + 1, n), 2);
                 result := Concatenation(result,
                                         ConjugatesInGeneralGroup(subfieldGroup,
@@ -577,7 +577,7 @@ C5SubgroupsSpecialUnitaryGroupGeneric := function(n, q)
     # type Sp subgroups
     if IsEvenInt(n) then
         subfieldGroup := SymplecticSubfieldSU(n, q);
-        # Cf. Tables 3.5.B and 3.5.G in [3]
+        # Cf. Tables 3.5.B and 3.5.G in [KL90]
         numberOfConjugates := Gcd(QuoInt(n, 2), q + 1);
         result := Concatenation(result,
                                 ConjugatesInGeneralGroup(subfieldGroup,
@@ -605,11 +605,11 @@ C6SubgroupsSpecialUnitaryGroupGeneric := function(n, q)
     m := factorisationOfn[2];
     generatorGUMinusSU := GUMinusSU(n, q);
 
-    # Cf. Table 4.6.B and the corresponding definition in [3]
+    # Cf. Table 4.6.B and the corresponding definition in [KL90]
     if IsOddInt(r) then
         if 2 * e = OrderMod(p, r) then
             extraspecialNormalizerSubgroup := ExtraspecialNormalizerInSU(r, m, q);
-            # Cf. Tables 3.5.A and 3.5.G in [3]
+            # Cf. Tables 3.5.A and 3.5.G in [KL90]
             numberOfConjugates := Gcd(n, q + 1);
             if n = 3 and ((q - 2) mod 9 = 0 or (q - 5) mod 9 = 0) then
                 numberOfConjugates := 1;
@@ -623,7 +623,7 @@ C6SubgroupsSpecialUnitaryGroupGeneric := function(n, q)
         # n = 2 ^ m >= 4
         if e = 1 and 2 * e = OrderMod(p, 4) then
             extraspecialNormalizerSubgroup := ExtraspecialNormalizerInSU(2, m, q);
-            # Cf. Tables 3.5.A and 3.5.G in [3]
+            # Cf. Tables 3.5.A and 3.5.G in [KL90]
             numberOfConjugates := Gcd(n, q + 1);
             if n = 4 and (q - 3) mod 8 = 0 then
                 numberOfConjugates := 2;
@@ -660,7 +660,7 @@ C7SubgroupsSpecialUnitaryGroupGeneric := function(n, q)
             continue;
         fi;
         tensorInducedSubgroup := TensorInducedDecompositionStabilizerInSU(m, t, q);
-        # Cf. Tables 3.5.B and 3.5.G in [3]
+        # Cf. Tables 3.5.B and 3.5.G in [KL90]
         numberOfConjugates := Gcd(q + 1, m ^ (t - 1));
         if m mod 4 = 2 and t = 2 and q mod 4 = 1 then
             numberOfConjugates := Gcd(q + 1, m) / 2;
@@ -707,7 +707,7 @@ function(n, q, classes...)
         # Cf. Propositions 3.2.1 (n = 3), 3.3.1 (n = 4), 3.4.1 (n = 5), 
         #                  3.5.1 (n = 6), 3.6.1 (n = 7), 3.7.1 (n = 8), 
         #                  3.8.1 (n = 9), 3.9.1 (n = 10), 3.10.1 (n = 11), 
-        #                  3.11.1 (n = 12) in [1]
+        #                  3.11.1 (n = 12) in [BHR13]
         maximalSubgroups := Concatenation(maximalSubgroups,
                                           C1SubgroupsSpecialUnitaryGroupGeneric(n, q));
     fi;
@@ -719,12 +719,12 @@ function(n, q, classes...)
         #                  3.6.2 (n = 7), 3.7.2, 3.7.3, 3.7.4 (all n = 8),
         #                  3.8.2 (n = 9), 3.9.2, 3.9.3, 3.9.4, 3.9.5 (all n = 10),
         #                  3.10.2 (n = 11), 3.11.2, 3.11.3, 3.11.4, 3.11.5,
-        #                  3.11.6 (all n = 12) in [1]
+        #                  3.11.6 (all n = 12) in [BHR13]
         if not (n = 3 and q = 5) and not (n = 4 and q <= 3) and not (n = 6 and q = 2) then
             maximalSubgroups := Concatenation(maximalSubgroups,
                                               C2SubgroupsSpecialUnitaryGroupGeneric(n, q));
         # There are no maximal C2 subgroups for n = 3 and q = 5, cf. Theorem
-        # 6.3.10 in [1].
+        # 6.3.10 in [BHR13].
         elif n = 4 and q <= 3 then
             if q = 3 then
                 Add(maximalSubgroups, SUNonDegenerateImprimitives(n, q, 2));
@@ -744,7 +744,7 @@ function(n, q, classes...)
         # Cf. Propositions 3.2.3 (n = 3), 3.3.4 (n = 4), 3.4.3 (n = 5), 
         #                  3.5.5 (n = 6), 3.6.3 (n = 7), 3.7.5 (n = 8), 
         #                  3.8.3 (n = 9), 3.9.5 (n = 10), 3.10.3 (n = 11), 
-        #                  3.11.7 (n = 12) in [1]
+        #                  3.11.7 (n = 12) in [BHR13]
         if not (n = 6 and q = 2) and not (n = 3 and q = 5)
                                  and not (n = 3 and q = 3)
                                  and not (n = 5 and q = 2) then
@@ -752,13 +752,13 @@ function(n, q, classes...)
                                               C3SubgroupsSpecialUnitaryGroupGeneric(n, q));
         fi;
         # There are no maximal C3 subgroups in the cases excluded above, cf.
-        # Proposition 3.5.5 and Theorem 6.3.10 in [1]
+        # Proposition 3.5.5 and Theorem 6.3.10 in [BHR13]
     fi;
 
     if 4 in classes then
         # Class C4 subgroups ######################################################
         # Cf. Propositions 3.5.6 (n = 6), 3.7.7 (n = 8), 3.9.6 (n = 10), 
-        #                  3.11.8 (n = 12) in [1]
+        #                  3.11.8 (n = 12) in [BHR13]
         maximalSubgroups := Concatenation(maximalSubgroups, 
                                           C4SubgroupsSpecialUnitaryGroupGeneric(n, q));
     fi;
@@ -773,11 +773,11 @@ function(n, q, classes...)
             maximalSubgroups := Concatenation(maximalSubgroups,
                                               C5SubgroupsSpecialUnitaryGroupGeneric(n, q));
         # There are no maximal C5 subgroups for n = 3 and q = 3 or n = 3 and q = 5, 
-        # cf. Proposition 3.2.4 and Theorem 6.3.10 in [1]
+        # cf. Proposition 3.2.4 and Theorem 6.3.10 in [BHR13]
         elif n = 4 and q = 3 then
             # type Sp
             subfieldGroup := SymplecticSubfieldSU(n, q);
-            # Cf. Tables 3.5.B and 3.5.G in [3]
+            # Cf. Tables 3.5.B and 3.5.G in [KL90]
             numberOfConjugates := 2;
             maximalSubgroups := Concatenation(maximalSubgroups, 
                                               ConjugatesInGeneralGroup(subfieldGroup,
@@ -785,7 +785,7 @@ function(n, q, classes...)
                                                                        numberOfConjugates));
             # type GO-
             subfieldGroup := OrthogonalSubfieldSU(-1, n, q);
-            # Cf. Tables 3.5.B and 3.5.G in [3]
+            # Cf. Tables 3.5.B and 3.5.G in [KL90]
             numberOfConjugates := 2;
             maximalSubgroups := Concatenation(maximalSubgroups,
                                               ConjugatesInGeneralGroup(subfieldGroup,
@@ -799,10 +799,10 @@ function(n, q, classes...)
         # Cf. Lemma 3.1.6 (n = 2) and Propositions 3.2.5 (n = 3), 3.3.6 (n = 4),
         #                                          3.4.3 (n = 5), 3.6.3 (n = 7),
         #                                          3.7.9 (n = 8), 3.8.5 (n = 9), 
-        #                                          3.10.3 (n = 11) in [1]
+        #                                          3.10.3 (n = 11) in [BHR13]
         # For all other n, class C6 is empty.
 
-        # Cf. Theorem 6.3.10 in [1]
+        # Cf. Theorem 6.3.10 in [BHR13]
         if not (n = 3 and q = 5) then
             maximalSubgroups := Concatenation(maximalSubgroups,
                                               C6SubgroupsSpecialUnitaryGroupGeneric(n, q));
@@ -811,7 +811,7 @@ function(n, q, classes...)
 
     if 7 in classes then
         # Class C7 subgroups ######################################################
-        # Cf. Proposition 3.8.6 (n = 9) in [1]
+        # Cf. Proposition 3.8.6 (n = 9) in [BHR13]
         # For all other n, class C7 is empty.
         maximalSubgroups := Concatenation(maximalSubgroups,
                                           C7SubgroupsSpecialUnitaryGroupGeneric(n, q));


### PR DESCRIPTION
Fixes #31.
 
## Checklist for the reviewer
### General
- [ ] All functions have unit tests

### Functions constructing generators of maximal subgroups
- [ ] The code which computes and then stores the sizes is correct. To do this one confers to the tables referenced by the code. Tests for the group size should use `RECOG.TestGroup` from the recog package.
- [ ] The test suite checks whether all constructed generators are sensible. That is it tests the generators'
  - [ ] determinants (and if applicable also the spinor norms are correct), and
  - [ ] compatibility with the correct form,
  - [ ] `DefaultFieldOfMatrixGroup` returns the correct field.

### Functions assembling the list of all maximal subgroups of a certain group
- [ ] The code agrees with the tables in section 8.2 of the book "The Maximal Subgroups of the Low-dimensional Finite Classical Groups".

The reviewer doesn't need to compare our results to magma's results. That's the job of the person implementing the code.
