### PR TITLE
Symplectic C2

### DIFF
--- a/gap/ClassicalMaximals.gi
+++ b/gap/ClassicalMaximals.gi
@@ -847,6 +847,43 @@ function(n, q)
     return ImmutableMatrix(F, result);
 end);
 
+BindGlobal("C1SubgroupsSymplecticGroupGeneric",
+function(n, q)
+    local listOfks, result;
+    listOfks := [1..QuoInt(n, 2) - 1];
+    # type P_k subgroups
+    result := List(listOfks, k -> SpStabilizerOfIsotropicSubspace(n, q, k));
+    # type Sp(k, q) _|_ Sp(n - k, q) subgroups
+    result := Concatenation(result, 
+                            List(listOfks, 
+                                k -> SpStabilizerOfNonDegenerateSubspace(n, q, k)));
+    return result;
+end);
+
+BindGlobal("C2SubgroupsSymplecticGroupGeneric",
+function(n, q)
+    local result, divisorListOfn, t;
+    
+    result := [];
+
+    divisorListOfn := List(DivisorsInt(n));
+    Remove(divisorListOfn, 1);
+
+    # type Sp(m, q) \wr Sym(t) subgroups
+    for t in divisorListOfn do
+        if IsEvenInt(QuoInt(n, t)) then
+            Add(result, SpNonDegenerateImprimitives(n, q, t));
+        fi;
+    od;
+
+    # type GL(n / 2, q).2 subgroups
+    if IsEvenInt(n) then
+        Add(result, SpIsotropicImprimitives(n, q));
+    fi;
+
+    return result;
+end);
+
 BindGlobal("C6SubgroupsSymplecticGroupGeneric",
 function(n, q)
     local factorisationOfq, p, e, factorisationOfn, r, m, result,
@@ -879,18 +916,5 @@ function(n, q)
                                            numberOfConjugates); 
     fi;
 
-    return result;
-end);
-
-BindGlobal("C1SubgroupsSymplecticGroupGeneric",
-function(n, q)
-    local listOfks, result;
-    listOfks := [1..QuoInt(n, 2) - 1];
-    # type P_k subgroups
-    result := List(listOfks, k -> SpStabilizerOfIsotropicSubspace(n, q, k));
-    # type Sp(k, q) _|_ Sp(n - k, q) subgroups
-    result := Concatenation(result, 
-                            List(listOfks, 
-                                k -> SpStabilizerOfNonDegenerateSubspace(n, q, k)));
     return result;
 end);

--- a/gap/ClassicalMaximals.gi
+++ b/gap/ClassicalMaximals.gi
@@ -869,6 +869,11 @@ function(n, q)
     divisorListOfn := List(DivisorsInt(n));
     Remove(divisorListOfn, 1);
 
+    # Cf. Proposition 2.3.6 in [BHR13]
+    if q = 2 then
+        RemoveSet(divisorListOfn, QuoInt(n, 2));
+    fi;
+
     # type Sp(m, q) \wr Sym(t) subgroups
     for t in divisorListOfn do
         if IsEvenInt(QuoInt(n, t)) then
@@ -877,7 +882,7 @@ function(n, q)
     od;
 
     # type GL(n / 2, q).2 subgroups
-    if IsEvenInt(n) then
+    if IsOddInt(q) then
         Add(result, SpIsotropicImprimitives(n, q));
     fi;
 

--- a/gap/ImprimitiveMatrixGroups.gi
+++ b/gap/ImprimitiveMatrixGroups.gi
@@ -205,10 +205,8 @@ function(d, q, t)
     gens := [];
 
     # This construction is the same as in Proposition 4.4 of [HR05]
-    # and is also used in the reducible case (C1). This could therefore
-    # be refactored into a Util-function at a later date.
-    # These generators are block matrices of the form [[A 0 B], [0 C 0], [D 0 E]],
-    # which corresponds to a subgroup corresponding to Sp(m, q).
+    # These generators are bidiagonal block matrices,
+    # which generate a subgroup corresponding to Sp(m, q).
     for Spgen in GeneratorsOfGroup(Sp(m, q)) do
         Xi := IdentityMat(d, field);
         Xi{[1..k]}{[1..k]} := Spgen{[1..k]}{[1..k]};
@@ -264,6 +262,48 @@ function(d, q, t)
 end);
 
 
+# Construction as in Proposition 5.3 of [HR05]
+# We stabilise the decomposition into the 2 subspaces
+# < e_1, ..., e_l > and < f_l, ..., f_1 >.
 BindGlobal("SpIsotropicImprimitives",
 function(d, q)
+    local l, field, one, gens, J, GLgen, AorB, C;
+
+    if IsOddInt(d) then
+        ErrorNoReturn("Dimension <d> must be even but ", d, " was given.");
+    fi;
+
+    if IsEvenInt(q) then
+        ErrorNoReturn("Characteristic <q> must be odd but ", q, " was given.");
+    fi;
+
+    l := QuoInt(d, 2);
+
+    field := GF(q);
+    one := One(field);
+    gens := [];
+    J := AntidiagonalMat(l, field);
+    
+    # For either generator of Sp(d,q), we take an
+    # invertable matrix AorB_1 which acts on
+    # the first l basis vectors and puts it in
+    # a matrix with another invertable matrix such
+    # that the form is preserved. This way, the
+    # decomposition must also be preserved.
+    for GLgen in GeneratorsOfGroup(GL(l, q)) do
+        AorB := IdentityMat(d, field);
+        AorB{[1..l]}{[1..l]} := GLgen;
+        AorB{[l + 1 .. d]}{[l + 1 .. d]} := J * TransposedMat(GLgen ^ (-1)) * J;
+        Add(gens, AorB);
+    od;
+
+    # This matrix effectively permutes the two subspaces.
+    C := NullMat(d, d, field);
+    C{[1..l]}{[l + 1..d]} := IdentityMat(l, field);
+    C{[l + 1..d]}{[1..l]} := -IdentityMat(l, field);
+
+    Add(gens, C);
+
+    return MatrixGroupWithSize(field, gens, SizeGL(l, q) * 2);
+
 end);

--- a/gap/ImprimitiveMatrixGroups.gi
+++ b/gap/ImprimitiveMatrixGroups.gi
@@ -184,17 +184,17 @@ function(d, q, t)
     local m, l, k, field, one, gens, Spgen, Xi, C, D;
 
     if IsOddInt(d) then
-        ErrorNoReturn("Dimension <d> must be even but ", d, " was given.");
+        ErrorNoReturn("<d> must be even.");
     fi;
 
     m := QuoInt(d, t);
 
     if not m * t = d then
-        ErrorNoReturn("The number <t> of subspaces must divide the dimension <d> but <d> = ", d, ", <t> = ", t, " was given.");
+        ErrorNoReturn("<t> must divide <d>.");
     fi;
 
     if IsOddInt(m) then
-        ErrorNoReturn("The dimension <m> = <d> / <t> must be even but <m> = ", m, ".");
+        ErrorNoReturn("<m> = <d> / <t> must be even.");
     fi;
 
     l := QuoInt(d, 2);
@@ -205,8 +205,9 @@ function(d, q, t)
     gens := [];
 
     # This construction is the same as in Proposition 4.4 of [HR05]
-    # These generators are bidiagonal block matrices,
-    # which generate a subgroup corresponding to Sp(m, q).
+    # These generators are block matrices of the form
+    # [[A 0 B], [0 C 0], [D 0 E]], which generate a subgroup
+    # corresponding to Sp(m, q).
     for Spgen in GeneratorsOfGroup(Sp(m, q)) do
         Xi := IdentityMat(d, field);
         Xi{[1..k]}{[1..k]} := Spgen{[1..k]}{[1..k]};
@@ -216,7 +217,7 @@ function(d, q, t)
         Add(gens, Xi);
     od;
 
-    # This Matrix will swap the vectors e_i with e_{i + k} and
+    # This matrix will swap the vectors e_i with e_{i + k} and
     # f_i with f_{i + k} for 1 <= i <= k respectively,
     # which corresponds to the product of m transpositions in Sym(t).
     # Since m is even, this permutation has signum 1 and det(C) = 1.
@@ -246,9 +247,8 @@ function(d, q, t)
         # e_i -> e_{((i + k -1) mod l) + 1} and
         # f_i -> f_{((i + k -1) mod l) + 1} 
         # which corresponds to a t-cycle in Sym(t).
-        # Althoug this permutation has signum -1, we still have 
-        # det(C) = 1 because we are effectively swapping an even
-        # number of rows/colums.
+        # We have det(C) = 1 because we are effectively
+        # swapping an even number of rows/colums.
         # One can easily check that this preserves the form.
         D := NullMat(d, d, field);
 
@@ -278,11 +278,11 @@ function(d, q)
     local l, field, one, gens, J, GLgen, AorB, C;
 
     if IsOddInt(d) then
-        ErrorNoReturn("Dimension <d> must be even but ", d, " was given.");
+        ErrorNoReturn("<d> must be even.");
     fi;
 
     if IsEvenInt(q) then
-        ErrorNoReturn("Characteristic <q> must be odd but ", q, " was given.");
+        ErrorNoReturn("<q> must be odd.");
     fi;
 
     l := QuoInt(d, 2);
@@ -293,11 +293,11 @@ function(d, q)
     J := AntidiagonalMat(l, field);
     
     # For either generator of Sp(d,q), we take an
-    # invertable matrix AorB_1 which acts on
-    # the first l basis vectors and puts it in
-    # a matrix with another invertable matrix such
-    # that the form is preserved. This way, the
-    # decomposition must also be preserved.
+    # invertible matrix AorB_1 which acts on
+    # the first l basis vectors and put it in
+    # a diagonal 2 x 2 block matrix with another
+    # invertible matrix such that the form is preserved.
+    # This way, the decomposition must also be preserved.
     for GLgen in GeneratorsOfGroup(GL(l, q)) do
         AorB := IdentityMat(d, field);
         AorB{[1..l]}{[1..l]} := GLgen;

--- a/gap/ImprimitiveMatrixGroups.gi
+++ b/gap/ImprimitiveMatrixGroups.gi
@@ -217,8 +217,8 @@ function(d, q, t)
         Add(gens, Xi);
     od;
 
-    # This matrix will swap the vectors e_i with e_{i + k} and
-    # f_i with f_{i + k} for 1 <= i <= k respectively,
+    # The matrix C we construct next will swap the vectors e_i with
+    # e_{i + k} and f_i with f_{i + k} for 1 <= i <= k respectively,
     # which corresponds to the product of m transpositions in Sym(t).
     # Since m is even, this permutation has signum 1 and det(C) = 1.
     # One can easily check that this preserves the form.
@@ -243,11 +243,11 @@ function(d, q, t)
     # so we do not need to do it again.
     if t <> 2 then
 
-        # This Matrix will map the basis vectors
+        # The matrix D will map the basis vectors
         # e_i -> e_{((i + k -1) mod l) + 1} and
         # f_i -> f_{((i + k -1) mod l) + 1} 
         # which corresponds to a t-cycle in Sym(t).
-        # We have det(C) = 1 because we are effectively
+        # We have det(D) = 1 because we are effectively
         # swapping an even number of rows/colums.
         # One can easily check that this preserves the form.
         D := NullMat(d, d, field);

--- a/gap/ImprimitiveMatrixGroups.gi
+++ b/gap/ImprimitiveMatrixGroups.gi
@@ -236,26 +236,34 @@ function(d, q, t)
 
     Add(gens, C);
 
-    # This Matrix will map the basis vectors
-    # e_i -> e_{((i + k -1) mod l) + 1} and
-    # f_i -> f_{((i + k -1) mod l) + 1} 
-    # which corresponds to a t-cycle in Sym(t).
-    # Althoug this permutation has signum -1, we still have 
-    # det(C) = 1 because we are effectively swapping an even
-    # number of rows/colums.
-    # One can easily check that this preserves the form.
-    D := NullMat(d, d, field);
+    # In the case t = 2, we only need one element to generate Sym(t),
+    # since 2-cycles (matrix C) and t-cycles (matrix D) are the same.
+    # Analogously, the construction for D would just yield a copy of C,
+    # so we do not need to do it again.
+    if t <> 2 then
 
-    # This block matrix magic is again just a
-    # fancy way of swapping the correct entries.
-    # Effectively, we are shifting t k x k - blocks
-    # by k row/colums each.
-    D{[1..l - k]}{[k + 1..l]} := IdentityMat(l - k, field);
-    D{[l - k + 1..l]}{[1..k]} := IdentityMat(k, field);
-    D{[l + 1..l + k]}{[d - k + 1..d]} := IdentityMat(k, field);
-    D{[l + k + 1..d]}{[l + 1..d - k]} := IdentityMat(l - k, field);
+        # This Matrix will map the basis vectors
+        # e_i -> e_{((i + k -1) mod l) + 1} and
+        # f_i -> f_{((i + k -1) mod l) + 1} 
+        # which corresponds to a t-cycle in Sym(t).
+        # Althoug this permutation has signum -1, we still have 
+        # det(C) = 1 because we are effectively swapping an even
+        # number of rows/colums.
+        # One can easily check that this preserves the form.
+        D := NullMat(d, d, field);
 
-    Add(gens, D);
+        # This block matrix magic is again just a
+        # fancy way of swapping the correct entries.
+        # Effectively, we are shifting t k x k - blocks
+        # by k row/colums each.
+        D{[1..l - k]}{[k + 1..l]} := IdentityMat(l - k, field);
+        D{[l - k + 1..l]}{[1..k]} := IdentityMat(k, field);
+        D{[l + 1..l + k]}{[d - k + 1..d]} := IdentityMat(k, field);
+        D{[l + k + 1..d]}{[l + 1..d - k]} := IdentityMat(l - k, field);
+
+        Add(gens, D);
+
+    fi;
 
     return MatrixGroupWithSize(field, gens, SizeSp(m, q) ^ t * Factorial(t));
 

--- a/gap/ImprimitiveMatrixGroups.gi
+++ b/gap/ImprimitiveMatrixGroups.gi
@@ -171,3 +171,99 @@ function(d, q)
 
     return MatrixGroupWithSize(F, generators, size);
 end);
+
+
+# Construction as in Proposition 5.2 of [HR05]
+# We stabilise the decomposition with the t summands 
+# < e_1, ..., e_k, f_k, ..., f_1 >,
+# < e_{k + 1}, ..., e_{2k}, f_{2k}, ..., f_{k + 1} >, ...
+# < e_{l - k + 1}, ..., e_{d / 2}, f_{d / 2}, ..., f_{l - k + 1} >,
+# where l = d / 2, m = d / t and k = m / 2.
+BindGlobal("SpNonDegenerateImprimitives",
+function(d, q, t)
+    local m, l, k, field, one, gens, Spgen, Xi, C, D;
+
+    if IsOddInt(d) then
+        ErrorNoReturn("Dimension <d> must be even but ", d, " was given.");
+    fi;
+
+    m := QuoInt(d, t);
+
+    if not m * t = d then
+        ErrorNoReturn("The number <t> of subspaces must divide the dimension <d> but <d> = ", d, ", <t> = ", t, " was given.");
+    fi;
+
+    if IsOddInt(m) then
+        ErrorNoReturn("The dimension <m> = <d> / <t> must be even but <m> = ", m, ".");
+    fi;
+
+    l := QuoInt(d, 2);
+    k := QuoInt(m, 2);
+
+    field := GF(q);
+    one := One(field);
+    gens := [];
+
+    # This construction is the same as in Proposition 4.4 of [HR05]
+    # and is also used in the reducible case (C1). This could therefore
+    # be refactored into a Util-function at a later date.
+    # These generators are block matrices of the form [[A 0 B], [0 C 0], [D 0 E]],
+    # which corresponds to a subgroup corresponding to Sp(m, q).
+    for Spgen in GeneratorsOfGroup(Sp(m, q)) do
+        Xi := IdentityMat(d, field);
+        Xi{[1..k]}{[1..k]} := Spgen{[1..k]}{[1..k]};
+        Xi{[1..k]}{[d - k + 1 .. d]} := Spgen{[1..k]}{[k + 1 .. 2 * k]};
+        Xi{[d - k + 1 .. d]}{[1..k]} := Spgen{[k + 1 .. 2 * k]}{[1..k]};
+        Xi{[d - k + 1 .. d]}{[d - k + 1 .. d]} := Spgen{[k + 1 .. 2 * k]}{[k + 1 .. 2 * k]};
+        Add(gens, Xi);
+    od;
+
+    # This Matrix will swap the vectors e_i with e_{i + k} and
+    # f_i with f_{i + k} for 1 <= i <= k respectively,
+    # which corresponds to the product of m transpositions in Sym(t).
+    # Since m is even, this permutation has signum 1 and det(C) = 1.
+    # One can easily check that this preserves the form.
+    C := NullMat(d, d, field);
+
+    # The central 2 * (l - m) = (d - 2m) basis vectors should be
+    # unaffected, so an identity matrix as a block works nicely.
+    C{[m + 1..d - m]}{[m + 1..d - m]} := IdentityMat(2 * (l - m), field);
+    
+    # This block matrix magic is just a
+    # fancy way of swapping the correct entries.
+    C{[1..k]}{[k + 1..m]} := IdentityMat(k, field);
+    C{[k + 1..m]}{[1..k]} := IdentityMat(k, field);
+    C{[d - k + 1..d]}{[d - m + 1..d - k]} := IdentityMat(k, field);
+    C{[d - m + 1..d - k]}{[d - k + 1..d]} := IdentityMat(k, field);
+
+    Add(gens, C);
+
+    # This Matrix will map the basis vectors
+    # e_i -> e_{((i + k -1) mod l) + 1} and
+    # f_i -> f_{((i + k -1) mod l) + 1} 
+    # which corresponds to a t-cycle in Sym(t).
+    # Althoug this permutation has signum -1, we still have 
+    # det(C) = 1 because we are effectively swapping an even
+    # number of rows/colums.
+    # One can easily check that this preserves the form.
+    D := NullMat(d, d, field);
+
+    # This block matrix magic is again just a
+    # fancy way of swapping the correct entries.
+    # Effectively, we are shifting t k x k - blocks
+    # by k row/colums each.
+    D{[1..l - k]}{[k + 1..l]} := IdentityMat(l - k, field);
+    D{[l - k + 1..l]}{[1..k]} := IdentityMat(k, field);
+    D{[l + 1..l + k]}{[d - k + 1..d]} := IdentityMat(k, field);
+    D{[l + k + 1..d]}{[l + 1..d - k]} := IdentityMat(l - k, field);
+
+    Add(gens, D);
+
+    return MatrixGroupWithSize(field, gens, SizeSp(m, q) ^ t * Factorial(t));
+
+end);
+
+
+BindGlobal("SpIsotropicImprimitives",
+function(d, q)
+end);

--- a/tst/standard/ImprimitiveMatrixGroups.tst
+++ b/tst/standard/ImprimitiveMatrixGroups.tst
@@ -64,6 +64,8 @@ gap> TestSpIsotropicImprimitives := function(args)
 gap> testsSpIsotropicImprimitives := [[4, 3], [4, 7], [6, 5], [8, 3]];;
 gap> ForAll(testsSpIsotropicImprimitives, TestSpIsotropicImprimitives);
 true
+
+# Test error handling
 gap> SpIsotropicImprimitives(3, 3);
 Error, <d> must be even.
 gap> SpIsotropicImprimitives(4, 2);
@@ -83,6 +85,8 @@ gap> TestSpNonDegenerateImprimitives := function(args)
 gap> testsSpNonDegenerateImprimitives := [[4, 2, 2], [6, 5, 3], [10, 3, 5], [12, 3, 3]];;
 gap> ForAll(testsSpNonDegenerateImprimitives, TestSpNonDegenerateImprimitives);
 true
+
+# Test error handling
 gap> SpNonDegenerateImprimitives(3, 3, 3);
 Error, <d> must be even.
 gap> SpNonDegenerateImprimitives(4, 3, 3);

--- a/tst/standard/ImprimitiveMatrixGroups.tst
+++ b/tst/standard/ImprimitiveMatrixGroups.tst
@@ -50,3 +50,42 @@ gap> TestSUNonDegenerateImprimitives := function(args)
 gap> testsSUNonDegenerateImprimitives := [[6, 3, 3], [9, 2, 3], [3, 5, 3]];;
 gap> ForAll(testsSUNonDegenerateImprimitives, TestSUNonDegenerateImprimitives);
 true
+gap> TestSpIsotropicImprimitives := function(args)
+>   local n, q, G, hasSize;
+>   n := args[1];
+>   q := args[2];
+>   G := SpIsotropicImprimitives(n, q);
+>   hasSize := HasSize(G);
+>   RECOG.TestGroup(G, false, Size(G));
+>   return IsSubset(Sp(n, q), GeneratorsOfGroup(G))
+>          and DefaultFieldOfMatrixGroup(G) = GF(q)
+>          and hasSize;
+> end;;
+gap> testsSpIsotropicImprimitives := [[4, 3], [4, 7], [6, 5], [8, 3]];;
+gap> ForAll(testsSpIsotropicImprimitives, TestSpIsotropicImprimitives);
+true
+gap> SpIsotropicImprimitives(3, 3);
+Error, <d> must be even.
+gap> SpIsotropicImprimitives(4, 2);
+Error, <q> must be odd.
+gap> TestSpNonDegenerateImprimitives := function(args)
+>   local n, q, t, G, hasSize;
+>   n := args[1];
+>   q := args[2];
+>   t := args[3];
+>   G := SpNonDegenerateImprimitives(n, q, t);
+>   hasSize := HasSize(G);
+>   RECOG.TestGroup(G, false, Size(G));
+>   return IsSubset(Sp(n, q), GeneratorsOfGroup(G))
+>          and DefaultFieldOfMatrixGroup(G) = GF(q)
+>          and hasSize;
+> end;;
+gap> testsSpNonDegenerateImprimitives := [[4, 2, 2], [6, 5, 3], [10, 3, 5], [12, 3, 3]];;
+gap> ForAll(testsSpNonDegenerateImprimitives, TestSpNonDegenerateImprimitives);
+true
+gap> SpNonDegenerateImprimitives(3, 3, 3);
+Error, <d> must be even.
+gap> SpNonDegenerateImprimitives(4, 3, 3);
+Error, <t> must divide <d>.
+gap> SpNonDegenerateImprimitives(6, 3, 2);
+Error, <m> = <d> / <t> must be even.


### PR DESCRIPTION
Add the necessary functions for the C5 subgroups in the symplectic case. The codecov bot will be happy once we add the symplectic main function.

## Checklist for the reviewer
### General
- [ ] All functions have unit tests

### Functions constructing generators of maximal subgroups
- [ ] The code which computes and then stores the sizes is correct. To do this one confers to the tables referenced by the code. Tests for the group size should use `RECOG.TestGroup` from the recog package.
- [ ] The test suite checks whether all constructed generators are sensible. That is it tests the generators'
  - [ ] determinants (and if applicable also the spinor norms are correct), and
  - [ ] compatibility with the correct form,
  - [ ] `DefaultFieldOfMatrixGroup` returns the correct field.

### Functions assembling the list of all maximal subgroups of a certain group
- [ ] The code agrees with the tables in section 8.2 of the book "The Maximal Subgroups of the Low-dimensional Finite Classical Groups".

The reviewer doesn't need to compare our results to magma's results. That's the job of the person implementing the code.
