### PR TITLE
Implement Orthogonal C1 symplectic type

### DIFF
--- a/doc/ClassicalMaximals.bib
+++ b/doc/ClassicalMaximals.bib
@@ -31,10 +31,6 @@ MRREVIEWER = {A. S. Kondrat\cprime ev},
        URL = {https://doi.org/10.1112/S1461157000000899},
 }
 
-%%%%%%%%%%%%%%%%%%%%%%%%%%%
-% TODO
-% Add MRNUMBER, MRREVIEWER
-%%%%%%%%%%%%%%%%%%%%%%%%%%%
 @article {HR10,
     AUTHOR = {Holt, Derek F. and Roney-Dougal, Colva M.},
      TITLE = {Constructing maximal subgroups of orthogonal groups},
@@ -43,11 +39,12 @@ MRREVIEWER = {A. S. Kondrat\cprime ev},
     VOLUME = {13},
       YEAR = {2010},
      PAGES = {164--191},
-   MRCLASS = {20D06 (20E28 20G40 68Q25)},
+   MRCLASS = {20H30 (20D06 20E28 20G40 68Q25)},
+  MRNUMBER = {2645140},
+MRREVIEWER = {Mohammad-Reza Darafsheh},
        DOI = {10.1112/S1461157009000035},
        URL = {https://doi.org/10.1112/S1461157009000035},
 }
-
 
 @book {KL90,
     AUTHOR = {Kleidman, Peter and Liebeck, Martin},

--- a/doc/ClassicalMaximals.bib
+++ b/doc/ClassicalMaximals.bib
@@ -31,6 +31,24 @@ MRREVIEWER = {A. S. Kondrat\cprime ev},
        URL = {https://doi.org/10.1112/S1461157000000899},
 }
 
+%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% TODO
+% Add MRNUMBER, MRREVIEWER
+%%%%%%%%%%%%%%%%%%%%%%%%%%%
+@article {HR10,
+    AUTHOR = {Holt, Derek F. and Roney-Dougal, Colva M.},
+     TITLE = {Constructing maximal subgroups of orthogonal groups},
+   JOURNAL = {LMS J. Comput. Math.},
+  FJOURNAL = {LMS Journal of Computation and Mathematics},
+    VOLUME = {13},
+      YEAR = {2010},
+     PAGES = {164--191},
+   MRCLASS = {20D06 (20E28 20G40 68Q25)},
+       DOI = {10.1112/S1461157009000035},
+       URL = {https://doi.org/10.1112/S1461157009000035},
+}
+
+
 @book {KL90,
     AUTHOR = {Kleidman, Peter and Liebeck, Martin},
      TITLE = {The subgroup structure of the finite classical groups},

--- a/doc/intro.autodoc
+++ b/doc/intro.autodoc
@@ -6,4 +6,5 @@ maximal subgroups of classical matrix groups.
 The code is based on descriptions in
 <Cite Key="BHR13" />,
 <Cite Key="HR05" />,
-<Cite Key="KL90" />.
+<Cite Key="KL90" />,
+<Cite Key="HR10" />.

--- a/gap/Forms.gd
+++ b/gap/Forms.gd
@@ -4,3 +4,4 @@ DeclareGlobalFunction("UnitaryForm");
 DeclareGlobalFunction("BilinearForm");
 DeclareGlobalFunction("SymplecticForm");
 DeclareGlobalFunction("SymmetricBilinearForm");
+DeclareGlobalFunction("QuadraticForm");

--- a/gap/Forms.gi
+++ b/gap/Forms.gi
@@ -5,14 +5,19 @@
 InstallGlobalFunction("ConjugateToSesquilinearForm",
 function(group, type, gramMatrix)
     local gapForm, newForm, gapToCanonical, canonicalToNew, field, formMatrix,
-        result, d, q;
+        result, d, q, broadType;
     if not type in ["S", "O-B", "O-Q", "U"] then
-        ErrorNoReturn("<type> must be one of 'S', 'U', 'O'");
+        ErrorNoReturn("<type> must be one of 'S', 'U', 'O-B', 'O-Q'");
     fi;
     d := DimensionOfMatrixGroup(group);
     field := DefaultFieldOfMatrixGroup(group);
     if type = "S" or type = "O-B" then
-        formMatrix := BilinearForm(group, type);
+        if type = "S" then
+            broadType := type;
+        else
+            broadType := "O";
+        fi;
+        formMatrix := BilinearForm(group, broadType);
         if formMatrix = fail then
             if type = "S" then
                 ErrorNoReturn("No preserved symplectic form found for <group>");

--- a/gap/Forms.gi
+++ b/gap/Forms.gi
@@ -113,7 +113,7 @@ function(group, type)
         ErrorNoReturn("<type> cannot be 'O+' or 'O-' if the dimension of",
                       " <group> is odd");
     elif IsEvenInt(Size(F)) and IsOddInt(d) and type in ["O+", "O-", "O"] then
-        ErrorNoReturn("It <type> is 'O+', 'O-' or 'O' and the size of <F> is",
+        ErrorNoReturn("If <type> is 'O+', 'O-' or 'O' and the size of <F> is",
                       " even, <d> must be even");
     fi;
     if type in ["S", "O", "O+", "O-"] then

--- a/gap/Forms.gi
+++ b/gap/Forms.gi
@@ -82,7 +82,7 @@ function(group, type, gramMatrix)
     elif type = "U" then
         SetInvariantSesquilinearForm(result, rec(matrix := gramMatrix));
     else
-        SetInvariantQuadraticForm(result, rec(matrix := gramMatrix));
+        SetInvariantQuadraticFormFromMatrix(result, gramMatrix);
     fi;
 
     return result;

--- a/gap/Forms.gi
+++ b/gap/Forms.gi
@@ -6,12 +6,12 @@ InstallGlobalFunction("ConjugateToSesquilinearForm",
 function(group, type, gramMatrix)
     local gapForm, newForm, gapToCanonical, canonicalToNew, field, formMatrix,
         result, d, q;
-    if not type in ["S", "O", "U"] then
+    if not type in ["S", "O-B", "O-Q", "U"] then
         ErrorNoReturn("<type> must be one of 'S', 'U', 'O'");
     fi;
     d := DimensionOfMatrixGroup(group);
     field := DefaultFieldOfMatrixGroup(group);
-    if type = "S" or type = "O" then
+    if type = "S" or type = "O-B" then
         formMatrix := BilinearForm(group, type);
         if formMatrix = fail then
             if type = "S" then
@@ -23,7 +23,7 @@ function(group, type, gramMatrix)
         fi;
         gapForm := BilinearFormByMatrix(formMatrix, field);
         newForm := BilinearFormByMatrix(gramMatrix, field);
-    else
+    elif type = "U" then
         if IsOddInt(DegreeOverPrimeField(field)) then
             q := Size(field);
             field := GF(q ^ 2);
@@ -34,6 +34,14 @@ function(group, type, gramMatrix)
         fi;
         gapForm := HermitianFormByMatrix(formMatrix, field);
         newForm := HermitianFormByMatrix(gramMatrix, field);
+    else
+        # This is the case type = "O-Q"
+        formMatrix := QuadraticForm(group);
+        if formMatrix = fail then
+            ErrorNoReturn("No preserved quadratic form found for <group>");
+        fi;
+        gapForm := QuadraticFormByMatrix(formMatrix, field);
+        newForm := QuadraticFormByMatrix(gramMatrix, field);
     fi;
     if gapForm = newForm then
         # nothing to be done
@@ -64,10 +72,12 @@ function(group, type, gramMatrix)
         result := group;
     fi;
 
-    if type = "S" or type = "O" then
+    if type = "S" or type = "O-B" then
         SetInvariantBilinearForm(result, rec(matrix := gramMatrix));
-    else
+    elif type = "U" then
         SetInvariantSesquilinearForm(result, rec(matrix := gramMatrix));
+    else
+        SetInvariantQuadraticForm(result, rec(matrix := gramMatrix));
     fi;
 
     return result;
@@ -76,8 +86,6 @@ end);
 # If <group> preserves a sesquilinear form of type <type> (one of "S", "U", "O"
 # (in odd dimension), "O+" or "O-" (both in even dimension), return a group
 # conjugate to <group> preserving the standard form of that type.
-#
-# Can only deal with sesquilinear forms, not with quadratic forms as of yet.
 #
 # Also, one need to ensure that the attribute DefaultFieldOfMatrixGroup is set
 # correctly for <group>; this can be done, for example, by making the
@@ -99,6 +107,9 @@ function(group, type)
     elif type in ["O+", "O-"] and IsOddInt(d) then
         ErrorNoReturn("<type> cannot be 'O+' or 'O-' if the dimension of",
                       " <group> is odd");
+    elif IsEvenInt(Size(F)) and IsOddInt(d) and type in ["O+", "O-", "O"] then
+        ErrorNoReturn("It <type> is 'O+', 'O-' or 'O' and the size of <F> is",
+                      " even, <d> must be even");
     fi;
     if type in ["S", "O", "O+", "O-"] then
         q := Size(F);
@@ -113,10 +124,6 @@ function(group, type)
             q := Size(F);
         fi;
     fi;
-    if type in ["O", "O+", "O-"] and IsEvenInt(q) then
-        ErrorNoReturn("ConjugateToGAPForm cannot deal with orthogonal groups in",
-                      " even characteristic yet");
-    fi;
     
     # get standard GAP form
     if type = "S" then
@@ -124,15 +131,27 @@ function(group, type)
     elif type = "U" then
         gapForm := InvariantSesquilinearForm(GU(d, q)).matrix;
     elif type = "O" then
-        gapForm := InvariantBilinearForm(GO(d, q)).matrix;
+        gapForm := InvariantBilinearForm(Omega(d, q)).matrix;
     elif type = "O+" then
-        gapForm := InvariantBilinearForm(GO(1, d, q)).matrix;
+        if Characteristic(F) = 2 then
+            gapForm := InvariantQuadraticForm(Omega(1, d, q)).matrix;
+        else
+            gapForm := InvariantBilinearForm(Omega(1, d, q)).matrix;
+        fi;
     elif type = "O-" then
-        gapForm := InvariantBilinearForm(GO(-1, d, q)).matrix;
+        if Characteristic(F) = 2 then
+            gapForm := InvariantQuadraticForm(Omega(-1, d, q)).matrix;
+        else
+            gapForm := InvariantBilinearForm(Omega(-1, d, q)).matrix;
+        fi;
     fi;
 
     if type in ["O", "O+", "O-"] then
-        broadType := "O";
+        if Characteristic(F) = 2 then
+            broadType := "O-Q";
+        else
+            broadType := "O-B";
+        fi;
     else
         broadType := type;
     fi;
@@ -340,3 +359,16 @@ function(G)
     return BilinearForm(G, "O");
 end);
 
+InstallGlobalFunction("QuadraticForm",
+function(G)
+    local F, formMatrix;
+
+    F := DefaultFieldOfMatrixGroup(G);
+
+    if HasInvariantQuadraticForm(G) then
+        formMatrix := InvariantQuadraticForm(G).matrix;
+        return ImmutableMatrix(F, formMatrix);
+    else
+        ErrorNoReturn("Someone should really implement this");
+    fi;
+ end);

--- a/gap/ReducibleMatrixGroups.gi
+++ b/gap/ReducibleMatrixGroups.gi
@@ -500,6 +500,8 @@ function(epsilon, d, q)
         ErrorNoReturn("<q> must be even");
     elif not IsEvenInt(d) then
         ErrorNoReturn("<d> must be even");
+    elif d <= 2 then
+        ErrorNoReturn("<d> must be greater than 2");
     fi;
 
     field := GF(q);

--- a/gap/ReducibleMatrixGroups.gi
+++ b/gap/ReducibleMatrixGroups.gi
@@ -486,3 +486,124 @@ function(d, q, k)
     # k with 2k because [BHR13] seems to have this wrong.
     return MatrixGroupWithSize(field, gens, SizeSp(twok, q) * SizeSp(d - twok, q));
 end);
+
+# Construction as in Lemma 4.4 of [HR10]
+BindGlobal("OmegaStabilizerOfNonSingularVector",
+function(epsilon, d, q)
+    local field, m, one, zero, gamma, F, Q, w, L, HStar, N, H, j, wj,
+        matForLinSys, rightSideForLinSys, particularSol, nullspace, basisVector, z,
+        alpha, gens, result;
+    
+    if not epsilon in [-1, 1] then
+        ErrorNoReturn("<epsilon> must be 1 or -1");
+    elif not IsEvenInt(q) then
+        ErrorNoReturn("<q> must be even");
+    elif not IsEvenInt(d) then
+        ErrorNoReturn("<d> must be even");
+    fi;
+
+    field := GF(q);
+    m := QuoInt(d, 2);
+    one := One(field);
+    zero := Zero(field);
+
+    # Q and F are the matrices of the quadratic form and corresponding polar
+    # bilinear form we will use in what follows
+    if epsilon = 1 then
+        F := AntidiagonalMat(d, field);
+        Q := AntidiagonalMat(Concatenation(ListWithIdenticalEntries(m, one), 
+                                           ListWithIdenticalEntries(m, zero)), 
+                             field);
+    else
+        gamma := FindGamma(q);
+        F := AntidiagonalMat(d, field);
+        Q := AntidiagonalMat(Concatenation(ListWithIdenticalEntries(m, one),
+                                           ListWithIdenticalEntries(m, zero)),
+                             field);
+        Q[m, m] := one;
+        Q[m + 1, m + 1] := gamma;
+    fi;
+
+    # This is the vector we will stabilise; we have w * Q * w^T = 1
+    w := Concatenation([one], ListWithIdenticalEntries(d - 2, zero), [one]);
+
+    gens := [];
+    for L in GeneratorsOfGroup(ConjugateToSesquilinearForm(Sp(d - 2, q),
+                                                           "S", 
+                                                           AntidiagonalMat(d - 2, field))) do
+        HStar := NullMat(d, d, field);
+        HStar{[2..d - 1]}{[2..d - 1]} := L;
+        N := Q + HStar * Q * TransposedMat(HStar);
+
+        # H will be the element of the subgroup to construct corresponding to
+        # the generator L of Sp(d - 2, q)
+        H := NullMat(d, d, field);
+
+        # The element L of Sp(d - 2, q) acts canonically on the quotient 
+        # <w, v_2, ..., v_{d - 2}> / <w>.
+        # To lift this action to the vector space <v_1, ..., v_d>, we construct
+        # an image wj for v_j, 2 <= j <= d - 1, with wj in (vj + W) * L and 
+        # wj * Q * wj^T = vj * Q * vj^T. 
+        for j in [2..d - 1] do
+            # It is a straightforward calculation to show that this does the job
+            wj := HStar[j] + RootFFE(field, N[j, j], 2) * w;
+            H[j] := wj;
+        od;
+
+        # Build a matrix with the wj^T in the first d - 2 columns and with w^T
+        # in the last column
+        matForLinSys := NullMat(d, d - 1, field);
+        matForLinSys{[1..d]}{[1..d - 2]} := TransposedMat(H{[2..d - 1]});
+        matForLinSys[1][d - 1] := one;
+        matForLinSys[d][d - 1] := one;
+
+        rightSideForLinSys := Concatenation(ListWithIdenticalEntries(d - 2, zero), 
+                                            [one]);
+
+        # We want a vector z with z * F * wj^T = 0 for all j and z * F * w^T = 1,
+        # i.e. we need z * F * matForLinSys = rightSideForLinSys.
+        particularSol := SolutionMat(F * matForLinSys, rightSideForLinSys);
+        nullspace := NullspaceMat(F * matForLinSys);
+
+        # We need z to not be in <w, v_2, ..., v_{d - 1}>, i.e. z[1] not equal
+        # to z[d].
+        if particularSol[1] <> particularSol[d] then
+            z := particularSol;
+        else
+            for basisVector in nullspace do
+                if basisVector[1] <> basisVector[d] then
+                    z := particularSol + basisVector;
+                    break;
+                fi;
+            od;
+        fi;
+
+        if not IsBound(z) then
+            ErrorNoReturn("This should not have happened");
+        fi;
+
+
+        alpha := SolveQuadraticEquation(field, one, one, z * Q * z);
+        # Now we can choose images for v_1, v_d
+        H[d] := z + alpha * w;
+        H[1] := (z + alpha * w) + w;
+
+        # Adjust the spinor norm of H to be 1 by adding a reflection in w if
+        # necessary
+        if FancySpinorNorm(F, field, H) = -1 then
+            H := H * ReflectionMatrix(d, q, Q, "Q", w);
+        fi;
+
+        Add(gens, H);
+    od;
+
+    # Size according to Table 2.3 of [BHR13]
+    result := MatrixGroupWithSize(field, gens, SizeSp(d - 2, q));
+    SetInvariantQuadraticForm(result, rec(matrix := Q));
+
+    if epsilon = 1 then
+        return ConjugateToStandardForm(result, "O+");
+    else
+        return ConjugateToStandardForm(result, "O-");
+    fi;
+end);

--- a/gap/ReducibleMatrixGroups.gi
+++ b/gap/ReducibleMatrixGroups.gi
@@ -509,17 +509,12 @@ function(epsilon, d, q)
 
     # Q and F are the matrices of the quadratic form and corresponding polar
     # bilinear form we will use in what follows
-    if epsilon = 1 then
-        F := AntidiagonalMat(d, field);
-        Q := AntidiagonalMat(Concatenation(ListWithIdenticalEntries(m, one), 
-                                           ListWithIdenticalEntries(m, zero)), 
-                             field);
-    else
+    F := AntidiagonalMat(d, field);
+    Q := AntidiagonalMat(Concatenation(ListWithIdenticalEntries(m, one),
+                                       ListWithIdenticalEntries(m, zero)),
+                         field);
+    if epsilon = -1 then
         gamma := FindGamma(q);
-        F := AntidiagonalMat(d, field);
-        Q := AntidiagonalMat(Concatenation(ListWithIdenticalEntries(m, one),
-                                           ListWithIdenticalEntries(m, zero)),
-                             field);
         Q[m, m] := one;
         Q[m + 1, m + 1] := gamma;
     fi;

--- a/gap/SubfieldMatrixGroups.gi
+++ b/gap/SubfieldMatrixGroups.gi
@@ -169,7 +169,7 @@ function(epsilon, d, q)
 
     if IsOddInt(d) then
         SOChangedForm := ConjugateToSesquilinearForm(SO(d, q),
-                                                     "O",
+                                                     "O-B",
                                                      AntidiagonalMat(d, F));
         generators := Concatenation(generators, GeneratorsOfGroup(SOChangedForm));
         result := MatrixGroupWithSize(F, generators, size);

--- a/gap/Utils.gi
+++ b/gap/Utils.gi
@@ -173,7 +173,7 @@ function(F, a, b, c)
         ErrorNoReturn("<a> must be non-zero");
     fi;
 
-    if b = 0 then
+    if IsZero(b) then
         return RootFFE(F, -c / a, 2);
     fi;
 
@@ -449,6 +449,10 @@ end);
 
 # Compute the spinor norm of an element of an orthogonal group.
 # We use Lemma 3.5 (2) from [HR10] for q even.
+#
+# Note that if q is odd, the argument <form> must be the Gram matrix of the
+# bilinear form preserved by the orthogonal group to which M belongs. If q is
+# even, the argument <form> is redundant.
 BindGlobal("FancySpinorNorm",
 function(form, F, M)
     # Don't fool yourself and return One(F) and -One(F) here ... - they are the

--- a/gap/Utils.gi
+++ b/gap/Utils.gi
@@ -189,7 +189,7 @@ function(F, a, b, c)
     # solving a linear system 
     V := AsVectorSpace(primeField, F);
     B := Basis(V);
-    M := List([1..e], i -> Coefficients(B, B[i] + B[i] ^ 2));
+    M := List(B, b -> Coefficients(B, b + b ^ 2));
 
     # Solve v * M = Coefficients(B, d) and express v as an element of F again
     t := LinearCombination(B, SolutionMat(M, Coefficients(B, d)));

--- a/gap/Utils.gi
+++ b/gap/Utils.gi
@@ -22,7 +22,7 @@ function(entries, field)
     for i in [1..d] do
         m[i, d - i + 1] := entries[i];
     od;
-    return ImmutableMatrix(field, m);
+    return m;
 end);
 
 # Solving the congruence a ^ 2 + b ^ 2 = c in F_q by trial and error.
@@ -134,6 +134,67 @@ function(type, alpha, q)
             fi;
         od;
     fi;
+end);
+
+# Find gamma in GF(q) such that x ^ 2 + x + gamma is irreducible for q a power
+# of two.
+BindGlobal("FindGamma",
+function(q)
+    local F, R, x, gamma, polynomial;
+
+    if not IsEvenInt(q) then
+        ErrorNoReturn("<q> must be even");
+    elif not IsPrimePowerInt(q) then
+        ErrorNoReturn("<q> must be a power of 2");
+    fi;
+
+    F := GF(q);
+    R := PolynomialRing(F, ["x"]);
+    x := Indeterminate(F, "x");
+
+    for gamma in F do
+        polynomial := x ^ 2 + x + gamma;
+        if IsIrreducibleRingElement(R, polynomial) then
+            return gamma;
+        fi;
+    od;
+end);
+
+# Return a root of a * x ^ 2 + b * x + c = 0 over a finite field GF(q) of
+# characteristic 2.
+BindGlobal("SolveQuadraticEquation",
+function(F, a, b, c)
+    local primeField, e, d, V, B, M, t;
+
+    if not Characteristic(F) = 2 then
+        ErrorNoReturn("<F> must be a field of characteristic 2");
+    elif IsZero(a) then
+        ErrorNoReturn("<a> must be non-zero");
+    fi;
+
+    if b = 0 then
+        return RootFFE(F, -c / a, 2);
+    fi;
+    
+    primeField := GF(2);
+    e := DegreeOverPrimeField(F);
+
+    # We have (a / b ^ 2) * (a * x ^ 2 + b * x + c) 
+    #       = (a / b * x) ^ 2 + (a / b * x) + (c * a / b ^ 2) 
+    # Hence we find a solution of t ^ 2 + t + c * a / b ^ 2 = 0.
+    d := c * a / b ^ 2; 
+
+    # Note that the map t --> t ^ 2 + t is linear so we can express it via a
+    # representation matrix and find a pre-image of -d (if one exists) by
+    # solving a linear system 
+    V := AsVectorSpace(primeField, F);
+    B := Basis(V);
+    M := List([1..e], i -> Coefficients(B, B[i] + B[i] ^ 2));
+
+    # Solve v * M = Coefficients(B, d) and express v as an element of F again
+    t := LinearCombination(B, SolutionMat(M, Coefficients(B, d)));
+
+    return b / a * t;
 end);
 
 # An n x n - matrix of zeroes over <field> with a 1 in position (<row>, <column>)
@@ -257,26 +318,49 @@ function(epsilon, n, q)
     return QuoInt(SizeGO(epsilon, n, q), Gcd(2, q - 1));
 end);
 
-# Return the reflection matrix in the space GF(q) ^ n determined by the
-# bilinear form given by the argument <gramMatrix> and the vector <v>.
+# Return the matrix corresponding to the reflection in the vector <v> of the 
+# space GF(q) ^ n equipped with the bilinear or quadratic form given by the 
+# argument <gramMatrix>, depending on whether type = "B" or type = "Q".
+# Note that, if q is even, we require type = "Q".
 BindGlobal("ReflectionMatrix",
-function(n, q, gramMatrix, v)
-    local F, reflectionMatrix, i, basisVector, reflectBasisVector, beta;
+function(n, q, gramMatrix, type, v)
+    local F, reflectionMatrix, i, basisVector, reflectBasisVector, beta, Q,
+    halfOfbeta;
     F := GF(q);
     reflectionMatrix := NullMat(n, n, F);
-    beta := BilinearFormByMatrix(gramMatrix);
-    if IsZero(EvaluateForm(beta, v, v)) then
-        ErrorNoReturn("The vector <v> must have non-zero norm with respect to",
-                      " the bilinear form given by <gramMatrix>");
+
+    if type = "B" and IsEvenInt(q) then
+        ErrorNoReturn("If <q> is even, <type> must be 'Q'");
     fi;
+
+    if type = "B" then
+        beta := BilinearFormByMatrix(gramMatrix);
+        # We have to divide by 2 here as the function
+        # QuadraticFormByBilinearForm returns a quadratic form with 
+        # Q(v) = halfOfbeta(v, v) = 1 / 2 * beta(v, v)
+        halfOfbeta := BilinearFormByMatrix(1 / 2 * gramMatrix);
+        Q := QuadraticFormByBilinearForm(halfOfbeta);
+    elif type = "Q" then
+        Q := QuadraticFormByMatrix(gramMatrix);
+        beta := AssociatedBilinearForm(Q);
+    else
+        ErrorNoReturn("<type> must be 'B' or 'Q'");
+    fi;
+
+    if IsZero(EvaluateForm(Q, v)) then
+        ErrorNoReturn("The vector <v> must have non-zero norm with respect to",
+                      " the form given by <gramMatrix>");
+    fi;
+
     for i in [1..n] do
-        basisVector := List([1..n], j -> Zero(F));
-        basisVector[i] := Z(q) ^ 0;
+        basisVector := ListWithIdenticalEntries(n, Zero(F));
+        basisVector[i] := One(F);
         reflectBasisVector := basisVector 
-                              - 2 * EvaluateForm(beta, v, basisVector) 
-                              / EvaluateForm(beta, v, v) * v;
-        reflectionMatrix[i]{[1..n]} := reflectBasisVector;
+                              - EvaluateForm(beta, v, basisVector) 
+                              / EvaluateForm(Q, v) * v;
+        reflectionMatrix[i] := reflectBasisVector;
     od;
+
     return reflectionMatrix;
 end);
 
@@ -299,7 +383,7 @@ function(epsilon, n, q)
     if IsOddInt(n) then
             gramMatrix := IdentityMat(n, F);
             generatorsOfSO := GeneratorsOfGroup(ConjugateToSesquilinearForm(SO(epsilon, n, q),
-                                                                            "O",
+                                                                            "O-B",
                                                                             gramMatrix));
             D := - IdentityMat(n, F);
             E := zeta * IdentityMat(n, F);
@@ -307,7 +391,7 @@ function(epsilon, n, q)
         if epsilon = 1 then
             gramMatrix := AntidiagonalMat(n, F);
             generatorsOfSO := GeneratorsOfGroup(ConjugateToSesquilinearForm(SO(epsilon, n, q),
-                                                                            "O",
+                                                                            "O-B",
                                                                             gramMatrix));
             # Our standard bilinear form is given by the Gram matrix 
             # Antidiag(1, ..., 1). The norm of [1, 0, ..., 0, 2] under this
@@ -315,7 +399,7 @@ function(epsilon, n, q)
             vectorOfSquareNorm := zeta ^ 0 * Concatenation([1], 
                                                            List([1..n - 2], i -> 0), 
                                                            [2]);
-            D := ReflectionMatrix(n, q, gramMatrix, vectorOfSquareNorm);
+            D := ReflectionMatrix(n, q, gramMatrix, "B", vectorOfSquareNorm);
             E := DiagonalMat(Concatenation(List([1..n / 2], i -> zeta), 
                                            List([1..n / 2], i -> zeta ^ 0)));
         elif epsilon = -1 then
@@ -328,14 +412,14 @@ function(epsilon, n, q)
             if IsOddInt(n * (q - 1) / 4) then
                 gramMatrix := IdentityMat(n, F);
                 generatorsOfSO := GeneratorsOfGroup(ConjugateToSesquilinearForm(SO(epsilon, n, q),
-                                                                                "O",
+                                                                                "O-B",
                                                                                 gramMatrix));
                 # Our standard bilinear form is given by the Gram matrix 
                 # Diag(1, ..., 1). The norm of [1, 0, ..., 0] under this bilinear
                 # form is 1, i.e. a square.
                 vectorOfSquareNorm := zeta ^ 0 * Concatenation([1], 
                                                                List([1..n - 1], i -> 0));
-                D := ReflectionMatrix(n, q, gramMatrix, vectorOfSquareNorm);
+                D := ReflectionMatrix(n, q, gramMatrix, "B", vectorOfSquareNorm);
                 # Block diagonal matrix consisting of n / 2 blocks of the form 
                 # [[a, b], [b, -a]].
                 E := MatrixByEntries(F, n, n, 
@@ -345,14 +429,14 @@ function(epsilon, n, q)
                 gramMatrix := Z(q) ^ 0 * DiagonalMat(Concatenation([zeta],
                                                                    List([1..n - 1], i -> 1)));
                 generatorsOfSO := GeneratorsOfGroup(ConjugateToSesquilinearForm(SO(epsilon, n, q),
-                                                                                "O",
+                                                                                "O-B",
                                                                                 gramMatrix));
                 # Our standard bilinear form is given by the Gram matrix 
                 # Diag(zeta, 1, ..., 1). The norm of [0, ..., 0, 1] under this
                 # bilinear form is 1, i.e. a square.
                 vectorOfSquareNorm := zeta ^ 0 * Concatenation(List([1..n - 1], i -> 0), 
                                                                [1]);
-                D := ReflectionMatrix(n, q, gramMatrix, vectorOfSquareNorm);
+                D := ReflectionMatrix(n, q, gramMatrix, "B", vectorOfSquareNorm);
                 # Block diagonal matrix consisting of one block [[0, zeta], [1, 0]]
                 # and n / 2 - 1 blocks of the form [[a, b], [b, -a]].
                 E := MatrixByEntries(F, n, n, 
@@ -365,7 +449,28 @@ function(epsilon, n, q)
     
     return rec(generatorsOfSO := generatorsOfSO, D := D, E := E);
 end);
- 
+
+# Compute the spinor norm of an element of an orthogonal group.
+# We use Lemma 3.5 (2) from [HR10] for q even.
+BindGlobal("FancySpinorNorm",
+function(form, F, M)
+    # Don't fool yourself and return One(F) and -One(F) here ... - they are the
+    # same in even characteristic!
+    if IsOddInt(Characteristic(F)) then
+        if IsOne(SpinorNorm(form, F, M)) then
+            return 1;
+        else 
+            return -1;
+        fi;
+    else
+        if IsEvenInt(RankMat(M + IdentityMat(NrRows(M), F))) then
+            return 1;
+        else
+            return -1;
+        fi;
+    fi;
+end);
+
 InstallGlobalFunction("MatrixGroup",
 function(F, gens)
     if IsEmpty(gens) then

--- a/tst/quick/Forms.tst
+++ b/tst/quick/Forms.tst
@@ -13,7 +13,7 @@ gap> ConjugateToSesquilinearForm(SL(3, 5), "O-B", IdentityMat(3, GF(5)));
 Error, No preserved symmetric bilinear form found for <group>
 gap> TestFormChangingFunctions := function(args)
 >   local n, q, type, gramMatrix, standardGroup, conjugatedGroup, broadType,
->   standardGramMatrix, twiceConjugatedGroup;
+>   standardGramMatrix, twiceConjugatedGroup, polarForm, standardPolarForm;
 >   n := args[1];
 >   q := args[2];
 >   type := args[3];
@@ -49,7 +49,10 @@ gap> TestFormChangingFunctions := function(args)
 >   elif IsOddInt(q) then
 >       standardGramMatrix := InvariantBilinearForm(standardGroup).matrix;
 >   else
+>       SetInvariantQuadraticForm(conjugatedGroup, rec(matrix := gramMatrix));
+>       polarForm := gramMatrix + TransposedMat(gramMatrix);
 >       standardGramMatrix := InvariantQuadraticForm(standardGroup).matrix;
+>       standardPolarForm := InvariantBilinearForm(standardGroup).matrix;
 >   fi;
 >   twiceConjugatedGroup := ConjugateToStandardForm(conjugatedGroup, type);
 >   if type = "U" then
@@ -57,11 +60,20 @@ gap> TestFormChangingFunctions := function(args)
 >                     g -> g * gramMatrix * HermitianConjugate(g, q) = gramMatrix)
 >              and ForAll(GeneratorsOfGroup(twiceConjugatedGroup), 
 >                         g -> g * standardGramMatrix * HermitianConjugate(g, q) = standardGramMatrix);
->   else
+>   elif IsOddInt(q) then
 >       return ForAll(GeneratorsOfGroup(conjugatedGroup),
 >                     g -> g * gramMatrix * TransposedMat(g) = gramMatrix)
 >              and ForAll(GeneratorsOfGroup(twiceConjugatedGroup),
 >                         g -> g * standardGramMatrix * TransposedMat(g) = standardGramMatrix);
+>   else
+>       return ForAll(GeneratorsOfGroup(conjugatedGroup), 
+>                     g -> (g * polarForm * TransposedMat(g) = polarForm 
+>                           and DiagonalOfMat(g * gramMatrix * TransposedMat(g)) 
+>                               = DiagonalOfMat(gramMatrix)))
+>              and ForAll(GeneratorsOfGroup(twiceConjugatedGroup),
+>                         g -> (g * standardPolarForm * TransposedMat(g) = standardPolarForm
+>                               and DiagonalOfMat(g * standardGramMatrix * TransposedMat(g)) 
+>                                   = DiagonalOfMat(standardGramMatrix)));
 >   fi;
 > end;;
 gap> testsFormChangingFunctions := [[3, 7, "U", IdentityMat(3, GF(7))],
@@ -71,7 +83,9 @@ gap> testsFormChangingFunctions := [[3, 7, "U", IdentityMat(3, GF(7))],
 >                                   [4, 7, "O-", Z(7) ^ 0 * DiagonalMat([Z(7), 1, 1, 1])],
 >                                   [6, 7, "O-", IdentityMat(6, GF(7))],
 >                                   [1, 5, "O", IdentityMat(1, GF(5))],
->                                   [1, 5, "O", Z(5) * IdentityMat(1, GF(5))]];;
+>                                   [1, 5, "O", Z(5) * IdentityMat(1, GF(5))],
+>                                   [2, 2, "O-", Z(2) ^ 0 * [[1, 1], [0, 1]]],
+>                                   [6, 4, "O+", AntidiagonalMat(Z(4) ^ 0 * [1, 1, 1, 0, 0, 0], GF(4))]];;
 gap> ForAll(testsFormChangingFunctions, TestFormChangingFunctions);
 true
 

--- a/tst/quick/Forms.tst
+++ b/tst/quick/Forms.tst
@@ -9,7 +9,7 @@ gap> SymmetricBilinearForm(SO(5, 9)) = InvariantBilinearForm(SO(5, 9)).matrix;
 true
 gap> ConjugateToSesquilinearForm(SL(3, 4), "U", AntidiagonalMat(3, GF(4)));
 Error, No preserved unitary form found for <group>
-gap> ConjugateToSesquilinearForm(SL(3, 5), "O", IdentityMat(3, GF(5)));
+gap> ConjugateToSesquilinearForm(SL(3, 5), "O-B", IdentityMat(3, GF(5)));
 Error, No preserved symmetric bilinear form found for <group>
 gap> TestFormChangingFunctions := function(args)
 >   local n, q, type, gramMatrix, standardGroup, conjugatedGroup, broadType,
@@ -23,14 +23,14 @@ gap> TestFormChangingFunctions := function(args)
 >   elif type = "S" then
 >       standardGroup := Sp(n, q);
 >   elif type = "O" then
->       standardGroup := SO(n, q);
+>       standardGroup := Omega(n, q);
 >   elif type = "O+" then
->       standardGroup := SO(1, n, q);
+>       standardGroup := Omega(1, n, q);
 >   elif type = "O-" then
->       standardGroup := SO(-1, n, q);
+>       standardGroup := Omega(-1, n, q);
 >   fi;
 >   if type in ["O", "O+", "O-"] then
->       broadType := "O";
+>       broadType := "O-B";
 >   else
 >       broadType := type;
 >   fi;

--- a/tst/quick/Forms.tst
+++ b/tst/quick/Forms.tst
@@ -30,7 +30,11 @@ gap> TestFormChangingFunctions := function(args)
 >       standardGroup := Omega(-1, n, q);
 >   fi;
 >   if type in ["O", "O+", "O-"] then
->       broadType := "O-B";
+>       if IsOddInt(q) then
+>           broadType := "O-B";
+>       else
+>           broadType := "O-Q";
+>       fi;
 >   else
 >       broadType := type;
 >   fi;
@@ -42,8 +46,10 @@ gap> TestFormChangingFunctions := function(args)
 >   fi;
 >   if type = "U" then
 >       standardGramMatrix := InvariantSesquilinearForm(standardGroup).matrix;
->   else
+>   elif IsOddInt(q) then
 >       standardGramMatrix := InvariantBilinearForm(standardGroup).matrix;
+>   else
+>       standardGramMatrix := InvariantQuadraticForm(standardGroup).matrix;
 >   fi;
 >   twiceConjugatedGroup := ConjugateToStandardForm(conjugatedGroup, type);
 >   if type = "U" then

--- a/tst/quick/Utils.tst
+++ b/tst/quick/Utils.tst
@@ -31,6 +31,44 @@ true
 gap> x := SolveFrobeniusEquation("P", - Z(7) ^ 0, 7);;
 gap> x * x ^ 7 = - Z(7) ^ 0;
 true
+gap> TestFindGamma := function(q)
+>   local gamma, R, x;
+>   gamma := FindGamma(q);
+>   R := PolynomialRing(GF(q), ["x"]);
+>   x := Indeterminate(GF(q), "x");
+>   Assert(0, IsIrreducibleRingElement(R, x ^ 2 + x + gamma));
+> end;;
+gap> TestFindGamma(8);
+gap> TestFindGamma(2 ^ 7);
+gap> TestFindGamma(2 ^ 13);
+gap> TestSolveQuadraticEquation := function(args)
+>   local F, a, b, c;
+>   F := args[1];
+>   a := args[2];
+>   b := args[3];
+>   c := args[4];
+>   x := SolveQuadraticEquation(F, a, b, c);
+>   Assert(0, IsZero(a * x ^ 2 + b * x + c));
+> end;;
+gap> TestSolveQuadraticEquation([GF(2), Z(2), 0 * Z(2), Z(2)]);
+gap> TestSolveQuadraticEquation([GF(4), Z(4), Z(4) ^ 3, Z(4) ^ 2]);
+gap> TestSolveQuadraticEquation([GF(2 ^ 19), Z(2 ^ 19) ^ 0, Z(2 ^ 19) ^ 113, Z(2 ^ 19) ^ (-1)]);
+gap> TestFancySpinorNorm := function(args)
+>   local epsilon, d, q, GroupOmega, GroupSO;
+>   epsilon := args[1];
+>   d := args[2];
+>   q := args[3];
+>   GroupOmega := Omega(epsilon, d, q);
+>   GroupSO := SO(epsilon, d, q);
+>   Assert(0, ForAll(GeneratorsOfGroup(GroupOmega), 
+>                    gen -> FancySpinorNorm(InvariantBilinearForm(GroupOmega).matrix, GF(q), gen) = 1));
+>   Assert(0, not ForAll(GeneratorsOfGroup(GroupSO), 
+>                        gen -> FancySpinorNorm(InvariantBilinearForm(GroupSO).matrix, GF(q), gen) = -1));
+> end;;
+gap> TestFancySpinorNorm([0, 3, 7]);
+gap> TestFancySpinorNorm([1, 4, 5]);
+gap> TestFancySpinorNorm([1, 4, 8]);
+gap> TestFancySpinorNorm([-1, 6, 4]);
 gap> TestGeneratorsOfOrthogonalGroup := function(args)
 >   local epsilon, n, q, F, zeta, gen, gens, rightDets, gramMatrix, rightForm;
 >   epsilon := args[1];

--- a/tst/quick/Utils.tst
+++ b/tst/quick/Utils.tst
@@ -25,6 +25,9 @@ true
 gap> M := ReflectionMatrix(5, 9, AntidiagonalMat(5, GF(9)), "B", Z(9) ^ 0 * [1, 1, 1, 1, 1]);; 
 gap> IsOne(M ^ 2);
 true
+gap> M := ReflectionMatrix(4, 4, AntidiagonalMat(Z(4) ^ 0 * [1, 1, 0, 0], GF(4)), "Q", Z(4) ^ 0 * [1, 1, 0, 1]);;
+gap> IsOne(M ^ 2);
+true
 gap> x := SolveFrobeniusEquation("S", - Z(7) ^ 0, 7);;
 gap> x + x ^ 7 = - Z(7) ^ 0;
 true

--- a/tst/quick/Utils.tst
+++ b/tst/quick/Utils.tst
@@ -22,7 +22,7 @@ gap> IsZero(M ^ 2);
 true
 gap> QuoCeil(5, 3) = QuoCeil(6, 3);
 true
-gap> M := ReflectionMatrix(5, 9, AntidiagonalMat(5, GF(9)), Z(9) ^ 0 * [1, 1, 1, 1, 1]);; 
+gap> M := ReflectionMatrix(5, 9, AntidiagonalMat(5, GF(9)), "B", Z(9) ^ 0 * [1, 1, 1, 1, 1]);; 
 gap> IsOne(M ^ 2);
 true
 gap> x := SolveFrobeniusEquation("S", - Z(7) ^ 0, 7);;

--- a/tst/standard/ReducibleMatrixGroups.tst
+++ b/tst/standard/ReducibleMatrixGroups.tst
@@ -105,4 +105,34 @@ gap> SpStabilizerOfNonDegenerateSubspace(4, 2, 3);
 Error, <k> must be less than <d> / 2
 
 #
+gap> TestOmegaStabilizerOfNonSingularVector := function(args)
+>   local epsilon, d, q, hasSize, G;
+>   epsilon := args[1];
+>   d := args[2];
+>   q := args[3];
+>   G := OmegaStabilizerOfNonSingularVector(epsilon, d, q);
+>   hasSize := HasSize(G);
+>   RECOG.TestGroup(G, false, Size(G));
+>   Assert(0, IsSubset(Omega(epsilon, d, q), GeneratorsOfGroup(G)));
+>   Assert(0, DefaultFieldOfMatrixGroup(G) = GF(q));
+>   Assert(0, hasSize);
+> end;;
+gap> TestOmegaStabilizerOfNonSingularVector([1, 6, 4]);
+gap> TestOmegaStabilizerOfNonSingularVector([-1, 6, 4]);
+gap> TestOmegaStabilizerOfNonSingularVector([1, 8, 2]);
+gap> TestOmegaStabilizerOfNonSingularVector([-1, 8, 2]);
+gap> TestOmegaStabilizerOfNonSingularVector([1, 4, 8]);
+gap> TestOmegaStabilizerOfNonSingularVector([-1, 4, 8]);
+
+# Test error handling
+gap> OmegaStabilizerOfNonSingularVector(0, 2, 4);
+Error, <epsilon> must be 1 or -1
+gap> OmegaStabilizerOfNonSingularVector(-1, 6, 3);
+Error, <q> must be even
+gap> OmegaStabilizerOfNonSingularVector(-1, 5, 4);
+Error, <d> must be even
+gap> OmegaStabilizerOfNonSingularVector(-1, 2, 4);
+Error, <d> must be greater than 2
+
+#
 gap> STOP_TEST("ReducibleMatrixGroups.tst", 0);


### PR DESCRIPTION
Add the following functions:
- [x] `OmegaStabilizerOfNonSingularVector` in `ReducibleMatrixGroups.gi`
- [x] `SolveQuadraticEquation`, `FindGamma` and `FancySpinorNorm` in `Utils.gi`
- [x] `QuadraticForm` in `Forms.gi`

Modify the following functions:
- [x] `ReflectionMatrix` in `Utils.gi`
- [x] `ConjugateToSesquilinearForm` and `ConjugateToStandardForm` in `Forms.gi`

Tests have now been added as well, lines not covered are almost exclusively error messages.

## Checklist for the reviewer
### General
- [ ] All functions have unit tests

### Functions constructing generators of maximal subgroups
- [ ] The code which computes and then stores the sizes is correct. To do this one confers to the tables referenced by the code. Tests for the group size should use `RECOG.TestGroup` from the recog package.
- [ ] The test suite checks whether all constructed generators are sensible. That is it tests the generators'
  - [ ] determinants (and if applicable also the spinor norms are correct), and
  - [ ] compatibility with the correct form,
  - [ ] `DefaultFieldOfMatrixGroup` returns the correct field.

### Functions assembling the list of all maximal subgroups of a certain group
- [ ] The code agrees with the tables in section 8.2 of the book "The Maximal Subgroups of the Low-dimensional Finite Classical Groups".

The reviewer doesn't need to compare our results to magma's results. That's the job of the person implementing the code.
