### PR TITLE
Fix some syntax errors from previous PRs

### DIFF
--- a/gap/ClassicalNormalizerMatrixGroups.gi
+++ b/gap/ClassicalNormalizerMatrixGroups.gi
@@ -1,7 +1,7 @@
 # Construction as in Proposition 11.1 of [HR05]
 BindGlobal("SymplecticNormalizerInSL",
 function(d, q)
-    local F, zeta, gcd, A, B, C, D, i, E, result;
+    local F, zeta, gcd, AandB, C, D, i, E, result;
     if IsOddInt(d) then
         ErrorNoReturn("<d> must be even but <d> = ", d);
     fi;

--- a/gap/SemilinearMatrixGroups.gi
+++ b/gap/SemilinearMatrixGroups.gi
@@ -143,7 +143,7 @@ end);
 # Construction as in Proposition 6.6 of [HR05]
 BindGlobal("GammaLMeetSU",
 function(d, q, s)
-    local F, As, Bs, Cs, Fs, m, gammaL1, Y, A, B, C, D, i,
+    local F, As, Bs, Cs, Fs, m, gammaL1, Y, AandB, C, D, i,
     range, result, AsInGU, omega, generators;
     if d mod s <> 0 or not IsPrime(s) or not IsOddInt(s) then
         ErrorNoReturn("<s> must be an odd prime and a divisor of <d> but <s> = ", s,

--- a/gap/SubfieldMatrixGroups.gi
+++ b/gap/SubfieldMatrixGroups.gi
@@ -50,7 +50,7 @@ end);
 # Construction as in Proposition 8.3 of [HR05]
 BindGlobal("UnitarySubfieldSU",
 function(d, p, e, f)
-    local F, A, B, C, D, c, k, q, matrixForCongruence, lambda, zeta, omega, z, X,
+    local F, AandB, C, D, c, k, q, matrixForCongruence, lambda, zeta, omega, z, X,
         result, generators;
 
     if e mod f <> 0 or not IsPrimeInt(QuoInt(e, f)) or not IsOddInt(QuoInt(e, f)) then

--- a/gap/Utils.gi
+++ b/gap/Utils.gi
@@ -365,7 +365,7 @@ end);
 
 InstallGlobalFunction("MatrixGroup",
 function(gens, F)
-    return Group(List(gens, g -> ImmutableMatrix(F, g));
+    return Group(List(gens, g -> ImmutableMatrix(F, g)));
 end);
 
 InstallGlobalFunction("MatrixGroupWithSize",


### PR DESCRIPTION
## Checklist for the reviewer
### General
- [ ] All functions have unit tests

### Functions constructing generators of maximal subgroups
- [ ] The code which computes and then stores the sizes is correct. To do this one confers to the tables referenced by the code. Tests for the group size should use `RECOG.TestGroup` from the recog package.
- [ ] The test suite checks whether all constructed generators are sensible. That is it tests the generators'
  - [ ] determinants (and if applicable also the spinor norms are correct), and
  - [ ] compatibility with the correct form,
  - [ ] `DefaultFieldOfMatrixGroup` returns the correct field.

### Functions assembling the list of all maximal subgroups of a certain group
- [ ] The code agrees with the tables in section 8.2 of the book "The Maximal Subgroups of the Low-dimensional Finite Classical Groups".

The reviewer doesn't need to compare our results to magma's results. That's the job of the person implementing the code.
