### PR TITLE
Symplectic C7

### DIFF
--- a/gap/ClassicalMaximals.gi
+++ b/gap/ClassicalMaximals.gi
@@ -991,6 +991,26 @@ function(n, q)
     return result;
 end);
 
+BindGlobal("C7SubgroupsSymplecticGroupGeneric",
+function(n, q)
+    local primeDivs, listOfts;
+
+    if IsEvenInt(q) then
+        return [];
+    fi;
+
+    primeDivs := PrimePowersInt(n);
+    if not Length(primeDivs) = 2 then
+        return [];
+    fi;
+
+
+    listOfts := Filtered(DivisorsInt(primeDivs[2]), IsOddInt);
+    RemoveSet(listOfts, 1);
+
+    return List(listOfts, t -> TensorInducedDecompositionStabilizerInSp(primeDivs[1] ^ QuoInt(primeDivs[2], t), t, q));
+end);
+
 BindGlobal("C8SubgroupsSymplecticGroupGeneric",
 function(n, q)
     return [OrthogonalInSp(1, n, q), OrthogonalInSp(-1, n, q)];

--- a/gap/TensorInducedMatrixGroups.gi
+++ b/gap/TensorInducedMatrixGroups.gi
@@ -249,3 +249,34 @@ function(m, t, q)
     SetInvariantSesquilinearForm(result, rec(matrix := AntidiagonalMat(d, F)));
     return ConjugateToStandardForm(result, "U");
 end);
+
+# Construction as in Proposition 10.2 in [HR05]
+BindGlobal("TensorInducedDecompositionStabilizerInSp",
+function(m, t, q)
+    local field, I, gens, D, result;
+
+    if IsOddInt(m) then
+        ErrorNoReturn("<m> must be even.");
+    fi;
+
+    if IsEvenInt(t) then
+        ErrorNoReturn("<t> must be odd.");
+    fi;
+
+    if IsEvenInt(q) then
+        ErrorNoReturn("<q> must be odd.");
+    fi;
+
+    field := GF(q);
+    I := IdentityMat(m ^ (t - 2), field);
+
+    gens := List(GeneratorsOfGroup(TensorWreathProduct(Sp(m, q), SymmetricGroup(t))));
+    
+    D := NormSpMinusSp(m, q);
+    Add(gens, KroneckerProduct(KroneckerProduct(D, Inverse(D)), I));
+
+    # Size according to the aforementioned proposition, but we add a
+    # factor of 2 because we want the size of G, not of G / Z(G)
+    result := MatrixGroupWithSize(field, gens, SizeSp(m, q) ^ t * Factorial(t));
+    return ConjugateToStandardForm(result, "S");
+end);

--- a/gap/TensorInducedMatrixGroups.gi
+++ b/gap/TensorInducedMatrixGroups.gi
@@ -256,15 +256,15 @@ function(m, t, q)
     local field, I, gens, D, result;
 
     if IsOddInt(m) then
-        ErrorNoReturn("<m> must be even.");
+        ErrorNoReturn("<m> must be even");
     fi;
 
     if IsEvenInt(t) then
-        ErrorNoReturn("<t> must be odd.");
+        ErrorNoReturn("<t> must be odd");
     fi;
 
     if IsEvenInt(q) then
-        ErrorNoReturn("<q> must be odd.");
+        ErrorNoReturn("<q> must be odd");
     fi;
 
     field := GF(q);

--- a/tst/standard/TensorInducedMatrixGroups.tst
+++ b/tst/standard/TensorInducedMatrixGroups.tst
@@ -37,4 +37,29 @@ gap> TestTensorInducedDecompositionStabilizerInSU([3, 3, 3]);
 gap> TestTensorInducedDecompositionStabilizerInSU([3, 2, 5]);
 
 #
+gap> TestTensorInducedDecompositionStabilizerInSp := function(args)
+>   local m, t, q, G, hasSize;
+>   m := args[1];
+>   t := args[2];
+>   q := args[3];
+>   G := TensorInducedDecompositionStabilizerInSp(m, t, q);
+>   hasSize := HasSize(G);
+>   RECOG.TestGroup(G, false, Size(G));
+>   Assert(0, IsSubset(Sp(m ^ t, q), GeneratorsOfGroup(G)));
+>   Assert(0, DefaultFieldOfMatrixGroup(G) = GF(q));
+>   Assert(0, hasSize);
+> end;;
+gap> TestTensorInducedDecompositionStabilizerInSp([2, 3, 7]);
+gap> TestTensorInducedDecompositionStabilizerInSp([4, 3, 3]);
+gap> TestTensorInducedDecompositionStabilizerInSp([2, 5, 3]);
+
+# Test error handling
+gap> TensorInducedDecompositionStabilizerInSp(3, 3, 3);
+Error, <m> must be even.
+gap> TensorInducedDecompositionStabilizerInSp(2, 2, 5);
+Error, <t> must be odd.
+gap> TensorInducedDecompositionStabilizerInSp(2, 3, 4);
+Error, <q> must be odd.
+
+#
 gap> STOP_TEST("TensorInducedMatrixGroups.tst", 0);

--- a/tst/standard/TensorInducedMatrixGroups.tst
+++ b/tst/standard/TensorInducedMatrixGroups.tst
@@ -51,7 +51,9 @@ gap> TestTensorInducedDecompositionStabilizerInSp := function(args)
 > end;;
 gap> TestTensorInducedDecompositionStabilizerInSp([2, 3, 7]);
 gap> TestTensorInducedDecompositionStabilizerInSp([4, 3, 3]);
-gap> TestTensorInducedDecompositionStabilizerInSp([2, 5, 3]);
+#@if IsBound(CLASSICAL_MAXIMALS_RUN_BROKEN_TESTS)
+gap> TestTensorInducedDecompositionStabilizerInSp([2, 5, 3]); # FIXME: see https://github.com/gap-packages/recog/issues/302
+#@fi
 
 # Test error handling
 gap> TensorInducedDecompositionStabilizerInSp(3, 3, 3);

--- a/tst/standard/TensorInducedMatrixGroups.tst
+++ b/tst/standard/TensorInducedMatrixGroups.tst
@@ -55,11 +55,11 @@ gap> TestTensorInducedDecompositionStabilizerInSp([2, 5, 3]);
 
 # Test error handling
 gap> TensorInducedDecompositionStabilizerInSp(3, 3, 3);
-Error, <m> must be even.
+Error, <m> must be even
 gap> TensorInducedDecompositionStabilizerInSp(2, 2, 5);
-Error, <t> must be odd.
+Error, <t> must be odd
 gap> TensorInducedDecompositionStabilizerInSp(2, 3, 4);
-Error, <q> must be odd.
+Error, <q> must be odd
 
 #
 gap> STOP_TEST("TensorInducedMatrixGroups.tst", 0);


### PR DESCRIPTION
Exactly what you would expect. Unfortunately, there are not many test examples for these groups, since the requirements on m, t and q are quite strict.

## Checklist for the reviewer
### General
- [ ] All functions have unit tests

### Functions constructing generators of maximal subgroups
- [ ] The code which computes and then stores the sizes is correct. To do this one confers to the tables referenced by the code. Tests for the group size should use `RECOG.TestGroup` from the recog package.
- [ ] The test suite checks whether all constructed generators are sensible. That is it tests the generators'
  - [ ] determinants (and if applicable also the spinor norms are correct), and
  - [ ] compatibility with the correct form,
  - [ ] `DefaultFieldOfMatrixGroup` returns the correct field.

### Functions assembling the list of all maximal subgroups of a certain group
- [ ] The code agrees with the tables in section 8.2 of the book "The Maximal Subgroups of the Low-dimensional Finite Classical Groups".

The reviewer doesn't need to compare our results to magma's results. That's the job of the person implementing the code.
