### PR TITLE
Symplectic C8

### DIFF
--- a/gap/ClassicalMaximals.gi
+++ b/gap/ClassicalMaximals.gi
@@ -990,3 +990,8 @@ function(n, q)
 
     return result;
 end);
+
+BindGlobal("C8SubgroupsSymplecticGroupGeneric",
+function(n, q)
+    return [OrthogonalInSp(1, n, q), OrthogonalInSp(-1, n, q)];
+end);

--- a/gap/ClassicalNormalizerMatrixGroups.gi
+++ b/gap/ClassicalNormalizerMatrixGroups.gi
@@ -165,3 +165,16 @@ function(epsilon, d, q)
     size := Gcd(q - 1, d) * SizeSO(epsilon, d, q);
     return MatrixGroupWithSize(F, generators, size);
 end);
+
+# Construction as in Proposition 11.4 of [HR05]
+BindGlobal("OrthogonalInSp",
+function(epsilon, d, q)
+    if IsOddInt(d) then
+    	ErrorNoReturn("<d> must be even.");
+    fi;
+    if IsOddInt(q) then
+        ErrorNoReturn("<q> must be even.");
+    fi;
+
+    return ConjugateToStandardForm(SO(epsilon, d, q), "S");
+end);

--- a/tst/standard/ClassicalNormalizerMatrixGroups.tst
+++ b/tst/standard/ClassicalNormalizerMatrixGroups.tst
@@ -45,6 +45,24 @@ gap> testsOrthogonalNormalizerInSL := [[0, 3, 5], [-1, 6, 5], [1, 6, 5], [-1, 4,
 >                                      [-1, 4, 5], [1, 4, 5], [-1, 6, 3]];;
 gap> ForAll(testsOrthogonalNormalizerInSL, TestOrthogonalNormalizerInSL);
 true
+gap> TestOrthogonalInSp := function(args)
+>   local epsilon, n, q, G, hasSize;
+>   epsilon := args[1];
+>   n := args[2];
+>   q := args[3];
+>   G := OrthogonalInSp(epsilon, n, q);
+>   hasSize := HasSize(G);
+>   RECOG.TestGroup(G, false, Size(G));
+>   Assert(0, IsSubset(Sp(n, q), GeneratorsOfGroup(G)));
+>   Assert(0, DefaultFieldOfMatrixGroup(G) = GF(q));
+>   Assert(0, hasSize);
+> end;;
+#@if IsBound(CLASSICAL_MAXIMALS_RUN_BROKEN_TESTS)
+gap> TestOrthogonalInSp([1, 4, 8]);
+gap> TestOrthogonalInSp([-1, 6, 2]);
+#@fi
+gap> TestOrthogonalInSp([-1, 4, 4]);
+gap> TestOrthogonalInSp([1, 6, 2]);
 
 #
 gap> STOP_TEST("ClassicalNormalizerMatrixGroups.tst", 0);


### PR DESCRIPTION
_Description of your PR_

## Checklist for the reviewer
### General
- [ ] All functions have unit tests

### Functions constructing generators of maximal subgroups
- [ ] The code which computes and then stores the sizes is correct. To do this one confers to the tables referenced by the code. Tests for the group size should use `RECOG.TestGroup` from the recog package.
- [ ] The test suite checks whether all constructed generators are sensible. That is it tests the generators'
  - [ ] determinants (and if applicable also the spinor norms are correct), and
  - [ ] compatibility with the correct form,
  - [ ] `DefaultFieldOfMatrixGroup` returns the correct field.

### Functions assembling the list of all maximal subgroups of a certain group
- [ ] The code agrees with the tables in section 8.2 of the book "The Maximal Subgroups of the Low-dimensional Finite Classical Groups".

The reviewer doesn't need to compare our results to magma's results. That's the job of the person implementing the code.
