### PR TITLE
Add an InfoClass

### DIFF
--- a/gap/ClassicalMaximals.gd
+++ b/gap/ClassicalMaximals.gd
@@ -1,9 +1,10 @@
 #
 # ClassicalMaximals: Maximal subgroups of classical groups
 #
+DeclareInfoClass("InfoClassicalMaximalsTests");
+
 #! @Chapter Maximal Subgroups of Classical Groups
 #! @Section The Main function
-
 #! @Arguments type, n, q
 #! @Description
 #! Return ...

--- a/tst/standard/ReducibleMatrixGroups.tst
+++ b/tst/standard/ReducibleMatrixGroups.tst
@@ -1,5 +1,6 @@
 gap> TestSLStabilizerOfSubspace := function(args)
 >   local n, q, k, G, hasSize;
+>   Info(InfoClassicalMaximalsTests, 1, args);
 >   n := args[1];
 >   q := args[2];
 >   k := args[3];


### PR DESCRIPTION
@maxhauck , @TristanPfersdorff  You can do `SetInfoLevel(InfoClassicalMaximalsTests, 1)` before running a test, to show its Info-messages. Per default the level is 0 and thus nothing is printed.

## Checklist for the reviewer
### General
- [ ] All functions have unit tests

### Functions constructing generators of maximal subgroups
- [ ] The code which computes and then stores the sizes is correct. To do this one confers to the tables referenced by the code. Tests for the group size should use `RECOG.TestGroup` from the recog package.
- [ ] The test suite checks whether all constructed generators are sensible. That is it tests the generators'
  - [ ] determinants (and if applicable also the spinor norms are correct), and
  - [ ] compatibility with the correct form,
  - [ ] `DefaultFieldOfMatrixGroup` returns the correct field.

### Functions assembling the list of all maximal subgroups of a certain group
- [ ] The code agrees with the tables in section 8.2 of the book "The Maximal Subgroups of the Low-dimensional Finite Classical Groups".

The reviewer doesn't need to compare our results to magma's results. That's the job of the person implementing the code.
