### PR TITLE
Refactor and adapt tests as requested in #37 and #29, #58

### DIFF
--- a/tst/standard/ClassicalNormalizerMatrixGroups.tst
+++ b/tst/standard/ClassicalNormalizerMatrixGroups.tst
@@ -1,84 +1,38 @@
-gap> n := 4;; q := 3;;
-gap> G := SymplecticNormalizerInSL(n, q);;
-gap> IsSubset(SL(n, q), GeneratorsOfGroup(G));
+gap> TestSymplecticNormalizerInSL := function(args)
+>   local n, q, G;
+>   n := args[1];
+>   q := args[2];
+>   G := SymplecticNormalizerInSL(n, q);
+>   RECOG.TestGroup(G, false, Size(G));
+>   return IsSubset(SL(n, q), GeneratorsOfGroup(G))
+>          and DefaultFieldOfMatrixGroup(G) = GF(q);
+> end;;
+gap> testsSymplecticNormalizerInSL := [[4, 3], [4, 5], [6, 4]];;
+gap> ForAll(testsSymplecticNormalizerInSL, TestSymplecticNormalizerInSL);
 true
-gap> Size(Group(GeneratorsOfGroup(G))) = Size(G);
+gap> TestUnitaryNormalizerInSL := function(args)
+>   local n, q, G;
+>   n := args[1];
+>   q := args[2];
+>   G := UnitaryNormalizerInSL(n, q);
+>   RECOG.TestGroup(G, false, Size(G));
+>   return IsSubset(SL(n, q), GeneratorsOfGroup(G))
+>          and DefaultFieldOfMatrixGroup(G) = GF(q);
+> end;;
+gap> testsUnitaryNormalizerInSL := [[4, 9], [3, 9], [4, 4]];;
+gap> ForAll(testsUnitaryNormalizerInSL, TestUnitaryNormalizerInSL);
 true
-gap> n := 4;; q := 5;;
-gap> G := SymplecticNormalizerInSL(n, q);;
-gap> IsSubset(SL(n, q), GeneratorsOfGroup(G));
-true
-gap> Size(Group(GeneratorsOfGroup(G))) = Size(G);
-true
-gap> n := 6;; q := 4;;
-gap> G := SymplecticNormalizerInSL(n, q);;
-gap> IsSubset(SL(n, q), GeneratorsOfGroup(G));
-true
-gap> Size(Group(GeneratorsOfGroup(G))) = Size(G);
-true
-gap> n := 4;; q := 9;;
-gap> G := UnitaryNormalizerInSL(n, q);;
-gap> IsSubset(SL(n, q), GeneratorsOfGroup(G));
-true
-gap> Size(Group(GeneratorsOfGroup(G))) = Size(G);
-true
-gap> n := 3;; q := 9;;
-gap> G := UnitaryNormalizerInSL(n, q);;
-gap> IsSubset(SL(n, q), GeneratorsOfGroup(G));
-true
-gap> Size(Group(GeneratorsOfGroup(G))) = Size(G);
-true
-gap> n := 4;; q := 4;;
-gap> G := UnitaryNormalizerInSL(n, q);;
-gap> IsSubset(SL(n, q), GeneratorsOfGroup(G));
-true
-gap> Size(Group(GeneratorsOfGroup(G))) = Size(G);
-true
-gap> epsilon := 0;; n := 3;; q := 5;;
-gap> G := OrthogonalNormalizerInSL(epsilon, n, q);;
-gap> IsSubset(SL(n, q), GeneratorsOfGroup(G));
-true
-gap> Size(Group(GeneratorsOfGroup(G))) = Size(G);
-true
-gap> epsilon := -1;; n := 6;; q := 5;;
-gap> G := OrthogonalNormalizerInSL(epsilon, n, q);;
-gap> IsSubset(SL(n, q), GeneratorsOfGroup(G));
-true
-gap> Size(Group(GeneratorsOfGroup(G))) = Size(G);
-true
-gap> epsilon := 1;; n := 6;; q := 5;;
-gap> G := OrthogonalNormalizerInSL(epsilon, n, q);;
-gap> IsSubset(SL(n, q), GeneratorsOfGroup(G));
-true
-gap> Size(Group(GeneratorsOfGroup(G))) = Size(G);
-true
-gap> epsilon := -1;; n := 4;; q := 3;;
-gap> G := OrthogonalNormalizerInSL(epsilon, n, q);;
-gap> IsSubset(SL(n, q), GeneratorsOfGroup(G));
-true
-gap> Size(Group(GeneratorsOfGroup(G))) = Size(G);
-true
-gap> epsilon := 1;; n := 4;; q := 3;;
-gap> G := OrthogonalNormalizerInSL(epsilon, n, q);;
-gap> IsSubset(SL(n, q), GeneratorsOfGroup(G));
-true
-gap> Size(Group(GeneratorsOfGroup(G))) = Size(G);
-true
-gap> epsilon := -1;; n := 4;; q := 5;;
-gap> G := OrthogonalNormalizerInSL(epsilon, n, q);;
-gap> IsSubset(SL(n, q), GeneratorsOfGroup(G));
-true
-gap> Size(Group(GeneratorsOfGroup(G))) = Size(G);
-true
-gap> epsilon := 1;; n := 4;; q := 5;;
-gap> G := OrthogonalNormalizerInSL(epsilon, n, q);;
-gap> IsSubset(SL(n, q), GeneratorsOfGroup(G));
-true
-gap> Size(Group(GeneratorsOfGroup(G))) = Size(G);
-true
-gap> epsilon := -1;; n := 6;; q := 3;;
-gap> G := OrthogonalNormalizerInSL(epsilon, n, q);;
-gap> IsSubset(SL(n, q), GeneratorsOfGroup(G));
-true
-gap> Size(Group(GeneratorsOfGroup(G))) = Size(G);
+gap> TestOrthogonalNormalizerInSL := function(args)
+>   local epsilon, n, q, G;
+>   epsilon := args[1];
+>   n := args[2];
+>   q := args[3];
+>   G := OrthogonalNormalizerInSL(epsilon, n, q);
+>   RECOG.TestGroup(G, false, Size(G));
+>   return IsSubset(SL(n, q), GeneratorsOfGroup(G))
+>          and DefaultFieldOfMatrixGroup(G) = GF(q);
+> end;;
+gap> testsOrthogonalNormalizerInSL := [[0, 3, 5], [-1, 6, 5], [1, 6, 5], [-1, 4, 3], [1, 4, 3], 
+>                                      [-1, 4, 5], [1, 4, 5], [-1, 6, 3]];;
+gap> ForAll(testsOrthogonalNormalizerInSL, TestOrthogonalNormalizerInSL);
 true

--- a/tst/standard/ClassicalNormalizerMatrixGroups.tst
+++ b/tst/standard/ClassicalNormalizerMatrixGroups.tst
@@ -1,36 +1,42 @@
 gap> TestSymplecticNormalizerInSL := function(args)
->   local n, q, G;
+>   local n, q, G, hasSize;
 >   n := args[1];
 >   q := args[2];
 >   G := SymplecticNormalizerInSL(n, q);
+>   hasSize := HasSize(G);
 >   RECOG.TestGroup(G, false, Size(G));
 >   return IsSubset(SL(n, q), GeneratorsOfGroup(G))
->          and DefaultFieldOfMatrixGroup(G) = GF(q);
+>          and DefaultFieldOfMatrixGroup(G) = GF(q)
+>          and hasSize;
 > end;;
 gap> testsSymplecticNormalizerInSL := [[4, 3], [4, 5], [6, 4]];;
 gap> ForAll(testsSymplecticNormalizerInSL, TestSymplecticNormalizerInSL);
 true
 gap> TestUnitaryNormalizerInSL := function(args)
->   local n, q, G;
+>   local n, q, G, hasSize;
 >   n := args[1];
 >   q := args[2];
 >   G := UnitaryNormalizerInSL(n, q);
+>   hasSize := HasSize(G);
 >   RECOG.TestGroup(G, false, Size(G));
 >   return IsSubset(SL(n, q), GeneratorsOfGroup(G))
->          and DefaultFieldOfMatrixGroup(G) = GF(q);
+>          and DefaultFieldOfMatrixGroup(G) = GF(q)
+>          and hasSize;
 > end;;
 gap> testsUnitaryNormalizerInSL := [[4, 9], [3, 9], [4, 4]];;
 gap> ForAll(testsUnitaryNormalizerInSL, TestUnitaryNormalizerInSL);
 true
 gap> TestOrthogonalNormalizerInSL := function(args)
->   local epsilon, n, q, G;
+>   local epsilon, n, q, G, hasSize;
 >   epsilon := args[1];
 >   n := args[2];
 >   q := args[3];
 >   G := OrthogonalNormalizerInSL(epsilon, n, q);
+>   hasSize := HasSize(G);
 >   RECOG.TestGroup(G, false, Size(G));
 >   return IsSubset(SL(n, q), GeneratorsOfGroup(G))
->          and DefaultFieldOfMatrixGroup(G) = GF(q);
+>          and DefaultFieldOfMatrixGroup(G) = GF(q)
+>          and hasSize;
 > end;;
 gap> testsOrthogonalNormalizerInSL := [[0, 3, 5], [-1, 6, 5], [1, 6, 5], [-1, 4, 3], [1, 4, 3], 
 >                                      [-1, 4, 5], [1, 4, 5], [-1, 6, 3]];;

--- a/tst/standard/ExtraspecialNormalizerMatrixGroups.tst
+++ b/tst/standard/ExtraspecialNormalizerMatrixGroups.tst
@@ -1,26 +1,30 @@
 gap> TestExtraspecialNormalizerInSL := function(args)
->   local r, m, q, G;
+>   local r, m, q, G, hasSize;
 >   r := args[1];
 >   m := args[2];
 >   q := args[3];
 >   G := ExtraspecialNormalizerInSL(r, m, q);
+>   hasSize := HasSize(G);
 >   RECOG.TestGroup(G, false, Size(G));
 >   return IsSubset(SL(r ^ m, q), GeneratorsOfGroup(G))
->          and DefaultFieldOfMatrixGroup(G) = GF(q);
+>          and DefaultFieldOfMatrixGroup(G) = GF(q)
+>          and hasSize;
 > end;;
 gap> testsExtraspecialNormalizerInSL := [[5, 1, 11], [3, 1, 7], [3, 2, 13], [2, 3, 5], [2, 2, 5], 
 >                                        [2, 2, 9], [2, 1, 9], [2, 1, 5], [2, 1, 7]];;
 gap> ForAll(testsExtraspecialNormalizerInSL, TestExtraspecialNormalizerInSL);
 true
 gap> TestExtraspecialNormalizerInSU := function(args)
->   local r, m, q, G;
+>   local r, m, q, G, hasSize;
 >   r := args[1];
 >   m := args[2];
 >   q := args[3];
 >   G := ExtraspecialNormalizerInSU(r, m, q);
+>   hasSize := HasSize(G);
 >   RECOG.TestGroup(G, false, Size(G));
 >   return IsSubset(SU(r ^ m, q), GeneratorsOfGroup(G))
->          and DefaultFieldOfMatrixGroup(G) = GF(q ^ 2);
+>          and DefaultFieldOfMatrixGroup(G) = GF(q ^ 2)
+>          and hasSize;
 > end;;
 #@if IsBound(CLASSICAL_MAXIMALS_RUN_BROKEN_TESTS)
 gap> testsExtraspecialNormalizerInSU := [[5, 1, 4], [2, 3, 3], [2, 3, 7], [2, 2, 3], [2, 2, 7], 

--- a/tst/standard/ExtraspecialNormalizerMatrixGroups.tst
+++ b/tst/standard/ExtraspecialNormalizerMatrixGroups.tst
@@ -1,106 +1,44 @@
-gap> r := 5;; m := 1;; q := 11;;
-gap> G := ExtraspecialNormalizerInSL(r, m, q);;
-gap> IsSubset(SL(r ^ m, q), GeneratorsOfGroup(G));
+gap> TestExtraspecialNormalizerInSL := function(args)
+>   local r, m, q, G;
+>   r := args[1];
+>   m := args[2];
+>   q := args[3];
+>   G := ExtraspecialNormalizerInSL(r, m, q);
+>   RECOG.TestGroup(G, false, Size(G));
+>   return IsSubset(SL(r ^ m, q), GeneratorsOfGroup(G))
+>          and DefaultFieldOfMatrixGroup(G) = GF(q);
+> end;;
+gap> testsExtraspecialNormalizerInSL := [[5, 1, 11], [3, 1, 7], [3, 2, 13], [2, 3, 5], [2, 2, 5], 
+>                                        [2, 2, 9], [2, 1, 9], [2, 1, 5], [2, 1, 7]];;
+gap> ForAll(testsExtraspecialNormalizerInSL, TestExtraspecialNormalizerInSL);
 true
-gap> Size(Group(GeneratorsOfGroup(G))) = Size(G);
-true
-gap> r := 3;; m := 1;; q := 7;;
-gap> G := ExtraspecialNormalizerInSL(r, m, q);;
-gap> IsSubset(SL(r ^ m, q), GeneratorsOfGroup(G));
-true
-gap> Size(Group(GeneratorsOfGroup(G))) = Size(G);
-true
-gap> r := 3;; m := 2;; q := 13;;
-gap> G := ExtraspecialNormalizerInSL(r, m, q);;
-gap> IsSubset(SL(r ^ m, q), GeneratorsOfGroup(G));
-true
-gap> Size(Group(GeneratorsOfGroup(G))) = Size(G);
-true
-gap> r := 2;; m := 3;; q := 5;;
-gap> G := ExtraspecialNormalizerInSL(r, m, q);;
-gap> IsSubset(SL(r ^ m, q), GeneratorsOfGroup(G));
-true
-gap> Size(Group(GeneratorsOfGroup(G))) = Size(G);
-true
-gap> r := 2;; m := 2;; q := 5;;
-gap> G := ExtraspecialNormalizerInSL(r, m, q);;
-gap> IsSubset(SL(r ^ m, q), GeneratorsOfGroup(G));
-true
-gap> Size(Group(GeneratorsOfGroup(G))) = Size(G);
-true
-gap> r := 2;; m := 2;; q := 9;;
-gap> G := ExtraspecialNormalizerInSL(r, m, q);;
-gap> IsSubset(SL(r ^ m, q), GeneratorsOfGroup(G));
-true
-gap> Size(Group(GeneratorsOfGroup(G))) = Size(G);
-true
-gap> r := 2;; m := 1;; q := 9;;
-gap> G := ExtraspecialNormalizerInSL(r, m, q);;
-gap> IsSubset(SL(r ^ m, q), GeneratorsOfGroup(G));
-true
-gap> Size(Group(GeneratorsOfGroup(G))) = Size(G);
-true
-gap> r := 2;; m := 1;; q := 5;;
-gap> G := ExtraspecialNormalizerInSL(r, m, q);;
-gap> IsSubset(SL(r ^ m, q), GeneratorsOfGroup(G));
-true
-gap> Size(Group(GeneratorsOfGroup(G))) = Size(G);
-true
-gap> r := 2;; m := 1;; q := 7;;
-gap> G := ExtraspecialNormalizerInSL(r, m, q);;
-gap> IsSubset(SL(r ^ m, q), GeneratorsOfGroup(G));
-true
-gap> Size(Group(GeneratorsOfGroup(G))) = Size(G);
-true
-gap> r := 5;; m := 1;; q := 4;;
-gap> G := ExtraspecialNormalizerInSU(r, m, q);;
-gap> IsSubset(SU(r ^ m, q), GeneratorsOfGroup(G));
-true
-gap> Size(Group(GeneratorsOfGroup(G))) = Size(G);
-true
-gap> r := 2;; m := 3;; q := 3;;
-gap> G := ExtraspecialNormalizerInSU(r, m, q);;
-gap> IsSubset(SU(r ^ m, q), GeneratorsOfGroup(G));
-true
-gap> r := 2;; m := 3;; q := 7;;
-gap> G := ExtraspecialNormalizerInSU(r, m, q);;
-gap> IsSubset(SU(r ^ m, q), GeneratorsOfGroup(G));
-true
-gap> r := 2;; m := 2;; q := 3;;
-gap> G := ExtraspecialNormalizerInSU(r, m, q);;
-gap> IsSubset(SU(r ^ m, q), GeneratorsOfGroup(G));
-true
-gap> Size(Group(GeneratorsOfGroup(G))) = Size(G);
-true
-gap> r := 2;; m := 2;; q := 7;;
-gap> G := ExtraspecialNormalizerInSU(r, m, q);;
-gap> IsSubset(SU(r ^ m, q), GeneratorsOfGroup(G));
-true
-gap> Size(Group(GeneratorsOfGroup(G))) = Size(G);
-true
-gap> r := 3;; m := 2;; q := 5;;
-gap> G := ExtraspecialNormalizerInSU(r, m, q);;
-gap> IsSubset(SU(r ^ m, q), GeneratorsOfGroup(G));
-true
-gap> r := 3;; m := 1;; q := 8;;
-gap> G := ExtraspecialNormalizerInSU(r, m, q);;
-gap> IsSubset(SU(r ^ m, q), GeneratorsOfGroup(G));
-true
-gap> Size(Group(GeneratorsOfGroup(G))) = Size(G);
-true
-gap> r := 3;; m := 1;; q := 5;;
-gap> G := ExtraspecialNormalizerInSU(r, m, q);;
-gap> IsSubset(SU(r ^ m, q), GeneratorsOfGroup(G));
-true
-gap> Size(Group(GeneratorsOfGroup(G))) = Size(G);
+gap> TestExtraspecialNormalizerInSU := function(args)
+>   local r, m, q, G;
+>   r := args[1];
+>   m := args[2];
+>   q := args[3];
+>   G := ExtraspecialNormalizerInSU(r, m, q);
+>   RECOG.TestGroup(G, false, Size(G));
+>   return IsSubset(SU(r ^ m, q), GeneratorsOfGroup(G))
+>          and DefaultFieldOfMatrixGroup(G) = GF(q ^ 2);
+> end;;
+#@if IsBound(CLASSICAL_MAXIMALS_RUN_BROKEN_TESTS)
+gap> testsExtraspecialNormalizerInSU := [[5, 1, 4], [2, 3, 3], [2, 3, 7], [2, 2, 3], [2, 2, 7], 
+>                                        [3, 2, 5], [3, 1, 8], [3, 1, 5]];;
+#@else
+gap> testsExtraspecialNormalizerInSU := [[2, 3, 3], [3, 2, 5], [3, 1, 8], [3, 1, 5]];;
+#@fi
+gap> ForAll(testsExtraspecialNormalizerInSU, TestExtraspecialNormalizerInSU);
 true
 gap> TestOddExtraspecialGroup := function(args)
->   local r, m, q, gens;
+>   local r, m, q, gens, G;
 >   r := args[1];
 >   m := args[2];
 >   q := args[3];
 >   gens := OddExtraspecialGroup(r, m, q);
->   return Size(Group(Concatenation(gens.listOfXi, gens.listOfYi))) = r ^ (2 * m + 1);
+>   G := Group(Concatenation(gens.listOfXi, gens.listOfYi));
+>   RECOG.TestGroup(G, false, r ^ (2 * m + 1));
+>   return true;
 > end;;
 gap> testsOddExtraspecialGroup := [[5, 1, 11], [3, 1, 7], [3, 2, 13]];;
 gap> ForAll(testsOddExtraspecialGroup, TestOddExtraspecialGroup);

--- a/tst/standard/ImprimitiveMatrixGroups.tst
+++ b/tst/standard/ImprimitiveMatrixGroups.tst
@@ -27,7 +27,7 @@ gap> TestSUIsotropicImprimitives := function(args)
 #@if IsBound(CLASSICAL_MAXIMALS_RUN_BROKEN_TESTS)
 gap> testsSUIsotropicImprimitives := [[6, 2], [4, 3], [2, 5]];;
 #@else
-gap> testsSUIsotropicImprimitives := [[6, 2], [4, 3]];;
+gap> testsSUIsotropicImprimitives := [[6, 2]];;
 #@fi
 gap> ForAll(testsSUIsotropicImprimitives, TestSUIsotropicImprimitives);
 true

--- a/tst/standard/ImprimitiveMatrixGroups.tst
+++ b/tst/standard/ImprimitiveMatrixGroups.tst
@@ -1,12 +1,14 @@
 gap> TestImprimitivesMeetSL := function(args)
->   local n, q, t, G;
+>   local n, q, t, G, hasSize;
 >   n := args[1];
 >   q := args[2];
 >   t := args[3];
 >   G := ImprimitivesMeetSL(n, q, t);
+>   hasSize := HasSize(G);
 >   RECOG.TestGroup(G, false, Size(G));
 >   return IsSubset(SL(n, q), GeneratorsOfGroup(G))
->          and DefaultFieldOfMatrixGroup(G) = GF(q);
+>          and DefaultFieldOfMatrixGroup(G) = GF(q)
+>          and hasSize;
 > end;;
 #@if IsBound(CLASSICAL_MAXIMALS_RUN_BROKEN_TESTS)
 gap> testsImprimitivesMeetSL := [[2, 3, 2], [4, 8, 2], [6, 5, 3]];;
@@ -16,13 +18,15 @@ gap> testsImprimitivesMeetSL := [[2, 3, 2], [6, 5, 3]];;
 gap> ForAll(testsImprimitivesMeetSL, TestImprimitivesMeetSL);
 true
 gap> TestSUIsotropicImprimitives := function(args)
->   local n, q, G;
+>   local n, q, G, hasSize;
 >   n := args[1];
 >   q := args[2];
 >   G := SUIsotropicImprimitives(n, q);
+>   hasSize := HasSize(G);
 >   RECOG.TestGroup(G, false, Size(G));
 >   return IsSubset(SU(n, q), GeneratorsOfGroup(G))
->          and DefaultFieldOfMatrixGroup(G) = GF(q ^ 2);
+>          and DefaultFieldOfMatrixGroup(G) = GF(q ^ 2)
+>          and hasSize;
 > end;;
 #@if IsBound(CLASSICAL_MAXIMALS_RUN_BROKEN_TESTS)
 gap> testsSUIsotropicImprimitives := [[6, 2], [4, 3], [2, 5]];;
@@ -32,14 +36,16 @@ gap> testsSUIsotropicImprimitives := [[6, 2]];;
 gap> ForAll(testsSUIsotropicImprimitives, TestSUIsotropicImprimitives);
 true
 gap> TestSUNonDegenerateImprimitives := function(args)
->   local n, q, t, G;
+>   local n, q, t, G, hasSize;
 >   n := args[1];
 >   q := args[2];
 >   t := args[3];
 >   G := SUNonDegenerateImprimitives(n, q, t);
+>   hasSize := HasSize(G);
 >   RECOG.TestGroup(G, false, Size(G));
 >   return IsSubset(SU(n, q), GeneratorsOfGroup(G))
->          and DefaultFieldOfMatrixGroup(G) = GF(q ^ 2);
+>          and DefaultFieldOfMatrixGroup(G) = GF(q ^ 2)
+>          and hasSize;
 > end;;
 gap> testsSUNonDegenerateImprimitives := [[6, 3, 3], [9, 2, 3], [3, 5, 3]];;
 gap> ForAll(testsSUNonDegenerateImprimitives, TestSUNonDegenerateImprimitives);

--- a/tst/standard/ReducibleMatrixGroups.tst
+++ b/tst/standard/ReducibleMatrixGroups.tst
@@ -1,12 +1,14 @@
 gap> TestSLStabilizerOfSubspace := function(args)
->   local n, q, k, G;
+>   local n, q, k, G, hasSize;
 >   n := args[1];
 >   q := args[2];
 >   k := args[3];
 >   G := SLStabilizerOfSubspace(n, q, k);
+>   hasSize := HasSize(G);
 >   RECOG.TestGroup(G, false, Size(G));
 >   return IsSubset(SL(n, q), GeneratorsOfGroup(G)) and
->          DefaultFieldOfMatrixGroup(G) = GF(q);
+>          DefaultFieldOfMatrixGroup(G) = GF(q) and
+>          hasSize;
 > end;;
 #@if IsBound(CLASSICAL_MAXIMALS_RUN_BROKEN_TESTS) 
 gap> testsSLStabilizerOfSubspace := [[4, 3, 2], [3, 8, 2], [2, 7, 1]];;
@@ -16,27 +18,31 @@ gap> testsSLStabilizerOfSubspace := [[4, 3, 2], [2, 7, 1]];;
 gap> ForAll(testsSLStabilizerOfSubspace, TestSLStabilizerOfSubspace);
 true
 gap> TestSUStabilizerOfIsotropicSubspace := function(args)
->   local n, q, k, G;
+>   local n, q, k, G, hasSize;
 >   n := args[1];
 >   q := args[2];
 >   k := args[3];
 >   G := SUStabilizerOfIsotropicSubspace(n, q, k);
+>   hasSize := HasSize(G);
 >   RECOG.TestGroup(G, false, Size(G));
 >   return IsSubset(SU(n, q), GeneratorsOfGroup(G)) and
->          DefaultFieldOfMatrixGroup(G) = GF(q ^ 2);
+>          DefaultFieldOfMatrixGroup(G) = GF(q ^ 2) and
+>          hasSize;
 > end;;
 gap> testsSUStabilizerOfIsotropicSubspace := [[4, 3, 2], [3, 5, 1], [3, 4, 1], [4, 3, 1]];;
 gap> ForAll(testsSUStabilizerOfIsotropicSubspace, TestSUStabilizerOfIsotropicSubspace);
 true
 gap> TestSUStabilizerOfNonDegenerateSubspace := function(args)
->   local n, q, k, G;
+>   local n, q, k, G, hasSize;
 >   n := args[1];
 >   q := args[2];
 >   k := args[3];
 >   G := SUStabilizerOfNonDegenerateSubspace(n, q, k);
+>   hasSize := HasSize(G);
 >   RECOG.TestGroup(G, false, Size(G));
 >   return IsSubset(SU(n, q), GeneratorsOfGroup(G)) and
->          DefaultFieldOfMatrixGroup(G) = GF(q ^ 2);
+>          DefaultFieldOfMatrixGroup(G) = GF(q ^ 2) and
+>          hasSize;
 > end;;
 gap> testsSUStabilizerOfNonDegenerateSubspace := [[5, 3, 2], [6, 3, 2], [4, 5, 1], [5, 4, 1]];;
 gap> ForAll(testsSUStabilizerOfNonDegenerateSubspace, TestSUStabilizerOfNonDegenerateSubspace);

--- a/tst/standard/SemilinearMatrixGroups.tst
+++ b/tst/standard/SemilinearMatrixGroups.tst
@@ -1,25 +1,29 @@
 gap> TestGammaLMeetSL := function(args)
->   local n, q, s, G;
+>   local n, q, s, G, hasSize;
 >   n := args[1];
 >   q := args[2];
 >   s := args[3];
 >   G := GammaLMeetSL(n, q, s);
+>   hasSize := HasSize(G);
 >   RECOG.TestGroup(G, false, Size(G));
 >   return IsSubset(SL(n, q), GeneratorsOfGroup(G))
->          and DefaultFieldOfMatrixGroup(G) = GF(q);
+>          and DefaultFieldOfMatrixGroup(G) = GF(q)
+>          and hasSize;
 > end;;
 gap> testsGammaLMeetSL := [[4, 3, 2], [2, 2, 2], [6, 5, 3], [3, 4, 3]];;
 gap> ForAll(testsGammaLMeetSL, TestGammaLMeetSL);
 true
 gap> TestGammaLMeetSU := function(args)
->   local n, q, s, G;
+>   local n, q, s, G, hasSize;
 >   n := args[1];
 >   q := args[2];
 >   s := args[3];
 >   G := GammaLMeetSU(n, q, s);
+>   hasSize := HasSize(G);
 >   RECOG.TestGroup(G, false, Size(G));
 >   return IsSubset(SU(n, q), GeneratorsOfGroup(G))
->          and DefaultFieldOfMatrixGroup(G) = GF(q ^ 2);
+>          and DefaultFieldOfMatrixGroup(G) = GF(q ^ 2)
+>          and hasSize;
 > end;;
 gap> testsGammaLMeetSU := [[3, 5, 3], [6, 3, 3], [3, 7, 3]];;
 gap> ForAll(testsGammaLMeetSU, TestGammaLMeetSU);

--- a/tst/standard/SubfieldMatrixGroups.tst
+++ b/tst/standard/SubfieldMatrixGroups.tst
@@ -14,7 +14,7 @@ gap> TestSubfieldSL := function(args)
 #@if IsBound(CLASSICAL_MAXIMALS_RUN_BROKEN_TESTS)
 gap> testsSubfieldSL := [[4, 2, 4, 2], [2, 3, 6, 2], [3, 7, 3, 1]];;
 #@else
-gap> testsSubfieldSL := [[4, 2, 4, 2], [3, 7, 3, 1]];;
+gap> testsSubfieldSL := [[4, 2, 4, 2]];;
 #@fi
 gap> ForAll(testsSubfieldSL, TestSubfieldSL);
 true
@@ -34,7 +34,7 @@ gap> TestUnitarySubfieldSU := function(args)
 #@if IsBound(CLASSICAL_MAXIMALS_RUN_BROKEN_TESTS) 
 gap> testsUnitarySubfieldSU := [[2, 3, 6, 2], [3, 7, 3, 1], [3, 5, 3, 1]];;
 #@else
-gap> testsUnitarySubfieldSU := [[3, 7, 3, 1], [3, 5, 3, 1]];;
+gap> testsUnitarySubfieldSU := [];;
 #@fi
 gap> ForAll(testsUnitarySubfieldSU, TestUnitarySubfieldSU);
 true

--- a/tst/standard/SubfieldMatrixGroups.tst
+++ b/tst/standard/SubfieldMatrixGroups.tst
@@ -7,14 +7,11 @@ gap> TestSubfieldSL := function(args)
 >   G := SubfieldSL(n, p, e, f);
 >   hasSize := HasSize(G);
 >   RECOG.TestGroup(G, false, Size(G));
->   if not DefaultFieldOfMatrixGroup(G) = GF(p ^ e) then
->       Print(n, p, e, f);
->   fi;
 >   return IsSubset(SL(n, p ^ e), GeneratorsOfGroup(G))
 >          and DefaultFieldOfMatrixGroup(G) = GF(p ^ e)
 >          and hasSize;
 > end;;
-#@if
+#@if IsBound(CLASSICAL_MAXIMALS_RUN_BROKEN_TESTS)
 gap> testsSubfieldSL := [[4, 2, 4, 2], [2, 3, 6, 2], [3, 7, 3, 1]];;
 #@else
 gap> testsSubfieldSL := [[4, 2, 4, 2], [3, 7, 3, 1]];;
@@ -30,14 +27,11 @@ gap> TestUnitarySubfieldSU := function(args)
 >   G := UnitarySubfieldSU(n, p, e, f);
 >   hasSize := HasSize(G);
 >   RECOG.TestGroup(G, false, Size(G));
->   if not DefaultFieldOfMatrixGroup(G) = GF(p ^ (2 * e)) then
->       Print(n, p, e, f);
->   fi;
 >   return IsSubset(SU(n, p ^ e), GeneratorsOfGroup(G))
 >          and DefaultFieldOfMatrixGroup(G) = GF(p ^ (2 * e))
 >          and hasSize;
 > end;;
-#@if
+#@if IsBound(CLASSICAL_MAXIMALS_RUN_BROKEN_TESTS) 
 gap> testsUnitarySubfieldSU := [[2, 3, 6, 2], [3, 7, 3, 1], [3, 5, 3, 1]];;
 #@else
 gap> testsUnitarySubfieldSU := [[3, 7, 3, 1], [3, 5, 3, 1]];;

--- a/tst/standard/SubfieldMatrixGroups.tst
+++ b/tst/standard/SubfieldMatrixGroups.tst
@@ -14,7 +14,11 @@ gap> TestSubfieldSL := function(args)
 >          and DefaultFieldOfMatrixGroup(G) = GF(p ^ e)
 >          and hasSize;
 > end;;
+#@if
 gap> testsSubfieldSL := [[4, 2, 4, 2], [2, 3, 6, 2], [3, 7, 3, 1]];;
+#@else
+gap> testsSubfieldSL := [[4, 2, 4, 2], [3, 7, 3, 1]];;
+#@fi
 gap> ForAll(testsSubfieldSL, TestSubfieldSL);
 true
 gap> TestUnitarySubfieldSU := function(args)
@@ -33,7 +37,11 @@ gap> TestUnitarySubfieldSU := function(args)
 >          and DefaultFieldOfMatrixGroup(G) = GF(p ^ (2 * e))
 >          and hasSize;
 > end;;
+#@if
 gap> testsUnitarySubfieldSU := [[2, 3, 6, 2], [3, 7, 3, 1], [3, 5, 3, 1]];;
+#@else
+gap> testsUnitarySubfieldSU := [[3, 7, 3, 1], [3, 5, 3, 1]];;
+#@fi
 gap> ForAll(testsUnitarySubfieldSU, TestUnitarySubfieldSU);
 true
 gap> TestSymplecticSubfieldSU := function(args)

--- a/tst/standard/SubfieldMatrixGroups.tst
+++ b/tst/standard/SubfieldMatrixGroups.tst
@@ -7,6 +7,9 @@ gap> TestSubfieldSL := function(args)
 >   G := SubfieldSL(n, p, e, f);
 >   hasSize := HasSize(G);
 >   RECOG.TestGroup(G, false, Size(G));
+>   if not DefaultFieldOfMatrixGroup(G) = GF(p ^ e) then
+>       Print(n, p, e, f);
+>   fi;
 >   return IsSubset(SL(n, p ^ e), GeneratorsOfGroup(G))
 >          and DefaultFieldOfMatrixGroup(G) = GF(p ^ e)
 >          and hasSize;
@@ -23,6 +26,9 @@ gap> TestUnitarySubfieldSU := function(args)
 >   G := UnitarySubfieldSU(n, p, e, f);
 >   hasSize := HasSize(G);
 >   RECOG.TestGroup(G, false, Size(G));
+>   if not DefaultFieldOfMatrixGroup(G) = GF(p ^ (2 * e)) then
+>       Print(n, p, e, f);
+>   fi;
 >   return IsSubset(SU(n, p ^ e), GeneratorsOfGroup(G))
 >          and DefaultFieldOfMatrixGroup(G) = GF(p ^ (2 * e))
 >          and hasSize;

--- a/tst/standard/SubfieldMatrixGroups.tst
+++ b/tst/standard/SubfieldMatrixGroups.tst
@@ -1,52 +1,60 @@
 gap> TestSubfieldSL := function(args)
->   local n, p, e, f, G;
+>   local n, p, e, f, G, hasSize;
 >   n := args[1];
 >   p := args[2];
 >   e := args[3];
 >   f := args[4];
 >   G := SubfieldSL(n, p, e, f);
+>   hasSize := HasSize(G);
 >   RECOG.TestGroup(G, false, Size(G));
 >   return IsSubset(SL(n, p ^ e), GeneratorsOfGroup(G))
->          and DefaultFieldOfMatrixGroup(G) = GF(p ^ e);
+>          and DefaultFieldOfMatrixGroup(G) = GF(p ^ e)
+>          and hasSize;
 > end;;
 gap> testsSubfieldSL := [[4, 2, 4, 2], [2, 3, 6, 2], [3, 7, 3, 1]];;
 gap> ForAll(testsSubfieldSL, TestSubfieldSL);
 true
 gap> TestUnitarySubfieldSU := function(args)
->   local n, p, e, f, G;
+>   local n, p, e, f, G, hasSize;
 >   n := args[1];
 >   p := args[2];
 >   e := args[3];
 >   f := args[4];
 >   G := UnitarySubfieldSU(n, p, e, f);
+>   hasSize := HasSize(G);
 >   RECOG.TestGroup(G, false, Size(G));
 >   return IsSubset(SU(n, p ^ e), GeneratorsOfGroup(G))
->          and DefaultFieldOfMatrixGroup(G) = GF(p ^ (2 * e));
+>          and DefaultFieldOfMatrixGroup(G) = GF(p ^ (2 * e))
+>          and hasSize;
 > end;;
 gap> testsUnitarySubfieldSU := [[2, 3, 6, 2], [3, 7, 3, 1], [3, 5, 3, 1]];;
 gap> ForAll(testsUnitarySubfieldSU, TestUnitarySubfieldSU);
 true
 gap> TestSymplecticSubfieldSU := function(args)
->   local n, q, G;
+>   local n, q, G, hasSize;
 >   n := args[1];
 >   q := args[2];
 >   G := SymplecticSubfieldSU(n, q);
+>   hasSize := HasSize(G);
 >   RECOG.TestGroup(G, false, Size(G));
 >   return IsSubset(SU(n, q), GeneratorsOfGroup(G))
->          and DefaultFieldOfMatrixGroup(G) = GF(q ^ 2);
+>          and DefaultFieldOfMatrixGroup(G) = GF(q ^ 2)
+>          and hasSize;
 > end;;
 gap> testsSymplecticSubfieldSU := [[4, 5], [2, 4], [4, 3]];;
 gap> ForAll(testsSymplecticSubfieldSU, TestSymplecticSubfieldSU);
 true
 gap> TestOrthogonalSubfieldSU := function(args)
->   local epsilon, n, q, G;
+>   local epsilon, n, q, G, hasSize;
 >   epsilon := args[1];
 >   n := args[2];
 >   q := args[3];
 >   G := OrthogonalSubfieldSU(epsilon, n, q);
+>   hasSize := HasSize(G);
 >   RECOG.TestGroup(G, false, Size(G));
 >   return IsSubset(SU(n, q), GeneratorsOfGroup(G))
->          and DefaultFieldOfMatrixGroup(G) = GF(q ^ 2);
+>          and DefaultFieldOfMatrixGroup(G) = GF(q ^ 2)
+>          and hasSize;
 > end;;
 #@if IsBound(CLASSICAL_MAXIMALS_RUN_BROKEN_TESTS)
 gap> testsOrthogonalSubfieldSU := [[0, 3, 5], [0, 5, 3], [1, 2, 5], [1, 4, 3], [-1, 2, 3], [-1, 2, 5], [-1, 4, 3]];;

--- a/tst/standard/SubfieldMatrixGroups.tst
+++ b/tst/standard/SubfieldMatrixGroups.tst
@@ -1,94 +1,57 @@
-gap> n := 4;; p := 2;; e := 4;; f := 2;;
-gap> G := SubfieldSL(n, p, e, f);;
-gap> IsSubset(SL(n, p ^ e), GeneratorsOfGroup(G));
+gap> TestSubfieldSL := function(args)
+>   local n, p, e, f, G;
+>   n := args[1];
+>   p := args[2];
+>   e := args[3];
+>   f := args[4];
+>   G := SubfieldSL(n, p, e, f);
+>   RECOG.TestGroup(G, false, Size(G));
+>   return IsSubset(SL(n, p ^ e), GeneratorsOfGroup(G))
+>          and DefaultFieldOfMatrixGroup(G) = GF(p ^ e);
+> end;;
+gap> testsSubfieldSL := [[4, 2, 4, 2], [2, 3, 6, 2], [3, 7, 3, 1]];;
+gap> ForAll(testsSubfieldSL, TestSubfieldSL);
 true
-gap> Size(Group(GeneratorsOfGroup(G))) = Size(G);
+gap> TestUnitarySubfieldSU := function(args)
+>   local n, p, e, f, G;
+>   n := args[1];
+>   p := args[2];
+>   e := args[3];
+>   f := args[4];
+>   G := UnitarySubfieldSU(n, p, e, f);
+>   RECOG.TestGroup(G, false, Size(G));
+>   return IsSubset(SU(n, p ^ e), GeneratorsOfGroup(G))
+>          and DefaultFieldOfMatrixGroup(G) = GF(p ^ (2 * e));
+> end;;
+gap> testsUnitarySubfieldSU := [[2, 3, 6, 2], [3, 7, 3, 1], [3, 5, 3, 1]];;
+gap> ForAll(testsUnitarySubfieldSU, TestUnitarySubfieldSU);
 true
-gap> n := 2;; p := 3;; e := 6;; f := 2;;
-gap> G := SubfieldSL(n, p, e, f);;
-gap> IsSubset(SL(n, p ^ e), GeneratorsOfGroup(G));
+gap> TestSymplecticSubfieldSU := function(args)
+>   local n, q, G;
+>   n := args[1];
+>   q := args[2];
+>   G := SymplecticSubfieldSU(n, q);
+>   RECOG.TestGroup(G, false, Size(G));
+>   return IsSubset(SU(n, q), GeneratorsOfGroup(G))
+>          and DefaultFieldOfMatrixGroup(G) = GF(q ^ 2);
+> end;;
+gap> testsSymplecticSubfieldSU := [[4, 5], [2, 4], [4, 3]];;
+gap> ForAll(testsSymplecticSubfieldSU, TestSymplecticSubfieldSU);
 true
-gap> Size(Group(GeneratorsOfGroup(G))) = Size(G);
-true
-gap> n := 3;; p := 7;; e := 3;; f := 1;;
-gap> G := SubfieldSL(n, p, e, f);;
-gap> IsSubset(SL(n, p ^ e), GeneratorsOfGroup(G));
-true
-gap> Size(Group(GeneratorsOfGroup(G))) = Size(G);
-true
-gap> n := 2;; p := 3;; e := 6;; f := 2;;
-gap> G := UnitarySubfieldSU(n, p, e, f);;
-gap> IsSubset(SU(n, p ^ e), GeneratorsOfGroup(G));
-true
-gap> Size(Group(GeneratorsOfGroup(G))) = Size(G);
-true
-gap> n := 3;; p := 7;; e := 3;; f := 1;;
-gap> G := UnitarySubfieldSU(n, p, e, f);;
-gap> IsSubset(SU(n, p ^ e), GeneratorsOfGroup(G));
-true
-gap> Size(Group(GeneratorsOfGroup(G))) = Size(G);
-true
-gap> n := 3;; p := 5;; e := 3;; f := 1;;
-gap> G := UnitarySubfieldSU(n, p, e, f);;
-gap> IsSubset(SU(n, p ^ e), GeneratorsOfGroup(G));
-true
-gap> n := 4;; q := 5;;
-gap> G := SymplecticSubfieldSU(n, q);;
-gap> IsSubset(SU(n, q), GeneratorsOfGroup(G));
-true
-gap> Size(Group(GeneratorsOfGroup(G))) = Size(G);
-true
-gap> n := 2;; q := 4;;
-gap> G := SymplecticSubfieldSU(n, q);;
-gap> IsSubset(SU(n, q), GeneratorsOfGroup(G));
-true
-gap> Size(Group(GeneratorsOfGroup(G))) = Size(G);
-true
-gap> n := 4;; q := 3;;
-gap> G := SymplecticSubfieldSU(n, q);;
-gap> IsSubset(SU(n, q), GeneratorsOfGroup(G));
-true
-gap> Size(Group(GeneratorsOfGroup(G))) = Size(G);
-true
-gap> epsilon := 0;; n := 3;; q := 5;;
-gap> G := OrthogonalSubfieldSU(epsilon, n, q);;
-gap> IsSubset(SU(n, q), GeneratorsOfGroup(G));
-true
-gap> Size(Group(GeneratorsOfGroup(G))) = Size(G);
-true
-gap> epsilon := 0;; n := 5;; q := 3;;
-gap> G := OrthogonalSubfieldSU(epsilon, n, q);;
-gap> IsSubset(SU(n, q), GeneratorsOfGroup(G));
-true
-gap> Size(Group(GeneratorsOfGroup(G))) = Size(G);
-true
-gap> epsilon := 1;; n := 2;; q := 5;;
-gap> G := OrthogonalSubfieldSU(epsilon, n, q);;
-gap> IsSubset(SU(n, q), GeneratorsOfGroup(G));
-true
-gap> Size(Group(GeneratorsOfGroup(G))) = Size(G);
-true
-gap> epsilon := 1;; n := 4;; q := 3;;
-gap> G := OrthogonalSubfieldSU(epsilon, n, q);;
-gap> IsSubset(SU(n, q), GeneratorsOfGroup(G));
-true
-gap> Size(Group(GeneratorsOfGroup(G))) = Size(G);
-true
-gap> epsilon := -1;; n := 2;; q := 3;;
-gap> G := OrthogonalSubfieldSU(epsilon, n, q);;
-gap> IsSubset(SU(n, q), GeneratorsOfGroup(G));
-true
-gap> Size(Group(GeneratorsOfGroup(G))) = Size(G);
-true
-gap> epsilon := -1;; n := 2;; q := 5;;
-gap> G := OrthogonalSubfieldSU(epsilon, n, q);;
-gap> IsSubset(SU(n, q), GeneratorsOfGroup(G));
-true
-gap> Size(Group(GeneratorsOfGroup(G))) = Size(G);
-true
-gap> epsilon := -1;; n := 4;; q := 3;;
-gap> G := OrthogonalSubfieldSU(epsilon, n, q);;
-gap> IsSubset(SU(n, q), GeneratorsOfGroup(G));
-true
-gap> Size(Group(GeneratorsOfGroup(G))) = Size(G);
+gap> TestOrthogonalSubfieldSU := function(args)
+>   local epsilon, n, q, G;
+>   epsilon := args[1];
+>   n := args[2];
+>   q := args[3];
+>   G := OrthogonalSubfieldSU(epsilon, n, q);
+>   RECOG.TestGroup(G, false, Size(G));
+>   return IsSubset(SU(n, q), GeneratorsOfGroup(G))
+>          and DefaultFieldOfMatrixGroup(G) = GF(q ^ 2);
+> end;;
+#@if IsBound(CLASSICAL_MAXIMALS_RUN_BROKEN_TESTS)
+gap> testsOrthogonalSubfieldSU := [[0, 3, 5], [0, 5, 3], [1, 2, 5], [1, 4, 3], [-1, 2, 3], [-1, 2, 5], [-1, 4, 3]];;
+#@else
+gap> testsOrthogonalSubfieldSU := [[0, 3, 5], [0, 5, 3], [-1, 2, 3], [-1, 4, 3]];;
+#@fi
+gap> ForAll(testsOrthogonalSubfieldSU, TestOrthogonalSubfieldSU);
 true

--- a/tst/standard/TensorInducedMatrixGroups.tst
+++ b/tst/standard/TensorInducedMatrixGroups.tst
@@ -1,25 +1,29 @@
 gap> TestTensorInducedDecompositionStabilizerInSL := function(args)
->   local m, t, q, G;
+>   local m, t, q, G, hasSize;
 >   m := args[1];
 >   t := args[2];
 >   q := args[3];
 >   G := TensorInducedDecompositionStabilizerInSL(m, t, q);
+>   hasSize := HasSize(G);
 >   RECOG.TestGroup(G, false, Size(G));
 >   return IsSubset(SL(m ^ t, q), GeneratorsOfGroup(G))
->          and DefaultFieldOfMatrixGroup(G) = GF(q);
+>          and DefaultFieldOfMatrixGroup(G) = GF(q)
+>          and hasSize;
 > end;;
 gap> testsTensorInducedDecompositionStabilizerInSL := [[3, 2, 5], [2, 2, 7], [2, 2, 5], [3, 3, 3]];;
 gap> ForAll(testsTensorInducedDecompositionStabilizerInSL, TestTensorInducedDecompositionStabilizerInSL);
 true
 gap> TestTensorInducedDecompositionStabilizerInSU := function(args)
->   local m, t, q, G;
+>   local m, t, q, G, hasSize;
 >   m := args[1];
 >   t := args[2];
 >   q := args[3];
 >   G := TensorInducedDecompositionStabilizerInSU(m, t, q);
+>   hasSize := HasSize(G);
 >   RECOG.TestGroup(G, false, Size(G));
 >   return IsSubset(SU(m ^ t, q), GeneratorsOfGroup(G))
->          and DefaultFieldOfMatrixGroup(G) = GF(q ^ 2);
+>          and DefaultFieldOfMatrixGroup(G) = GF(q ^ 2)
+>          and hasSize;
 > end;;
 gap> testsTensorInducedDecompositionStabilizerInSU := [[2, 2, 7], [2, 2, 5], [3, 2, 3], [3, 3, 3], [3, 2, 5]];;
 gap> ForAll(testsTensorInducedDecompositionStabilizerInSU, TestTensorInducedDecompositionStabilizerInSU);

--- a/tst/standard/TensorInducedMatrixGroups.tst
+++ b/tst/standard/TensorInducedMatrixGroups.tst
@@ -1,50 +1,26 @@
-gap> m := 3;; t := 2;; q := 5;;
-gap> G := TensorInducedDecompositionStabilizerInSL(m, t, q);;
-gap> IsSubset(SL(m ^ t, q), GeneratorsOfGroup(G));
+gap> TestTensorInducedDecompositionStabilizerInSL := function(args)
+>   local m, t, q, G;
+>   m := args[1];
+>   t := args[2];
+>   q := args[3];
+>   G := TensorInducedDecompositionStabilizerInSL(m, t, q);
+>   RECOG.TestGroup(G, false, Size(G));
+>   return IsSubset(SL(m ^ t, q), GeneratorsOfGroup(G))
+>          and DefaultFieldOfMatrixGroup(G) = GF(q);
+> end;;
+gap> testsTensorInducedDecompositionStabilizerInSL := [[3, 2, 5], [2, 2, 7], [2, 2, 5], [3, 3, 3]];;
+gap> ForAll(testsTensorInducedDecompositionStabilizerInSL, TestTensorInducedDecompositionStabilizerInSL);
 true
-gap> Size(Group(GeneratorsOfGroup(G))) = Size(G);
-true
-gap> m := 2;; t := 2;; q := 7;;
-gap> G := TensorInducedDecompositionStabilizerInSL(m, t, q);;
-gap> IsSubset(SL(m ^ t, q), GeneratorsOfGroup(G));
-true
-gap> Size(Group(GeneratorsOfGroup(G))) = Size(G);
-true
-gap> m := 2;; t := 2;; q := 5;;
-gap> G := TensorInducedDecompositionStabilizerInSL(m, t, q);;
-gap> IsSubset(SL(m ^ t, q), GeneratorsOfGroup(G));
-true
-gap> Size(Group(GeneratorsOfGroup(G))) = Size(G);
-true
-gap> m := 3;; t := 3;; q := 3;;
-gap> G := TensorInducedDecompositionStabilizerInSL(m, t, q);;
-gap> IsSubset(SL(m ^ t, q), GeneratorsOfGroup(G));
-true
-gap> Size(Group(GeneratorsOfGroup(G))) = Size(G);
-true
-gap> m := 2;; t := 2;; q := 7;;
-gap> G := TensorInducedDecompositionStabilizerInSU(m, t, q);;
-gap> IsSubset(SU(m ^ t, q), GeneratorsOfGroup(G));
-true
-gap> Size(Group(GeneratorsOfGroup(G))) = Size(G);
-true
-gap> m := 2;; t := 2;; q := 5;;
-gap> G := TensorInducedDecompositionStabilizerInSU(m, t, q);;
-gap> IsSubset(SU(m ^ t, q), GeneratorsOfGroup(G));
-true
-gap> Size(Group(GeneratorsOfGroup(G))) = Size(G);
-true
-gap> m := 3;; t := 2;; q := 3;;
-gap> G := TensorInducedDecompositionStabilizerInSU(m, t, q);;
-gap> IsSubset(SU(m ^ t, q), GeneratorsOfGroup(G));
-true
-gap> Size(Group(GeneratorsOfGroup(G))) = Size(G);
-true
-gap> m := 3;; t := 3;; q := 3;;
-gap> G := TensorInducedDecompositionStabilizerInSU(m, t, q);;
-gap> IsSubset(SU(m ^ t, q), GeneratorsOfGroup(G));
-true
-gap> m := 3;; t := 2;; q := 5;;
-gap> G := TensorInducedDecompositionStabilizerInSU(m, t, q);;
-gap> IsSubset(SU(m ^ t, q), GeneratorsOfGroup(G));
+gap> TestTensorInducedDecompositionStabilizerInSU := function(args)
+>   local m, t, q, G;
+>   m := args[1];
+>   t := args[2];
+>   q := args[3];
+>   G := TensorInducedDecompositionStabilizerInSU(m, t, q);
+>   RECOG.TestGroup(G, false, Size(G));
+>   return IsSubset(SU(m ^ t, q), GeneratorsOfGroup(G))
+>          and DefaultFieldOfMatrixGroup(G) = GF(q ^ 2);
+> end;;
+gap> testsTensorInducedDecompositionStabilizerInSU := [[2, 2, 7], [2, 2, 5], [3, 2, 3], [3, 3, 3], [3, 2, 5]];;
+gap> ForAll(testsTensorInducedDecompositionStabilizerInSU, TestTensorInducedDecompositionStabilizerInSU);
 true

--- a/tst/standard/TensorProductMatrixGroups.tst
+++ b/tst/standard/TensorProductMatrixGroups.tst
@@ -1,25 +1,29 @@
 gap> TestTensorProductStabilizerInSL := function(args)
->   local d1, d2, q, G;
+>   local d1, d2, q, G, hasSize;
 >   d1 := args[1];
 >   d2 := args[2];
 >   q := args[3];
 >   G := TensorProductStabilizerInSL(d1, d2, q);
+>   hasSize := HasSize(G);
 >   RECOG.TestGroup(G, false, Size(G));
 >   return IsSubset(SL(d1 * d2, q), GeneratorsOfGroup(G))
->          and DefaultFieldOfMatrixGroup(G) = GF(q);
+>          and DefaultFieldOfMatrixGroup(G) = GF(q)
+>          and hasSize;
 > end;;
 gap> testsTensorProductStabilizerInSL := [[2, 3, 2], [2, 3, 3], [2, 3, 4], [2, 3, 5], [2, 4, 3], [3, 4, 2], [3, 4, 3]];;
 gap> ForAll(testsTensorProductStabilizerInSL, TestTensorProductStabilizerInSL);
 true
 gap> TestTensorProductStabilizerInSU := function(args)
->   local d1, d2, q, G;
+>   local d1, d2, q, G, hasSize;
 >   d1 := args[1];
 >   d2 := args[2];
 >   q := args[3];
 >   G := TensorProductStabilizerInSU(d1, d2, q);
+>   hasSize := HasSize(G);
 >   RECOG.TestGroup(G, false, Size(G));
 >   return IsSubset(SU(d1 * d2, q), GeneratorsOfGroup(G))
->          and DefaultFieldOfMatrixGroup(G) = GF(q ^ 2);
+>          and DefaultFieldOfMatrixGroup(G) = GF(q ^ 2)
+>          and hasSize;
 > end;;
 #@if IsBound(CLASSICAL_MAXIMALS_RUN_BROKEN_TESTS)
 gap> testsTensorProductStabilizerInSU := [[2, 3, 2], [2, 3, 3], [2, 3, 4], [2, 4, 3]];;


### PR DESCRIPTION
- Refactor tests by writing small functions
- Use `RECOG.TestGroup` 
- Test for correctness of `DefaultFieldOfMatrixGroup`

The tests I removed in `SubfieldMatrixGroups.tst` will work once `MatrixGroup` works properly (and not only for small finite fields, as it is the case right now).

Fixes #37. Fixes #58.

## Checklist for the reviewer
### General
- [ ] All functions have unit tests

### Functions constructing generators of maximal subgroups
- [ ] The code which computes and then stores the sizes is correct. To do this one confers to the tables referenced by the code. Tests for the group size should use `RECOG.TestGroup` from the recog package.
- [ ] The test suite checks whether all constructed generators are sensible. That is it tests the generators'
  - [ ] determinants (and if applicable also the spinor norms are correct), and
  - [ ] compatibility with the correct form,
  - [ ] `DefaultFieldOfMatrixGroup` returns the correct field.

### Functions assembling the list of all maximal subgroups of a certain group
- [ ] The code agrees with the tables in section 8.2 of the book "The Maximal Subgroups of the Low-dimensional Finite Classical Groups".

The reviewer doesn't need to compare our results to magma's results. That's the job of the person implementing the code.
