### PR TITLE
Don't use ForAll to run many tests in a row

### DIFF
--- a/tst/standard/ClassicalMaximals.tst
+++ b/tst/standard/ClassicalMaximals.tst
@@ -2,82 +2,204 @@ gap> START_TEST("ClassicalMaximals.tst");
 
 #
 gap> TestClassicalMaximalsLinear := function(args)
->   return Length(ClassicalMaximalsGeneric("L", args[1], args[2])) = args[3];
+>   Assert(0, Length(ClassicalMaximalsGeneric("L", args[1], args[2])) = args[3]);
 > end;;
-gap> testsClassicalMaximalsLinear := [[2, 4, 3], [2, 5, 3], [2, 7, 3],
->                                     [2, 8, 3], [2, 9, 3], [2, 11, 2],
->                                     [2, 13, 4], [2, 16, 4], [2, 17, 5],
->                                     [2, 19, 3],
->                                     [3, 2, 3], [3, 3, 4], [3, 4, 6],
->                                     [3, 5, 5], [3, 7, 8], [3, 8, 5],
->                                     [3, 9, 7], [3, 11, 5], [3, 13, 8],
->                                     [3, 16, 8], [3, 17, 5], [3, 19, 10],
->                                     [4, 2, 5], [4, 3, 8], [4, 4, 8],
->                                     [4, 5, 13], [4, 7, 10], [4, 8, 8],
->                                     [4, 9, 18], [4, 11, 10], [4, 13, 14],
->                                     [4, 16, 9], [4, 17, 16], [4, 19, 10],
->                                     [5, 2, 5], [5, 3, 6], [5, 4, 7],
->                                     [5, 5, 7], [5, 7, 7], [5, 8, 7],
->                                     [5, 9, 9], [5, 11, 16], [5, 13, 7],
->                                     [5, 16, 12], [5, 17, 7], [5, 19, 7],
->                                     [6, 2, 9], [6, 3, 13], [6, 4, 17],
->                                     [6, 5, 14], [6, 7, 20], [6, 8, 13],
->                                     [6, 9, 18], [6, 11, 14], [6, 13, 20], 
->                                     [6, 16, 18], [6, 17, 14], [6, 19, 20],
->                                     [7, 2, 7], [7, 3, 8], [7, 4, 9],
->                                     [7, 5, 9], [7, 7, 9], [7, 8, 22],
->                                     [7, 9, 11], [7, 11, 9], [7, 13, 9],
->                                     [7, 16, 10], [7, 17, 9], [7, 19, 9],
->                                     [8, 2, 10], [8, 3, 16], [8, 4, 14],
->                                     [8, 5, 25], [8, 7, 17], [8, 8, 14],
->                                     [8, 9, 31], [8, 11, 17], [8, 13, 25],
->                                     [8, 16, 15], [8, 17, 33], [8, 19, 17],
->                                     [9, 2, 11], [9, 3, 12], [9, 4, 17],
->                                     [9, 5, 13], [9, 7, 20], [9, 8, 13],
->                                     [9, 9, 15], [9, 11, 13], [9, 13, 20],
->                                     [9, 16, 18], [9, 17, 13], [9, 19, 32],
->                                     [10, 2, 13], [10, 3, 17], [10, 4, 17],
->                                     [10, 5, 18], [10, 7, 18], [10, 8, 17],
->                                     [10, 9, 22], [10, 11, 30], [10, 13, 18],
->                                     [10, 16, 26], [10, 17, 18], [10, 19, 18],
->                                     [11, 2, 11], [11, 3, 12], [11, 4, 13], 
->                                     [11, 5, 13], [11, 7, 13], [11, 8, 13],
->                                     [11, 9, 15], [11, 11, 13], [11, 13, 13],
->                                     [11, 16, 14], [11, 17, 13], [11, 19, 13],
->                                     [12, 2, 18], [12, 3, 24], [12, 4, 26],
->                                     [12, 5, 27], [12, 7, 33], [12, 8, 22],
->                                     [12, 9, 33], [12, 11, 25], [12, 13, 39],
->                                     [12, 16, 27], [12, 17, 27], [12, 19, 33]];;
-gap> ForAll(testsClassicalMaximalsLinear, TestClassicalMaximalsLinear);
-true
+gap> TestClassicalMaximalsLinear([2, 4, 3]);
+gap> TestClassicalMaximalsLinear([2, 5, 3]);
+gap> TestClassicalMaximalsLinear([2, 7, 3]);
+gap> TestClassicalMaximalsLinear([2, 8, 3]);
+gap> TestClassicalMaximalsLinear([2, 9, 3]);
+gap> TestClassicalMaximalsLinear([2, 11, 2]);
+gap> TestClassicalMaximalsLinear([2, 13, 4]);
+gap> TestClassicalMaximalsLinear([2, 16, 4]);
+gap> TestClassicalMaximalsLinear([2, 17, 5]);
+gap> TestClassicalMaximalsLinear([2, 19, 3]);
+gap> TestClassicalMaximalsLinear([3, 2, 3]);
+gap> TestClassicalMaximalsLinear([3, 3, 4]);
+gap> TestClassicalMaximalsLinear([3, 4, 6]);
+gap> TestClassicalMaximalsLinear([3, 5, 5]);
+gap> TestClassicalMaximalsLinear([3, 7, 8]);
+gap> TestClassicalMaximalsLinear([3, 8, 5]);
+gap> TestClassicalMaximalsLinear([3, 9, 7]);
+gap> TestClassicalMaximalsLinear([3, 11, 5]);
+gap> TestClassicalMaximalsLinear([3, 13, 8]);
+gap> TestClassicalMaximalsLinear([3, 16, 8]);
+gap> TestClassicalMaximalsLinear([3, 17, 5]);
+gap> TestClassicalMaximalsLinear([3, 19, 10]);
+gap> TestClassicalMaximalsLinear([4, 2, 5]);
+gap> TestClassicalMaximalsLinear([4, 3, 8]);
+gap> TestClassicalMaximalsLinear([4, 4, 8]);
+gap> TestClassicalMaximalsLinear([4, 5, 13]);
+gap> TestClassicalMaximalsLinear([4, 7, 10]);
+gap> TestClassicalMaximalsLinear([4, 8, 8]);
+gap> TestClassicalMaximalsLinear([4, 9, 18]);
+gap> TestClassicalMaximalsLinear([4, 11, 10]);
+gap> TestClassicalMaximalsLinear([4, 13, 14]);
+gap> TestClassicalMaximalsLinear([4, 16, 9]);
+gap> TestClassicalMaximalsLinear([4, 17, 16]);
+gap> TestClassicalMaximalsLinear([4, 19, 10]);
+gap> TestClassicalMaximalsLinear([5, 2, 5]);
+gap> TestClassicalMaximalsLinear([5, 3, 6]);
+gap> TestClassicalMaximalsLinear([5, 4, 7]);
+gap> TestClassicalMaximalsLinear([5, 5, 7]);
+gap> TestClassicalMaximalsLinear([5, 7, 7]);
+gap> TestClassicalMaximalsLinear([5, 8, 7]);
+gap> TestClassicalMaximalsLinear([5, 9, 9]);
+gap> TestClassicalMaximalsLinear([5, 11, 16]);
+gap> TestClassicalMaximalsLinear([5, 13, 7]);
+gap> TestClassicalMaximalsLinear([5, 16, 12]);
+gap> TestClassicalMaximalsLinear([5, 17, 7]);
+gap> TestClassicalMaximalsLinear([5, 19, 7]);
+gap> TestClassicalMaximalsLinear([6, 2, 9]);
+gap> TestClassicalMaximalsLinear([6, 3, 13]);
+gap> TestClassicalMaximalsLinear([6, 4, 17]);
+gap> TestClassicalMaximalsLinear([6, 5, 14]);
+gap> TestClassicalMaximalsLinear([6, 7, 20]);
+gap> TestClassicalMaximalsLinear([6, 8, 13]);
+gap> TestClassicalMaximalsLinear([6, 9, 18]);
+gap> TestClassicalMaximalsLinear([6, 11, 14]);
+gap> TestClassicalMaximalsLinear([6, 13, 20]);
+gap> TestClassicalMaximalsLinear([6, 16, 18]);
+gap> TestClassicalMaximalsLinear([6, 17, 14]);
+gap> TestClassicalMaximalsLinear([6, 19, 20]);
+gap> TestClassicalMaximalsLinear([7, 2, 7]);
+gap> TestClassicalMaximalsLinear([7, 3, 8]);
+gap> TestClassicalMaximalsLinear([7, 4, 9]);
+gap> TestClassicalMaximalsLinear([7, 5, 9]);
+gap> TestClassicalMaximalsLinear([7, 7, 9]);
+gap> TestClassicalMaximalsLinear([7, 8, 22]);
+gap> TestClassicalMaximalsLinear([7, 9, 11]);
+gap> TestClassicalMaximalsLinear([7, 11, 9]);
+gap> TestClassicalMaximalsLinear([7, 13, 9]);
+gap> TestClassicalMaximalsLinear([7, 16, 10]);
+gap> TestClassicalMaximalsLinear([7, 17, 9]);
+gap> TestClassicalMaximalsLinear([7, 19, 9]);
+gap> TestClassicalMaximalsLinear([8, 2, 10]);
+gap> TestClassicalMaximalsLinear([8, 3, 16]);
+gap> TestClassicalMaximalsLinear([8, 4, 14]);
+gap> TestClassicalMaximalsLinear([8, 5, 25]);
+gap> TestClassicalMaximalsLinear([8, 7, 17]);
+gap> TestClassicalMaximalsLinear([8, 8, 14]);
+gap> TestClassicalMaximalsLinear([8, 9, 31]);
+gap> TestClassicalMaximalsLinear([8, 11, 17]);
+gap> TestClassicalMaximalsLinear([8, 13, 25]);
+gap> TestClassicalMaximalsLinear([8, 16, 15]);
+gap> TestClassicalMaximalsLinear([8, 17, 33]);
+gap> TestClassicalMaximalsLinear([8, 19, 17]);
+gap> TestClassicalMaximalsLinear([9, 2, 11]);
+gap> TestClassicalMaximalsLinear([9, 3, 12]);
+gap> TestClassicalMaximalsLinear([9, 4, 17]);
+gap> TestClassicalMaximalsLinear([9, 5, 13]);
+gap> TestClassicalMaximalsLinear([9, 7, 20]);
+gap> TestClassicalMaximalsLinear([9, 8, 13]);
+gap> TestClassicalMaximalsLinear([9, 9, 15]);
+gap> TestClassicalMaximalsLinear([9, 11, 13]);
+gap> TestClassicalMaximalsLinear([9, 13, 20]);
+gap> TestClassicalMaximalsLinear([9, 16, 18]);
+gap> TestClassicalMaximalsLinear([9, 17, 13]);
+gap> TestClassicalMaximalsLinear([9, 19, 32]);
+gap> TestClassicalMaximalsLinear([10, 2, 13]);
+gap> TestClassicalMaximalsLinear([10, 3, 17]);
+gap> TestClassicalMaximalsLinear([10, 4, 17]);
+gap> TestClassicalMaximalsLinear([10, 5, 18]);
+gap> TestClassicalMaximalsLinear([10, 7, 18]);
+gap> TestClassicalMaximalsLinear([10, 8, 17]);
+gap> TestClassicalMaximalsLinear([10, 9, 22]);
+gap> TestClassicalMaximalsLinear([10, 11, 30]);
+gap> TestClassicalMaximalsLinear([10, 13, 18]);
+gap> TestClassicalMaximalsLinear([10, 16, 26]);
+gap> TestClassicalMaximalsLinear([10, 17, 18]);
+gap> TestClassicalMaximalsLinear([10, 19, 18]);
+gap> TestClassicalMaximalsLinear([11, 2, 11]);
+gap> TestClassicalMaximalsLinear([11, 3, 12]);
+gap> TestClassicalMaximalsLinear([11, 4, 13]);
+gap> TestClassicalMaximalsLinear([11, 5, 13]);
+gap> TestClassicalMaximalsLinear([11, 7, 13]);
+gap> TestClassicalMaximalsLinear([11, 8, 13]);
+gap> TestClassicalMaximalsLinear([11, 9, 15]);
+gap> TestClassicalMaximalsLinear([11, 11, 13]);
+gap> TestClassicalMaximalsLinear([11, 13, 13]);
+gap> TestClassicalMaximalsLinear([11, 16, 14]);
+gap> TestClassicalMaximalsLinear([11, 17, 13]);
+gap> TestClassicalMaximalsLinear([11, 19, 13]);
+gap> TestClassicalMaximalsLinear([12, 2, 18]);
+gap> TestClassicalMaximalsLinear([12, 3, 24]);
+gap> TestClassicalMaximalsLinear([12, 4, 26]);
+gap> TestClassicalMaximalsLinear([12, 5, 27]);
+gap> TestClassicalMaximalsLinear([12, 7, 33]);
+gap> TestClassicalMaximalsLinear([12, 8, 22]);
+gap> TestClassicalMaximalsLinear([12, 9, 33]);
+gap> TestClassicalMaximalsLinear([12, 11, 25]);
+gap> TestClassicalMaximalsLinear([12, 13, 39]);
+gap> TestClassicalMaximalsLinear([12, 16, 27]);
+gap> TestClassicalMaximalsLinear([12, 17, 27]);
+gap> TestClassicalMaximalsLinear([12, 19, 33]);
+
+#
 gap> TestClassicalMaximalsUnitary := function(args)
->   return Length(ClassicalMaximalsGeneric("U", args[1], args[2])) = args[3];
+>   Assert(0, Length(ClassicalMaximalsGeneric("U", args[1], args[2])) = args[3]);
 > end;;
-gap> testsClassicalMaximalsUnitary := [[3, 3, 3], [3, 4, 4], [3, 5, 2], 
->                                      [3, 7, 5], [3, 8, 7], [3, 9, 5], 
->                                      [3, 11, 8], [3, 13, 5], [3, 16, 4],
->                                      [3, 17, 10], [3, 19, 5],
->                                      [4, 2, 5], [4, 3, 10], [4, 4, 7],
->                                      [4, 5, 10], [4, 7, 16], [4, 8, 8],
->                                      [4, 9, 10], [4, 11, 14], [4, 13, 10],
->                                      [4, 16, 7], [4, 17, 10], [4, 19, 14],
->                                      [5, 2, 5], [5, 3, 7], [5, 4, 11], 
->                                      [5, 5, 7], [5, 7, 7], [5, 8, 7],
->                                      [5, 9, 16], [5, 11, 7], [5, 13, 7], 
->                                      [5, 16, 6], [5, 17, 7], [5, 19, 16],
->                                      [6, 2, 10], [6, 3, 14], [6, 4, 12],
->                                      [6, 5, 20], [6, 7, 14], [6, 8, 17],
->                                      [7, 2, 8], [7, 3, 9], [7, 8, 9],
->                                      [7, 13, 22],
->                                      [8, 2, 11], [8, 3, 25], [8, 4, 13],
->                                      [8, 5, 17], [8, 8, 14],
->                                      [9, 2, 14], [9, 3, 13], [9, 4, 12],
->                                      [9, 5, 20], [9, 8, 17],
->                                      [10, 2, 14], [10, 3, 18],
->                                      [11, 2, 12], [11, 3, 13],
->                                      [12, 2, 21], [12, 3, 27]];;
-gap> ForAll(testsClassicalMaximalsUnitary, TestClassicalMaximalsUnitary);
-true
+gap> TestClassicalMaximalsUnitary([3, 3, 3]);
+gap> TestClassicalMaximalsUnitary([3, 4, 4]);
+gap> TestClassicalMaximalsUnitary([3, 5, 2]);
+gap> TestClassicalMaximalsUnitary([3, 7, 5]);
+gap> TestClassicalMaximalsUnitary([3, 8, 7]);
+gap> TestClassicalMaximalsUnitary([3, 9, 5]);
+gap> TestClassicalMaximalsUnitary([3, 11, 8]);
+gap> TestClassicalMaximalsUnitary([3, 13, 5]);
+gap> TestClassicalMaximalsUnitary([3, 16, 4]);
+gap> TestClassicalMaximalsUnitary([3, 17, 10]);
+gap> TestClassicalMaximalsUnitary([3, 19, 5]);
+gap> TestClassicalMaximalsUnitary([4, 2, 5]);
+gap> TestClassicalMaximalsUnitary([4, 3, 10]);
+gap> TestClassicalMaximalsUnitary([4, 4, 7]);
+gap> TestClassicalMaximalsUnitary([4, 5, 10]);
+gap> TestClassicalMaximalsUnitary([4, 7, 16]);
+gap> TestClassicalMaximalsUnitary([4, 8, 8]);
+gap> TestClassicalMaximalsUnitary([4, 9, 10]);
+gap> TestClassicalMaximalsUnitary([4, 11, 14]);
+gap> TestClassicalMaximalsUnitary([4, 13, 10]);
+gap> TestClassicalMaximalsUnitary([4, 16, 7]);
+gap> TestClassicalMaximalsUnitary([4, 17, 10]);
+gap> TestClassicalMaximalsUnitary([4, 19, 14]);
+gap> TestClassicalMaximalsUnitary([5, 2, 5]);
+gap> TestClassicalMaximalsUnitary([5, 3, 7]);
+gap> TestClassicalMaximalsUnitary([5, 4, 11]);
+gap> TestClassicalMaximalsUnitary([5, 5, 7]);
+gap> TestClassicalMaximalsUnitary([5, 7, 7]);
+gap> TestClassicalMaximalsUnitary([5, 8, 7]);
+gap> TestClassicalMaximalsUnitary([5, 9, 16]);
+gap> TestClassicalMaximalsUnitary([5, 11, 7]);
+gap> TestClassicalMaximalsUnitary([5, 13, 7]);
+gap> TestClassicalMaximalsUnitary([5, 16, 6]);
+gap> TestClassicalMaximalsUnitary([5, 17, 7]);
+gap> TestClassicalMaximalsUnitary([5, 19, 16]);
+gap> TestClassicalMaximalsUnitary([6, 2, 10]);
+gap> TestClassicalMaximalsUnitary([6, 3, 14]);
+gap> TestClassicalMaximalsUnitary([6, 4, 12]);
+gap> TestClassicalMaximalsUnitary([6, 5, 20]);
+gap> TestClassicalMaximalsUnitary([6, 7, 14]);
+gap> TestClassicalMaximalsUnitary([6, 8, 17]);
+gap> TestClassicalMaximalsUnitary([7, 2, 8]);
+gap> TestClassicalMaximalsUnitary([7, 3, 9]);
+gap> TestClassicalMaximalsUnitary([7, 8, 9]);
+gap> TestClassicalMaximalsUnitary([7, 13, 22]);
+gap> TestClassicalMaximalsUnitary([8, 2, 11]);
+gap> TestClassicalMaximalsUnitary([8, 3, 25]);
+gap> TestClassicalMaximalsUnitary([8, 4, 13]);
+gap> TestClassicalMaximalsUnitary([8, 5, 17]);
+gap> TestClassicalMaximalsUnitary([8, 8, 14]);
+gap> TestClassicalMaximalsUnitary([9, 2, 14]);
+gap> TestClassicalMaximalsUnitary([9, 3, 13]);
+gap> TestClassicalMaximalsUnitary([9, 4, 12]);
+gap> TestClassicalMaximalsUnitary([9, 5, 20]);
+gap> TestClassicalMaximalsUnitary([9, 8, 17]);
+gap> TestClassicalMaximalsUnitary([10, 2, 14]);
+gap> TestClassicalMaximalsUnitary([10, 3, 18]);
+gap> TestClassicalMaximalsUnitary([11, 2, 12]);
+gap> TestClassicalMaximalsUnitary([11, 3, 13]);
+gap> TestClassicalMaximalsUnitary([12, 2, 21]);
+gap> TestClassicalMaximalsUnitary([12, 3, 27]);
 
 #
 gap> STOP_TEST("ClassicalMaximals.tst", 0);

--- a/tst/standard/ClassicalNormalizerMatrixGroups.tst
+++ b/tst/standard/ClassicalNormalizerMatrixGroups.tst
@@ -8,13 +8,15 @@ gap> TestSymplecticNormalizerInSL := function(args)
 >   G := SymplecticNormalizerInSL(n, q);
 >   hasSize := HasSize(G);
 >   RECOG.TestGroup(G, false, Size(G));
->   return IsSubset(SL(n, q), GeneratorsOfGroup(G))
->          and DefaultFieldOfMatrixGroup(G) = GF(q)
->          and hasSize;
+>   Assert(0, IsSubset(SL(n, q), GeneratorsOfGroup(G)));
+>   Assert(0, DefaultFieldOfMatrixGroup(G) = GF(q));
+>   Assert(0, hasSize);
 > end;;
-gap> testsSymplecticNormalizerInSL := [[4, 3], [4, 5], [6, 4]];;
-gap> ForAll(testsSymplecticNormalizerInSL, TestSymplecticNormalizerInSL);
-true
+gap> TestSymplecticNormalizerInSL([4, 3]);
+gap> TestSymplecticNormalizerInSL([4, 5]);
+gap> TestSymplecticNormalizerInSL([6, 4]);
+
+#
 gap> TestUnitaryNormalizerInSL := function(args)
 >   local n, q, G, hasSize;
 >   n := args[1];
@@ -22,13 +24,15 @@ gap> TestUnitaryNormalizerInSL := function(args)
 >   G := UnitaryNormalizerInSL(n, q);
 >   hasSize := HasSize(G);
 >   RECOG.TestGroup(G, false, Size(G));
->   return IsSubset(SL(n, q), GeneratorsOfGroup(G))
->          and DefaultFieldOfMatrixGroup(G) = GF(q)
->          and hasSize;
+>   Assert(0, IsSubset(SL(n, q), GeneratorsOfGroup(G)));
+>   Assert(0, DefaultFieldOfMatrixGroup(G) = GF(q));
+>   Assert(0, hasSize);
 > end;;
-gap> testsUnitaryNormalizerInSL := [[4, 9], [3, 9], [4, 4]];;
-gap> ForAll(testsUnitaryNormalizerInSL, TestUnitaryNormalizerInSL);
-true
+gap> TestUnitaryNormalizerInSL([4, 9]);
+gap> TestUnitaryNormalizerInSL([3, 9]);
+gap> TestUnitaryNormalizerInSL([4, 4]);
+
+#
 gap> TestOrthogonalNormalizerInSL := function(args)
 >   local epsilon, n, q, G, hasSize;
 >   epsilon := args[1];
@@ -37,14 +41,20 @@ gap> TestOrthogonalNormalizerInSL := function(args)
 >   G := OrthogonalNormalizerInSL(epsilon, n, q);
 >   hasSize := HasSize(G);
 >   RECOG.TestGroup(G, false, Size(G));
->   return IsSubset(SL(n, q), GeneratorsOfGroup(G))
->          and DefaultFieldOfMatrixGroup(G) = GF(q)
->          and hasSize;
+>   Assert(0, IsSubset(SL(n, q), GeneratorsOfGroup(G)));
+>   Assert(0, DefaultFieldOfMatrixGroup(G) = GF(q));
+>   Assert(0, hasSize);
 > end;;
-gap> testsOrthogonalNormalizerInSL := [[0, 3, 5], [-1, 6, 5], [1, 6, 5], [-1, 4, 3], [1, 4, 3], 
->                                      [-1, 4, 5], [1, 4, 5], [-1, 6, 3]];;
-gap> ForAll(testsOrthogonalNormalizerInSL, TestOrthogonalNormalizerInSL);
-true
+gap> TestOrthogonalNormalizerInSL([0, 3, 5]);
+gap> TestOrthogonalNormalizerInSL([-1, 6, 5]);
+gap> TestOrthogonalNormalizerInSL([1, 6, 5]);
+gap> TestOrthogonalNormalizerInSL([-1, 4, 3]);
+gap> TestOrthogonalNormalizerInSL([1, 4, 3]);
+gap> TestOrthogonalNormalizerInSL([-1, 4, 5]);
+gap> TestOrthogonalNormalizerInSL([1, 4, 5]);
+gap> TestOrthogonalNormalizerInSL([-1, 6, 3]);
+
+#
 gap> TestOrthogonalInSp := function(args)
 >   local epsilon, n, q, G, hasSize;
 >   epsilon := args[1];

--- a/tst/standard/ExtraspecialNormalizerMatrixGroups.tst
+++ b/tst/standard/ExtraspecialNormalizerMatrixGroups.tst
@@ -9,14 +9,21 @@ gap> TestExtraspecialNormalizerInSL := function(args)
 >   G := ExtraspecialNormalizerInSL(r, m, q);
 >   hasSize := HasSize(G);
 >   RECOG.TestGroup(G, false, Size(G));
->   return IsSubset(SL(r ^ m, q), GeneratorsOfGroup(G))
->          and DefaultFieldOfMatrixGroup(G) = GF(q)
->          and hasSize;
+>   Assert(0, IsSubset(SL(r ^ m, q), GeneratorsOfGroup(G)));
+>   Assert(0, DefaultFieldOfMatrixGroup(G) = GF(q));
+>   Assert(0, hasSize);
 > end;;
-gap> testsExtraspecialNormalizerInSL := [[5, 1, 11], [3, 1, 7], [3, 2, 13], [2, 3, 5], [2, 2, 5], 
->                                        [2, 2, 9], [2, 1, 9], [2, 1, 5], [2, 1, 7]];;
-gap> ForAll(testsExtraspecialNormalizerInSL, TestExtraspecialNormalizerInSL);
-true
+gap> TestExtraspecialNormalizerInSL([5, 1, 11]);
+gap> TestExtraspecialNormalizerInSL([3, 1, 7]);
+gap> TestExtraspecialNormalizerInSL([3, 2, 13]);
+gap> TestExtraspecialNormalizerInSL([2, 3, 5]);
+gap> TestExtraspecialNormalizerInSL([2, 2, 5]);
+gap> TestExtraspecialNormalizerInSL([2, 2, 9]);
+gap> TestExtraspecialNormalizerInSL([2, 1, 9]);
+gap> TestExtraspecialNormalizerInSL([2, 1, 5]);
+gap> TestExtraspecialNormalizerInSL([2, 1, 7]);
+
+#
 gap> TestExtraspecialNormalizerInSU := function(args)
 >   local r, m, q, G, hasSize;
 >   r := args[1];
@@ -25,18 +32,22 @@ gap> TestExtraspecialNormalizerInSU := function(args)
 >   G := ExtraspecialNormalizerInSU(r, m, q);
 >   hasSize := HasSize(G);
 >   RECOG.TestGroup(G, false, Size(G));
->   return IsSubset(SU(r ^ m, q), GeneratorsOfGroup(G))
->          and DefaultFieldOfMatrixGroup(G) = GF(q ^ 2)
->          and hasSize;
+>   Assert(0, IsSubset(SU(r ^ m, q), GeneratorsOfGroup(G)));
+>   Assert(0, DefaultFieldOfMatrixGroup(G) = GF(q ^ 2));
+>   Assert(0, hasSize);
 > end;;
+gap> TestExtraspecialNormalizerInSU([5, 1, 4]);
+gap> TestExtraspecialNormalizerInSU([2, 3, 3]);
 #@if IsBound(CLASSICAL_MAXIMALS_RUN_BROKEN_TESTS)
-gap> testsExtraspecialNormalizerInSU := [[5, 1, 4], [2, 3, 3], [2, 3, 7], [2, 2, 3], [2, 2, 7], 
->                                        [3, 2, 5], [3, 1, 8], [3, 1, 5]];;
-#@else
-gap> testsExtraspecialNormalizerInSU := [];;
+gap> TestExtraspecialNormalizerInSU([2, 3, 7]); # FIXME: `Giving up, Schreier tree is not shallow.`
+gap> TestExtraspecialNormalizerInSU([2, 2, 3]); # FIXME: `Error, the recognition described by this recognition node has failed!`
 #@fi
-gap> ForAll(testsExtraspecialNormalizerInSU, TestExtraspecialNormalizerInSU);
-true
+gap> TestExtraspecialNormalizerInSU([2, 2, 7]);
+gap> TestExtraspecialNormalizerInSU([3, 2, 5]);
+gap> TestExtraspecialNormalizerInSU([3, 1, 8]);
+gap> TestExtraspecialNormalizerInSU([3, 1, 5]);
+
+#
 gap> TestExtraspecialNormalizerInSp := function(args)
 >   local m, q, G, hasSize;
 >   m := args[1];
@@ -44,17 +55,22 @@ gap> TestExtraspecialNormalizerInSp := function(args)
 >   G := ExtraspecialNormalizerInSp(m, q);
 >   hasSize := HasSize(G);
 >   RECOG.TestGroup(G, false, Size(G));
->   return IsSubset(Sp(2 ^ m, q), GeneratorsOfGroup(G))
->          and DefaultFieldOfMatrixGroup(G) = GF(q)
->          and hasSize;
+>   Assert(0, IsSubset(Sp(2 ^ m, q), GeneratorsOfGroup(G)));
+>   Assert(0, DefaultFieldOfMatrixGroup(G) = GF(q));
+>   Assert(0, hasSize);
 > end;;
+gap> TestExtraspecialNormalizerInSp([2, 3]);
+gap> TestExtraspecialNormalizerInSp([2, 5]);
+gap> TestExtraspecialNormalizerInSp([2, 7]);
 #@if IsBound(CLASSICAL_MAXIMALS_RUN_BROKEN_TESTS)
-gap> testsExtraspecialNormalizerInSp := [[2, 3], [2, 5], [2, 7], [3, 3], [3, 5], [3, 7]];;
-#@else
-gap> testsExtraspecialNormalizerInSp := [[2, 3], [2, 5], [3, 5]];;
+gap> TestExtraspecialNormalizerInSp([3, 3]); # FIXME: `Error, the recognition described by this recognition node has failed!`
 #@fi
-gap> ForAll(testsExtraspecialNormalizerInSp, TestExtraspecialNormalizerInSp);
-true
+gap> TestExtraspecialNormalizerInSp([3, 5]);
+#@if IsBound(CLASSICAL_MAXIMALS_RUN_BROKEN_TESTS)
+gap> TestExtraspecialNormalizerInSp([3, 7]); # FIXME: `Error, the recognition described by this recognition node has failed!`
+#@fi
+
+#
 gap> TestOddExtraspecialGroup := function(args)
 >   local r, m, q, gens, G;
 >   r := args[1];
@@ -63,11 +79,12 @@ gap> TestOddExtraspecialGroup := function(args)
 >   gens := OddExtraspecialGroup(r, m, q);
 >   G := Group(Concatenation(gens.listOfXi, gens.listOfYi));
 >   RECOG.TestGroup(G, false, r ^ (2 * m + 1));
->   return true;
 > end;;
-gap> testsOddExtraspecialGroup := [[5, 1, 11], [3, 1, 7], [3, 2, 13]];;
-gap> ForAll(testsOddExtraspecialGroup, TestOddExtraspecialGroup);
-true
+gap> TestOddExtraspecialGroup([5, 1, 11]);
+gap> TestOddExtraspecialGroup([3, 1, 7]);
+gap> TestOddExtraspecialGroup([3, 2, 13]);
+
+#
 gap> TestOddExtraspecialNormalizerInGL := function(args)
 >   local r, m, q, gensNormalizer, gensExtraspecial, extraspecialGroup,
 >   normalizer;
@@ -84,11 +101,13 @@ gap> TestOddExtraspecialNormalizerInGL := function(args)
 >                                     gensNormalizer.listOfVi,
 >                                     gensNormalizer.listOfWi,
 >                                     [gensNormalizer.generatingScalar]));
->   return ForAll(GeneratorsOfGroup(normalizer), g -> extraspecialGroup ^ g = extraspecialGroup);
+>   Assert(0, ForAll(GeneratorsOfGroup(normalizer), g -> extraspecialGroup ^ g = extraspecialGroup));
 > end;;
-gap> testsOddExtraspecialNormalizerInGL := [[5, 1, 11], [3, 1, 7], [3, 2, 13]];;
-gap> ForAll(testsOddExtraspecialNormalizerInGL, TestOddExtraspecialNormalizerInGL);
-true
+gap> TestOddExtraspecialNormalizerInGL([5, 1, 11]);
+gap> TestOddExtraspecialNormalizerInGL([3, 1, 7]);
+gap> TestOddExtraspecialNormalizerInGL([3, 2, 13]);
+
+#
 gap> TestSymplecticTypeNormalizerInGL := function(args)
 >   local r, m, q, gensNormalizer, gensExtraspecial, extraspecialGroup,
 >   normalizer, zeta, F;
@@ -108,11 +127,13 @@ gap> TestSymplecticTypeNormalizerInGL := function(args)
 >                                     gensNormalizer.listOfVi,
 >                                     gensNormalizer.listOfWi,
 >                                     [gensNormalizer.generatingScalar]));
->   return ForAll(GeneratorsOfGroup(normalizer), g -> extraspecialGroup ^ g = extraspecialGroup);
+>   Assert(0, ForAll(GeneratorsOfGroup(normalizer), g -> extraspecialGroup ^ g = extraspecialGroup));
 > end;;
-gap> testsSymplecticTypeNormalizerInGL := [[3, 5], [2, 5], [2, 9]];;
-gap> ForAll(testsSymplecticTypeNormalizerInGL, TestSymplecticTypeNormalizerInGL);
-true
+gap> TestSymplecticTypeNormalizerInGL([3, 5]);
+gap> TestSymplecticTypeNormalizerInGL([2, 5]);
+gap> TestSymplecticTypeNormalizerInGL([2, 9]);
+
+#
 gap> TestExtraspecial2MinusTypeNormalizerInGL := function(args)
 >   local r, m, q, gensNormalizer, extraspecialGroup, normalizer, zeta, F;
 >   r := 2;
@@ -129,11 +150,12 @@ gap> TestExtraspecial2MinusTypeNormalizerInGL := function(args)
 >                                     gensNormalizer.listOfVi,
 >                                     gensNormalizer.listOfWi,
 >                                     [gensNormalizer.generatingScalar]));
->   return ForAll(GeneratorsOfGroup(normalizer), g -> extraspecialGroup ^ g = extraspecialGroup);
+>   Assert(0, ForAll(GeneratorsOfGroup(normalizer), g -> extraspecialGroup ^ g = extraspecialGroup));
 > end;;
-gap> testsExtraspecial2MinusTypeNormalizerInGL := [[1, 9], [1, 5], [1, 7], [2, 5]];;
-gap> ForAll(testsExtraspecial2MinusTypeNormalizerInGL, TestExtraspecial2MinusTypeNormalizerInGL);
-true
+gap> TestExtraspecial2MinusTypeNormalizerInGL([1, 9]);
+gap> TestExtraspecial2MinusTypeNormalizerInGL([1, 5]);
+gap> TestExtraspecial2MinusTypeNormalizerInGL([1, 7]);
+gap> TestExtraspecial2MinusTypeNormalizerInGL([2, 5]);
 
 #
 gap> STOP_TEST("ExtraspecialNormalizerMatrixGroups.tst", 0);

--- a/tst/standard/ImprimitiveMatrixGroups.tst
+++ b/tst/standard/ImprimitiveMatrixGroups.tst
@@ -9,17 +9,17 @@ gap> TestImprimitivesMeetSL := function(args)
 >   G := ImprimitivesMeetSL(n, q, t);
 >   hasSize := HasSize(G);
 >   RECOG.TestGroup(G, false, Size(G));
->   return IsSubset(SL(n, q), GeneratorsOfGroup(G))
->          and DefaultFieldOfMatrixGroup(G) = GF(q)
->          and hasSize;
+>   Assert(0, IsSubset(SL(n, q), GeneratorsOfGroup(G)));
+>   Assert(0, DefaultFieldOfMatrixGroup(G) = GF(q));
+>   Assert(0, hasSize);
 > end;;
+gap> TestImprimitivesMeetSL([2, 3, 2]);
 #@if IsBound(CLASSICAL_MAXIMALS_RUN_BROKEN_TESTS)
-gap> testsImprimitivesMeetSL := [[2, 3, 2], [4, 8, 2], [6, 5, 3]];;
-#@else
-gap> testsImprimitivesMeetSL := [[2, 3, 2], [6, 5, 3]];;
+gap> TestImprimitivesMeetSL([4, 8, 2]); # FIXME: `Error, !!!`, see https://github.com/gap-packages/recog/issues/12
 #@fi
-gap> ForAll(testsImprimitivesMeetSL, TestImprimitivesMeetSL);
-true
+gap> TestImprimitivesMeetSL([6, 5, 3]);
+
+#
 gap> TestSUIsotropicImprimitives := function(args)
 >   local n, q, G, hasSize;
 >   n := args[1];
@@ -27,17 +27,15 @@ gap> TestSUIsotropicImprimitives := function(args)
 >   G := SUIsotropicImprimitives(n, q);
 >   hasSize := HasSize(G);
 >   RECOG.TestGroup(G, false, Size(G));
->   return IsSubset(SU(n, q), GeneratorsOfGroup(G))
->          and DefaultFieldOfMatrixGroup(G) = GF(q ^ 2)
->          and hasSize;
+>   Assert(0, IsSubset(SU(n, q), GeneratorsOfGroup(G)));
+>   Assert(0, DefaultFieldOfMatrixGroup(G) = GF(q ^ 2));
+>   Assert(0, hasSize);
 > end;;
-#@if IsBound(CLASSICAL_MAXIMALS_RUN_BROKEN_TESTS)
-gap> testsSUIsotropicImprimitives := [[6, 2], [4, 3], [2, 5]];;
-#@else
-gap> testsSUIsotropicImprimitives := [[6, 2]];;
-#@fi
-gap> ForAll(testsSUIsotropicImprimitives, TestSUIsotropicImprimitives);
-true
+gap> TestSUIsotropicImprimitives([6, 2]);
+gap> TestSUIsotropicImprimitives([4, 3]);
+gap> TestSUIsotropicImprimitives([2, 5]);
+
+#
 gap> TestSUNonDegenerateImprimitives := function(args)
 >   local n, q, t, G, hasSize;
 >   n := args[1];
@@ -46,13 +44,15 @@ gap> TestSUNonDegenerateImprimitives := function(args)
 >   G := SUNonDegenerateImprimitives(n, q, t);
 >   hasSize := HasSize(G);
 >   RECOG.TestGroup(G, false, Size(G));
->   return IsSubset(SU(n, q), GeneratorsOfGroup(G))
->          and DefaultFieldOfMatrixGroup(G) = GF(q ^ 2)
->          and hasSize;
+>   Assert(0, IsSubset(SU(n, q), GeneratorsOfGroup(G)));
+>   Assert(0, DefaultFieldOfMatrixGroup(G) = GF(q ^ 2));
+>   Assert(0, hasSize);
 > end;;
-gap> testsSUNonDegenerateImprimitives := [[6, 3, 3], [9, 2, 3], [3, 5, 3]];;
-gap> ForAll(testsSUNonDegenerateImprimitives, TestSUNonDegenerateImprimitives);
-true
+gap> TestSUNonDegenerateImprimitives([6, 3, 3]);
+gap> TestSUNonDegenerateImprimitives([9, 2, 3]);
+gap> TestSUNonDegenerateImprimitives([3, 5, 3]);
+
+#
 gap> TestSpIsotropicImprimitives := function(args)
 >   local n, q, G, hasSize;
 >   n := args[1];
@@ -60,19 +60,22 @@ gap> TestSpIsotropicImprimitives := function(args)
 >   G := SpIsotropicImprimitives(n, q);
 >   hasSize := HasSize(G);
 >   RECOG.TestGroup(G, false, Size(G));
->   return IsSubset(Sp(n, q), GeneratorsOfGroup(G))
->          and DefaultFieldOfMatrixGroup(G) = GF(q)
->          and hasSize;
+>   Assert(0, IsSubset(Sp(n, q), GeneratorsOfGroup(G)));
+>   Assert(0, DefaultFieldOfMatrixGroup(G) = GF(q));
+>   Assert(0, hasSize);
 > end;;
-gap> testsSpIsotropicImprimitives := [[4, 3], [4, 7], [6, 5], [8, 3]];;
-gap> ForAll(testsSpIsotropicImprimitives, TestSpIsotropicImprimitives);
-true
+gap> TestSpIsotropicImprimitives([4, 3]);
+gap> TestSpIsotropicImprimitives([4, 7]);
+gap> TestSpIsotropicImprimitives([6, 5]);
+gap> TestSpIsotropicImprimitives([8, 3]);
 
 # Test error handling
 gap> SpIsotropicImprimitives(3, 3);
 Error, <d> must be even.
 gap> SpIsotropicImprimitives(4, 2);
 Error, <q> must be odd.
+
+#
 gap> TestSpNonDegenerateImprimitives := function(args)
 >   local n, q, t, G, hasSize;
 >   n := args[1];
@@ -81,13 +84,14 @@ gap> TestSpNonDegenerateImprimitives := function(args)
 >   G := SpNonDegenerateImprimitives(n, q, t);
 >   hasSize := HasSize(G);
 >   RECOG.TestGroup(G, false, Size(G));
->   return IsSubset(Sp(n, q), GeneratorsOfGroup(G))
->          and DefaultFieldOfMatrixGroup(G) = GF(q)
->          and hasSize;
+>   Assert(0, IsSubset(Sp(n, q), GeneratorsOfGroup(G)));
+>   Assert(0, DefaultFieldOfMatrixGroup(G) = GF(q));
+>   Assert(0, hasSize);
 > end;;
-gap> testsSpNonDegenerateImprimitives := [[4, 2, 2], [6, 5, 3], [10, 3, 5], [12, 3, 3]];;
-gap> ForAll(testsSpNonDegenerateImprimitives, TestSpNonDegenerateImprimitives);
-true
+gap> TestSpNonDegenerateImprimitives([4, 2, 2]);
+gap> TestSpNonDegenerateImprimitives([6, 5, 3]);
+gap> TestSpNonDegenerateImprimitives([10, 3, 5]);
+gap> TestSpNonDegenerateImprimitives([12, 3, 3]);
 
 # Test error handling
 gap> SpNonDegenerateImprimitives(3, 3, 3);

--- a/tst/standard/ReducibleMatrixGroups.tst
+++ b/tst/standard/ReducibleMatrixGroups.tst
@@ -10,17 +10,17 @@ gap> TestSLStabilizerOfSubspace := function(args)
 >   G := SLStabilizerOfSubspace(n, q, k);
 >   hasSize := HasSize(G);
 >   RECOG.TestGroup(G, false, Size(G));
->   return IsSubset(SL(n, q), GeneratorsOfGroup(G)) and
->          DefaultFieldOfMatrixGroup(G) = GF(q) and
->          hasSize;
+>   Assert(0, IsSubset(SL(n, q), GeneratorsOfGroup(G)));
+>   Assert(0, DefaultFieldOfMatrixGroup(G) = GF(q));
+>   Assert(0, hasSize);
 > end;;
-#@if IsBound(CLASSICAL_MAXIMALS_RUN_BROKEN_TESTS) 
-gap> testsSLStabilizerOfSubspace := [[4, 3, 2], [3, 8, 2], [2, 7, 1]];;
-#@else
-gap> testsSLStabilizerOfSubspace := [[4, 3, 2], [2, 7, 1]];;
+gap> TestSLStabilizerOfSubspace([4, 3, 2]);
+#@if IsBound(CLASSICAL_MAXIMALS_RUN_BROKEN_TESTS)
+gap> TestSLStabilizerOfSubspace([3, 8, 2]); # FIXME: `Error, !!!`, see https://github.com/gap-packages/recog/issues/12
 #@fi
-gap> ForAll(testsSLStabilizerOfSubspace, TestSLStabilizerOfSubspace);
-true
+gap> TestSLStabilizerOfSubspace([2, 7, 1]);
+
+#
 gap> TestSUStabilizerOfIsotropicSubspace := function(args)
 >   local n, q, k, G, hasSize;
 >   n := args[1];
@@ -29,13 +29,16 @@ gap> TestSUStabilizerOfIsotropicSubspace := function(args)
 >   G := SUStabilizerOfIsotropicSubspace(n, q, k);
 >   hasSize := HasSize(G);
 >   RECOG.TestGroup(G, false, Size(G));
->   return IsSubset(SU(n, q), GeneratorsOfGroup(G)) and
->          DefaultFieldOfMatrixGroup(G) = GF(q ^ 2) and
->          hasSize;
+>   Assert(0, IsSubset(SU(n, q), GeneratorsOfGroup(G)));
+>   Assert(0, DefaultFieldOfMatrixGroup(G) = GF(q ^ 2));
+>   Assert(0, hasSize);
 > end;;
-gap> testsSUStabilizerOfIsotropicSubspace := [[4, 3, 2], [3, 5, 1], [3, 4, 1], [4, 3, 1]];;
-gap> ForAll(testsSUStabilizerOfIsotropicSubspace, TestSUStabilizerOfIsotropicSubspace);
-true
+gap> TestSUStabilizerOfIsotropicSubspace([4, 3, 2]);
+gap> TestSUStabilizerOfIsotropicSubspace([3, 5, 1]);
+gap> TestSUStabilizerOfIsotropicSubspace([3, 4, 1]);
+gap> TestSUStabilizerOfIsotropicSubspace([4, 3, 1]);
+
+#
 gap> TestSUStabilizerOfNonDegenerateSubspace := function(args)
 >   local n, q, k, G, hasSize;
 >   n := args[1];
@@ -44,13 +47,16 @@ gap> TestSUStabilizerOfNonDegenerateSubspace := function(args)
 >   G := SUStabilizerOfNonDegenerateSubspace(n, q, k);
 >   hasSize := HasSize(G);
 >   RECOG.TestGroup(G, false, Size(G));
->   return IsSubset(SU(n, q), GeneratorsOfGroup(G)) and
->          DefaultFieldOfMatrixGroup(G) = GF(q ^ 2) and
->          hasSize;
+>   Assert(0, IsSubset(SU(n, q), GeneratorsOfGroup(G)));
+>   Assert(0, DefaultFieldOfMatrixGroup(G) = GF(q ^ 2));
+>   Assert(0, hasSize);
 > end;;
-gap> testsSUStabilizerOfNonDegenerateSubspace := [[5, 3, 2], [6, 3, 2], [4, 5, 1], [5, 4, 1]];;
-gap> ForAll(testsSUStabilizerOfNonDegenerateSubspace, TestSUStabilizerOfNonDegenerateSubspace);
-true
+gap> TestSUStabilizerOfNonDegenerateSubspace([5, 3, 2]);
+gap> TestSUStabilizerOfNonDegenerateSubspace([6, 3, 2]);
+gap> TestSUStabilizerOfNonDegenerateSubspace([4, 5, 1]);
+gap> TestSUStabilizerOfNonDegenerateSubspace([5, 4, 1]);
+
+#
 gap> TestSpStabilizerOfIsotropicSubspace := function(args)
 >   local n, q, k, G, hasSize;
 >   n := args[1];
@@ -59,13 +65,16 @@ gap> TestSpStabilizerOfIsotropicSubspace := function(args)
 >   G := SpStabilizerOfIsotropicSubspace(n, q, k);
 >   hasSize := HasSize(G);
 >   RECOG.TestGroup(G, false, Size(G));
->   return IsSubset(Sp(n, q), GeneratorsOfGroup(G)) and
->          DefaultFieldOfMatrixGroup(G) = GF(q) and
->          hasSize;
+>   Assert(0, IsSubset(Sp(n, q), GeneratorsOfGroup(G)));
+>   Assert(0, DefaultFieldOfMatrixGroup(G) = GF(q));
+>   Assert(0, hasSize);
 > end;;
-gap> testsSpStabilizerOfIsotropicSubspace := [[4, 2, 1], [4, 9, 1], [6, 4, 1], [6, 7, 2]];;
-gap> ForAll(testsSpStabilizerOfIsotropicSubspace, TestSpStabilizerOfIsotropicSubspace);
-true
+gap> TestSpStabilizerOfIsotropicSubspace([4, 2, 1]);
+gap> TestSpStabilizerOfIsotropicSubspace([4, 9, 1]);
+gap> TestSpStabilizerOfIsotropicSubspace([6, 4, 1]);
+gap> TestSpStabilizerOfIsotropicSubspace([6, 7, 2]);
+
+#
 gap> SpStabilizerOfIsotropicSubspace(5, 2, 1);
 Error, <d> must be even.
 gap> SpStabilizerOfIsotropicSubspace(4, 2, 3);
@@ -78,13 +87,16 @@ gap> TestSpStabilizerOfNonDegenerateSubspace := function(args)
 >   G := SpStabilizerOfNonDegenerateSubspace(n, q, k);
 >   hasSize := HasSize(G);
 >   RECOG.TestGroup(G, false, Size(G));
->   return IsSubset(Sp(n, q), GeneratorsOfGroup(G)) and
->          DefaultFieldOfMatrixGroup(G) = GF(q) and
->          hasSize;
+>   Assert(0, IsSubset(Sp(n, q), GeneratorsOfGroup(G)));
+>   Assert(0, DefaultFieldOfMatrixGroup(G) = GF(q));
+>   Assert(0, hasSize);
 > end;;
-gap> testsSpStabilizerOfNonDegenerateSubspace := [[4, 2, 1], [4, 9, 1], [6, 4, 1], [6, 7, 2]];;
-gap> ForAll(testsSpStabilizerOfNonDegenerateSubspace, TestSpStabilizerOfNonDegenerateSubspace);
-true
+gap> TestSpStabilizerOfNonDegenerateSubspace([4, 2, 1]);
+gap> TestSpStabilizerOfNonDegenerateSubspace([4, 9, 1]);
+gap> TestSpStabilizerOfNonDegenerateSubspace([6, 4, 1]);
+gap> TestSpStabilizerOfNonDegenerateSubspace([6, 7, 2]);
+
+# Test error handling
 gap> SpStabilizerOfNonDegenerateSubspace(5, 2, 1);
 Error, <d> must be even.
 gap> SpStabilizerOfNonDegenerateSubspace(4, 2, 3);

--- a/tst/standard/SemilinearMatrixGroups.tst
+++ b/tst/standard/SemilinearMatrixGroups.tst
@@ -9,13 +9,16 @@ gap> TestGammaLMeetSL := function(args)
 >   G := GammaLMeetSL(n, q, s);
 >   hasSize := HasSize(G);
 >   RECOG.TestGroup(G, false, Size(G));
->   return IsSubset(SL(n, q), GeneratorsOfGroup(G))
->          and DefaultFieldOfMatrixGroup(G) = GF(q)
->          and hasSize;
+>   Assert(0, IsSubset(SL(n, q), GeneratorsOfGroup(G)));
+>   Assert(0, DefaultFieldOfMatrixGroup(G) = GF(q));
+>   Assert(0, hasSize);
 > end;;
-gap> testsGammaLMeetSL := [[4, 3, 2], [2, 2, 2], [6, 5, 3], [3, 4, 3]];;
-gap> ForAll(testsGammaLMeetSL, TestGammaLMeetSL);
-true
+gap> TestGammaLMeetSL([4, 3, 2]);
+gap> TestGammaLMeetSL([2, 2, 2]);
+gap> TestGammaLMeetSL([6, 5, 3]);
+gap> TestGammaLMeetSL([3, 4, 3]);
+
+#
 gap> TestGammaLMeetSU := function(args)
 >   local n, q, s, G, hasSize;
 >   n := args[1];
@@ -24,13 +27,15 @@ gap> TestGammaLMeetSU := function(args)
 >   G := GammaLMeetSU(n, q, s);
 >   hasSize := HasSize(G);
 >   RECOG.TestGroup(G, false, Size(G));
->   return IsSubset(SU(n, q), GeneratorsOfGroup(G))
->          and DefaultFieldOfMatrixGroup(G) = GF(q ^ 2)
->          and hasSize;
+>   Assert(0, IsSubset(SU(n, q), GeneratorsOfGroup(G)));
+>   Assert(0, DefaultFieldOfMatrixGroup(G) = GF(q ^ 2));
+>   Assert(0, hasSize);
 > end;;
-gap> testsGammaLMeetSU := [[3, 5, 3], [6, 3, 3], [3, 7, 3]];;
-gap> ForAll(testsGammaLMeetSU, TestGammaLMeetSU);
-true
+gap> TestGammaLMeetSU([3, 5, 3]);
+gap> TestGammaLMeetSU([6, 3, 3]);
+gap> TestGammaLMeetSU([3, 7, 3]);
+
+#
 gap> TestSymplecticSemilinearSp := function(args)
 >   local n, q, s, G, hasSize;
 >   n := args[1];
@@ -39,13 +44,15 @@ gap> TestSymplecticSemilinearSp := function(args)
 >   G := SymplecticSemilinearSp(n, q, s);
 >   hasSize := HasSize(G);
 >   RECOG.TestGroup(G, false, Size(G));
->   return IsSubset(Sp(n, q), GeneratorsOfGroup(G))
->          and DefaultFieldOfMatrixGroup(G) = GF(q)
->          and hasSize;
+>   Assert(0, IsSubset(Sp(n, q), GeneratorsOfGroup(G)));
+>   Assert(0, DefaultFieldOfMatrixGroup(G) = GF(q));
+>   Assert(0, hasSize);
 > end;;
-gap> testsSymplecticSemilinearSp := [[4, 7, 2], [6, 5, 3], [8, 4, 2]];;
-gap> ForAll(testsSymplecticSemilinearSp, TestSymplecticSemilinearSp);
-true
+gap> TestSymplecticSemilinearSp([4, 7, 2]);
+gap> TestSymplecticSemilinearSp([6, 5, 3]);
+gap> TestSymplecticSemilinearSp([8, 4, 2]);
+
+#
 gap> TestUnitarySemilinearSp := function(args)
 >   local n, q, G, hasSize;
 >   n := args[1];
@@ -53,23 +60,27 @@ gap> TestUnitarySemilinearSp := function(args)
 >   G := UnitarySemilinearSp(n, q);
 >   hasSize := HasSize(G);
 >   RECOG.TestGroup(G, false, Size(G));
->   return IsSubset(Sp(n, q), GeneratorsOfGroup(G))
->          and DefaultFieldOfMatrixGroup(G) = GF(q)
->          and hasSize;
+>   Assert(0, IsSubset(Sp(n, q), GeneratorsOfGroup(G)));
+>   Assert(0, DefaultFieldOfMatrixGroup(G) = GF(q));
+>   Assert(0, hasSize);
 > end;;
-gap> testsUnitarySemilinearSp := [[4, 7], [8, 5], [6, 5]];;
-gap> ForAll(testsUnitarySemilinearSp, TestUnitarySemilinearSp);
-true
+gap> TestUnitarySemilinearSp([4, 7]);
+gap> TestUnitarySemilinearSp([8, 5]);
+gap> TestUnitarySemilinearSp([6, 5]);
+
+#
 gap> TestMatricesInducingGaloisGroupOfGFQToSOverGFQ := function(args)
 >   local q, s, gens;
 >   q := args[1];
 >   s := args[2];
 >   gens := MatricesInducingGaloisGroupOfGFQToSOverGFQ(s, q);
->   return Order(gens.A) = (q ^ s - 1) and Order(gens.B) = s;
+>   Assert(0, Order(gens.A) = (q ^ s - 1));
+>   Assert(0, Order(gens.B) = s);
 > end;;
-gap> testsMatricesInducingGaloisGroupOfGFQToSOverGFQ := [[3, 2], [2, 2], [5, 3], [4, 3]];;
-gap> ForAll(testsMatricesInducingGaloisGroupOfGFQToSOverGFQ, TestMatricesInducingGaloisGroupOfGFQToSOverGFQ);
-true
+gap> TestMatricesInducingGaloisGroupOfGFQToSOverGFQ([3, 2]);
+gap> TestMatricesInducingGaloisGroupOfGFQToSOverGFQ([2, 2]);
+gap> TestMatricesInducingGaloisGroupOfGFQToSOverGFQ([5, 3]);
+gap> TestMatricesInducingGaloisGroupOfGFQToSOverGFQ([4, 3]);
 
 #
 gap> STOP_TEST("SemilinearMatrixGroups.tst", 0);

--- a/tst/standard/SubfieldMatrixGroups.tst
+++ b/tst/standard/SubfieldMatrixGroups.tst
@@ -10,17 +10,17 @@ gap> TestSubfieldSL := function(args)
 >   G := SubfieldSL(n, p, e, f);
 >   hasSize := HasSize(G);
 >   RECOG.TestGroup(G, false, Size(G));
->   return IsSubset(SL(n, p ^ e), GeneratorsOfGroup(G))
->          and DefaultFieldOfMatrixGroup(G) = GF(p ^ e)
->          and hasSize;
+>   Assert(0, IsSubset(SL(n, p ^ e), GeneratorsOfGroup(G)));
+>   Assert(0, DefaultFieldOfMatrixGroup(G) = GF(p ^ e));
+>   Assert(0, hasSize);
 > end;;
+gap> TestSubfieldSL([4, 2, 4, 2]);
 #@if IsBound(CLASSICAL_MAXIMALS_RUN_BROKEN_TESTS)
-gap> testsSubfieldSL := [[4, 2, 4, 2], [2, 3, 6, 2], [3, 7, 3, 1]];;
-#@else
-gap> testsSubfieldSL := [[4, 2, 4, 2]];;
+gap> TestSubfieldSL([2, 3, 6, 2]);
+gap> TestSubfieldSL([3, 7, 3, 1]);
 #@fi
-gap> ForAll(testsSubfieldSL, TestSubfieldSL);
-true
+
+#
 gap> TestUnitarySubfieldSU := function(args)
 >   local n, p, e, f, G, hasSize;
 >   n := args[1];
@@ -30,17 +30,15 @@ gap> TestUnitarySubfieldSU := function(args)
 >   G := UnitarySubfieldSU(n, p, e, f);
 >   hasSize := HasSize(G);
 >   RECOG.TestGroup(G, false, Size(G));
->   return IsSubset(SU(n, p ^ e), GeneratorsOfGroup(G))
->          and DefaultFieldOfMatrixGroup(G) = GF(p ^ (2 * e))
->          and hasSize;
+>   Assert(0, IsSubset(SU(n, p ^ e), GeneratorsOfGroup(G)));
+>   #Assert(0, DefaultFieldOfMatrixGroup(G) = GF(p ^ (2 * e))); # FIXME
+>   Assert(0, hasSize);
 > end;;
-#@if IsBound(CLASSICAL_MAXIMALS_RUN_BROKEN_TESTS) 
-gap> testsUnitarySubfieldSU := [[2, 3, 6, 2], [3, 7, 3, 1], [3, 5, 3, 1]];;
-#@else
-gap> testsUnitarySubfieldSU := [];;
-#@fi
-gap> ForAll(testsUnitarySubfieldSU, TestUnitarySubfieldSU);
-true
+gap> TestUnitarySubfieldSU([2, 3, 6, 2]);
+gap> TestUnitarySubfieldSU([3, 7, 3, 1]);
+gap> TestUnitarySubfieldSU([3, 5, 3, 1]);
+
+#
 gap> TestSymplecticSubfieldSU := function(args)
 >   local n, q, G, hasSize;
 >   n := args[1];
@@ -48,32 +46,31 @@ gap> TestSymplecticSubfieldSU := function(args)
 >   G := SymplecticSubfieldSU(n, q);
 >   hasSize := HasSize(G);
 >   RECOG.TestGroup(G, false, Size(G));
->   return IsSubset(SU(n, q), GeneratorsOfGroup(G))
->          and DefaultFieldOfMatrixGroup(G) = GF(q ^ 2)
->          and hasSize;
+>   Assert(0, IsSubset(SU(n, q), GeneratorsOfGroup(G)));
+>   Assert(0, DefaultFieldOfMatrixGroup(G) = GF(q ^ 2));
+>   Assert(0, hasSize);
 > end;;
-gap> testsSymplecticSubfieldSU := [[4, 5], [2, 4], [4, 3]];;
-gap> ForAll(testsSymplecticSubfieldSU, TestSymplecticSubfieldSU);
-true
-gap> TestOrthogonalSubfieldSU := function(args)
->   local epsilon, n, q, G, hasSize;
->   epsilon := args[1];
->   n := args[2];
->   q := args[3];
+gap> TestSymplecticSubfieldSU([4, 5]);
+gap> TestSymplecticSubfieldSU([2, 4]);
+gap> TestSymplecticSubfieldSU([4, 3]);
+
+#
+gap> TestOrthogonalSubfieldSU := function(epsilon, n, q)
+>   local G, hasSize;
 >   G := OrthogonalSubfieldSU(epsilon, n, q);
 >   hasSize := HasSize(G);
 >   RECOG.TestGroup(G, false, Size(G));
->   return IsSubset(SU(n, q), GeneratorsOfGroup(G))
->          and DefaultFieldOfMatrixGroup(G) = GF(q ^ 2)
->          and hasSize;
+>   Assert(0, IsSubset(SU(n, q), GeneratorsOfGroup(G)));
+>   Assert(0, DefaultFieldOfMatrixGroup(G) = GF(q ^ 2));
+>   Assert(0, hasSize);
 > end;;
-#@if IsBound(CLASSICAL_MAXIMALS_RUN_BROKEN_TESTS)
-gap> testsOrthogonalSubfieldSU := [[0, 3, 5], [0, 5, 3], [1, 2, 5], [1, 4, 3], [-1, 2, 3], [-1, 2, 5], [-1, 4, 3]];;
-#@else
-gap> testsOrthogonalSubfieldSU := [[0, 3, 5], [0, 5, 3], [-1, 2, 3]];;
-#@fi
-gap> ForAll(testsOrthogonalSubfieldSU, TestOrthogonalSubfieldSU);
-true
+gap> TestOrthogonalSubfieldSU(0, 3, 5);
+gap> TestOrthogonalSubfieldSU(0, 5, 3);
+gap> TestOrthogonalSubfieldSU(1, 2, 5);
+gap> TestOrthogonalSubfieldSU(1, 4, 3);
+gap> TestOrthogonalSubfieldSU(-1, 2, 3);
+gap> TestOrthogonalSubfieldSU(-1, 2, 5);
+gap> TestOrthogonalSubfieldSU(-1, 4, 3);
 
 #
 gap> TestSubfieldSp := function(args)
@@ -85,13 +82,16 @@ gap> TestSubfieldSp := function(args)
 >   G := SubfieldSp(n, p, e, f);
 >   hasSize := HasSize(G);
 >   RECOG.TestGroup(G, false, Size(G));
->   return IsSubset(Sp(n, p ^ e), GeneratorsOfGroup(G))
->          and DefaultFieldOfMatrixGroup(G) = GF(p ^ e)
->          and hasSize;
+>   Assert(0, IsSubset(Sp(n, p ^ e), GeneratorsOfGroup(G)));
+>   Assert(0, DefaultFieldOfMatrixGroup(G) = GF(p ^ e));
+>   Assert(0, hasSize);
 > end;;
-gap> testsSubfieldSp := [[6, 2, 2, 1], [4, 3, 2, 1], [4, 3, 4, 2], [4, 7, 2, 1]];;
-gap> ForAll(testsSubfieldSp, TestSubfieldSp);
-true
+gap> TestSubfieldSp([6, 2, 2, 1]);
+gap> TestSubfieldSp([4, 3, 2, 1]);
+gap> TestSubfieldSp([4, 3, 4, 2]);
+gap> TestSubfieldSp([4, 7, 2, 1]);
+
+# Test error handling
 gap> SubfieldSp(3, 2, 2, 1);
 Error, <d> must be even.
 gap> SubfieldSp(4, 2, 1, 2);

--- a/tst/standard/TensorInducedMatrixGroups.tst
+++ b/tst/standard/TensorInducedMatrixGroups.tst
@@ -9,17 +9,16 @@ gap> TestTensorInducedDecompositionStabilizerInSL := function(args)
 >   G := TensorInducedDecompositionStabilizerInSL(m, t, q);
 >   hasSize := HasSize(G);
 >   RECOG.TestGroup(G, false, Size(G));
->   return IsSubset(SL(m ^ t, q), GeneratorsOfGroup(G))
->          and DefaultFieldOfMatrixGroup(G) = GF(q)
->          and hasSize;
+>   Assert(0, IsSubset(SL(m ^ t, q), GeneratorsOfGroup(G)));
+>   Assert(0, DefaultFieldOfMatrixGroup(G) = GF(q));
+>   Assert(0, hasSize);
 > end;;
-#@if IsBound(CLASSICAL_MAXIMALS_RUN_BROKEN_TESTS)
-gap> testsTensorInducedDecompositionStabilizerInSL := [[3, 2, 5], [2, 2, 7], [2, 2, 5], [3, 3, 3]];;
-#@else
-gap> testsTensorInducedDecompositionStabilizerInSL := [[3, 2, 5], [2, 2, 7], [3, 3, 3]];;
-#@fi
-gap> ForAll(testsTensorInducedDecompositionStabilizerInSL, TestTensorInducedDecompositionStabilizerInSL);
-true
+gap> TestTensorInducedDecompositionStabilizerInSL([3, 2, 5]);
+gap> TestTensorInducedDecompositionStabilizerInSL([2, 2, 7]);
+gap> TestTensorInducedDecompositionStabilizerInSL([2, 2, 5]);
+gap> TestTensorInducedDecompositionStabilizerInSL([3, 3, 3]);
+
+#
 gap> TestTensorInducedDecompositionStabilizerInSU := function(args)
 >   local m, t, q, G, hasSize;
 >   m := args[1];
@@ -27,17 +26,15 @@ gap> TestTensorInducedDecompositionStabilizerInSU := function(args)
 >   q := args[3];
 >   G := TensorInducedDecompositionStabilizerInSU(m, t, q);
 >   hasSize := HasSize(G);
->   return IsSubset(SU(m ^ t, q), GeneratorsOfGroup(G))
->          and DefaultFieldOfMatrixGroup(G) = GF(q ^ 2)
->          and hasSize;
+>   Assert(0, IsSubset(SU(m ^ t, q), GeneratorsOfGroup(G)));
+>   Assert(0, DefaultFieldOfMatrixGroup(G) = GF(q ^ 2));
+>   Assert(0, hasSize);
 > end;;
-#@if IsBound(CLASSICAL_MAXIMALS_RUN_BROKEN_TESTS)
-gap> testsTensorInducedDecompositionStabilizerInSU := [[2, 2, 7], [2, 2, 5], [3, 2, 3], [3, 3, 3], [3, 2, 5]];;
-#@else
-gap> testsTensorInducedDecompositionStabilizerInSU := [[2, 2, 5], [3, 2, 3], [3, 3, 3], [3, 2, 5]];;
-#@fi
-gap> ForAll(testsTensorInducedDecompositionStabilizerInSU, TestTensorInducedDecompositionStabilizerInSU);
-true
+gap> TestTensorInducedDecompositionStabilizerInSU([2, 2, 7]);
+gap> TestTensorInducedDecompositionStabilizerInSU([2, 2, 5]);
+gap> TestTensorInducedDecompositionStabilizerInSU([3, 2, 3]);
+gap> TestTensorInducedDecompositionStabilizerInSU([3, 3, 3]);
+gap> TestTensorInducedDecompositionStabilizerInSU([3, 2, 5]);
 
 #
 gap> STOP_TEST("TensorInducedMatrixGroups.tst", 0);

--- a/tst/standard/TensorProductMatrixGroups.tst
+++ b/tst/standard/TensorProductMatrixGroups.tst
@@ -9,13 +9,19 @@ gap> TestTensorProductStabilizerInSL := function(args)
 >   G := TensorProductStabilizerInSL(d1, d2, q);
 >   hasSize := HasSize(G);
 >   RECOG.TestGroup(G, false, Size(G));
->   return IsSubset(SL(d1 * d2, q), GeneratorsOfGroup(G))
->          and DefaultFieldOfMatrixGroup(G) = GF(q)
->          and hasSize;
+>   Assert(0, IsSubset(SL(d1 * d2, q), GeneratorsOfGroup(G)));
+>   Assert(0, DefaultFieldOfMatrixGroup(G) = GF(q));
+>   Assert(0, hasSize);
 > end;;
-gap> testsTensorProductStabilizerInSL := [[2, 3, 2], [2, 3, 3], [2, 3, 4], [2, 3, 5], [2, 4, 3], [3, 4, 2], [3, 4, 3]];;
-gap> ForAll(testsTensorProductStabilizerInSL, TestTensorProductStabilizerInSL);
-true
+gap> TestTensorProductStabilizerInSL([2, 3, 2]);
+gap> TestTensorProductStabilizerInSL([2, 3, 3]);
+gap> TestTensorProductStabilizerInSL([2, 3, 4]);
+gap> TestTensorProductStabilizerInSL([2, 3, 5]);
+gap> TestTensorProductStabilizerInSL([2, 4, 3]);
+gap> TestTensorProductStabilizerInSL([3, 4, 2]);
+gap> TestTensorProductStabilizerInSL([3, 4, 3]);
+
+#
 gap> TestTensorProductStabilizerInSU := function(args)
 >   local d1, d2, q, G, hasSize;
 >   d1 := args[1];
@@ -24,17 +30,18 @@ gap> TestTensorProductStabilizerInSU := function(args)
 >   G := TensorProductStabilizerInSU(d1, d2, q);
 >   hasSize := HasSize(G);
 >   RECOG.TestGroup(G, false, Size(G));
->   return IsSubset(SU(d1 * d2, q), GeneratorsOfGroup(G))
->          and DefaultFieldOfMatrixGroup(G) = GF(q ^ 2)
->          and hasSize;
+>   Assert(0, IsSubset(SU(d1 * d2, q), GeneratorsOfGroup(G)));
+>   Assert(0, DefaultFieldOfMatrixGroup(G) = GF(q ^ 2));
+>   Assert(0, hasSize);
 > end;;
+gap> TestTensorProductStabilizerInSU([2, 3, 2]);
+gap> TestTensorProductStabilizerInSU([2, 3, 3]);
+gap> TestTensorProductStabilizerInSU([2, 3, 4]);
 #@if IsBound(CLASSICAL_MAXIMALS_RUN_BROKEN_TESTS)
-gap> testsTensorProductStabilizerInSU := [[2, 3, 2], [2, 3, 3], [2, 3, 4], [2, 4, 3]];;
-#@else
-gap> testsTensorProductStabilizerInSU := [[2, 3, 2], [2, 3, 3]];;
+gap> TestTensorProductStabilizerInSU([2, 4, 3]); # FIXME: see https://github.com/gap-packages/recog/issues/302
 #@fi
-gap> ForAll(testsTensorProductStabilizerInSU, TestTensorProductStabilizerInSU);
-true
+
+#
 gap> TestTensorProductStabilizerInSp := function(args)
 >   local epsilon, d1, d2, q, G, hasSize;
 >   epsilon := args[1];
@@ -44,13 +51,14 @@ gap> TestTensorProductStabilizerInSp := function(args)
 >   G := TensorProductStabilizerInSp(epsilon, d1, d2, q);
 >   hasSize := HasSize(G);
 >   RECOG.TestGroup(G, false, Size(G));
->   return IsSubset(Sp(d1 * d2, q), GeneratorsOfGroup(G))
->          and DefaultFieldOfMatrixGroup(G) = GF(q)
->          and hasSize;
+>   Assert(0, IsSubset(Sp(d1 * d2, q), GeneratorsOfGroup(G)));
+>   Assert(0, DefaultFieldOfMatrixGroup(G) = GF(q));
+>   Assert(0, hasSize);
 > end;;
-gap> testsTensorProductStabilizerInSp := [[0, 2, 3, 3], [0, 4, 3, 5], [1, 2, 4, 5], [-1, 2, 4, 5]];;
-gap> ForAll(testsTensorProductStabilizerInSp, TestTensorProductStabilizerInSp);
-true
+gap> TestTensorProductStabilizerInSp([0, 2, 3, 3]);
+gap> TestTensorProductStabilizerInSp([0, 4, 3, 5]);
+gap> TestTensorProductStabilizerInSp([1, 2, 4, 5]);
+gap> TestTensorProductStabilizerInSp([-1, 2, 4, 5]);
 
 # Test error handling
 gap> TensorProductStabilizerInSp(0, 1, 3, 3);


### PR DESCRIPTION
Also add some comments for disabled tests that explain why they are disabled.
Ideally all of these would include links to issues reporting the problem. I've only done this in a few cases, the others still need to be analyzed and possible issues be filed.

With this setup, it is much easier to pinpoint which tests precisely is failing; one also gets better (more fine granular) feedback on the progress of the tests.

