### PR TITLE
Revise tests to check forms directly

### DIFF
--- a/gap/SubfieldMatrixGroups.gi
+++ b/gap/SubfieldMatrixGroups.gi
@@ -307,27 +307,28 @@ function (d, p, e, f)
     field := GF(p ^ e);
     q0 := p ^ f;
     gens := List(GeneratorsOfGroup(Sp(d, q0)));
+    l := QuoInt(d, 2);
 
-    # In this case the embedding of Sp(d, q0) in Sp(d, q) is already
-    # the C5-subgroup, so we just need to adjust the base field.
     if Gcd(2, b, p - 1) = 1 then
-        return MatrixGroupWithSize(field, gens, SizeSp(d, q0));
+        # In this case the embedding of Sp(d, q0) in Sp(d, q) is already
+        # the C5-subgroup, so we just need to adjust the base field.
+        result := MatrixGroupWithSize(field, gens, SizeSp(d, q0));
+    else
+        zeta := PrimitiveElement(field);
+        omega := PrimitiveElement(GF(q0));
+        zetaPower := zeta ^ - QuoInt(q0 + 1, 2);
+
+        # This matrix C preserves the form and is constructed to
+        # have determinant 1, but it is not in Sp(d, q0). Therefore it is
+        # our missing generator to extend Sp(d, q0) to a C5-subgroup, since
+        # C is in the normalizer of Sp(d, q0) in Sp(d, q).
+        C := DiagonalMat(Concatenation(ListWithIdenticalEntries(l, omega * zetaPower), ListWithIdenticalEntries(l, zetaPower)));
+        Add(gens, C);
+
+        # Size according to Table 2.8 in [BHR13]
+        result := MatrixGroupWithSize(field, gens, SizeSp(d, q0) * 2);
     fi;
 
-    l := QuoInt(d, 2);
-    zeta := PrimitiveElement(field);
-    omega := PrimitiveElement(GF(q0));
-    zetaPower := zeta ^ - QuoInt(q0 + 1, 2);
-
-    # This matrix C preserves the form and is constructed to
-    # have determinant 1, but it is not in Sp(d, q0). Therefore it is
-    # our missing generator to extend Sp(d, q0) to a C5-subgroup, since
-    # C is in the normalizer of Sp(d, q0) in Sp(d, q).
-    C := DiagonalMat(Concatenation(ListWithIdenticalEntries(l, omega * zetaPower), ListWithIdenticalEntries(l, zetaPower)));
-    Add(gens, C);
-
-    # Size according to Table 2.8 in [BHR13]
-    result := MatrixGroupWithSize(field, gens, SizeSp(d, q0) * 2);
     SetInvariantBilinearForm(result, rec(matrix := AntidiagonalMat(Concatenation(
         ListWithIdenticalEntries(l, One(field)), ListWithIdenticalEntries(l, -One(field))), field)));
 

--- a/tst/standard/ClassicalNormalizerMatrixGroups.tst
+++ b/tst/standard/ClassicalNormalizerMatrixGroups.tst
@@ -2,15 +2,13 @@ gap> START_TEST("ClassicalNormalizerMatrixGroups.tst");
 
 #
 gap> TestSymplecticNormalizerInSL := function(args)
->   local n, q, G, hasSize;
+>   local n, q, G;
 >   n := args[1];
 >   q := args[2];
 >   G := SymplecticNormalizerInSL(n, q);
->   hasSize := HasSize(G);
+>   Assert(0, HasSize(G));
+>   Assert(0, IsSubsetSL(n, q, G));
 >   RECOG.TestGroup(G, false, Size(G));
->   Assert(0, IsSubset(SL(n, q), GeneratorsOfGroup(G)));
->   Assert(0, DefaultFieldOfMatrixGroup(G) = GF(q));
->   Assert(0, hasSize);
 > end;;
 gap> TestSymplecticNormalizerInSL([4, 3]);
 gap> TestSymplecticNormalizerInSL([4, 5]);
@@ -18,15 +16,13 @@ gap> TestSymplecticNormalizerInSL([6, 4]);
 
 #
 gap> TestUnitaryNormalizerInSL := function(args)
->   local n, q, G, hasSize;
+>   local n, q, G;
 >   n := args[1];
 >   q := args[2];
 >   G := UnitaryNormalizerInSL(n, q);
->   hasSize := HasSize(G);
+>   Assert(0, HasSize(G));
+>   Assert(0, IsSubsetSL(n, q, G));
 >   RECOG.TestGroup(G, false, Size(G));
->   Assert(0, IsSubset(SL(n, q), GeneratorsOfGroup(G)));
->   Assert(0, DefaultFieldOfMatrixGroup(G) = GF(q));
->   Assert(0, hasSize);
 > end;;
 gap> TestUnitaryNormalizerInSL([4, 9]);
 gap> TestUnitaryNormalizerInSL([3, 9]);
@@ -34,16 +30,14 @@ gap> TestUnitaryNormalizerInSL([4, 4]);
 
 #
 gap> TestOrthogonalNormalizerInSL := function(args)
->   local epsilon, n, q, G, hasSize;
+>   local epsilon, n, q, G;
 >   epsilon := args[1];
 >   n := args[2];
 >   q := args[3];
 >   G := OrthogonalNormalizerInSL(epsilon, n, q);
->   hasSize := HasSize(G);
+>   Assert(0, HasSize(G));
+>   Assert(0, IsSubsetSL(n, q, G));
 >   RECOG.TestGroup(G, false, Size(G));
->   Assert(0, IsSubset(SL(n, q), GeneratorsOfGroup(G)));
->   Assert(0, DefaultFieldOfMatrixGroup(G) = GF(q));
->   Assert(0, hasSize);
 > end;;
 gap> TestOrthogonalNormalizerInSL([0, 3, 5]);
 gap> TestOrthogonalNormalizerInSL([-1, 6, 5]);
@@ -56,16 +50,14 @@ gap> TestOrthogonalNormalizerInSL([-1, 6, 3]);
 
 #
 gap> TestOrthogonalInSp := function(args)
->   local epsilon, n, q, G, hasSize;
+>   local epsilon, n, q, G;
 >   epsilon := args[1];
 >   n := args[2];
 >   q := args[3];
 >   G := OrthogonalInSp(epsilon, n, q);
->   hasSize := HasSize(G);
+>   Assert(0, HasSize(G));
+>   Assert(0, IsSubsetSp(n, q, G));
 >   RECOG.TestGroup(G, false, Size(G));
->   Assert(0, IsSubset(Sp(n, q), GeneratorsOfGroup(G)));
->   Assert(0, DefaultFieldOfMatrixGroup(G) = GF(q));
->   Assert(0, hasSize);
 > end;;
 #@if IsBound(CLASSICAL_MAXIMALS_RUN_BROKEN_TESTS)
 gap> TestOrthogonalInSp([1, 4, 8]);

--- a/tst/standard/ExtraspecialNormalizerMatrixGroups.tst
+++ b/tst/standard/ExtraspecialNormalizerMatrixGroups.tst
@@ -2,16 +2,14 @@ gap> START_TEST("ExtraspecialNormalizerMatrixGroups.tst");
 
 #
 gap> TestExtraspecialNormalizerInSL := function(args)
->   local r, m, q, G, hasSize;
+>   local r, m, q, G;
 >   r := args[1];
 >   m := args[2];
 >   q := args[3];
 >   G := ExtraspecialNormalizerInSL(r, m, q);
->   hasSize := HasSize(G);
+>   Assert(0, HasSize(G));
+>   Assert(0, IsSubsetSL(r ^ m, q, G));
 >   RECOG.TestGroup(G, false, Size(G));
->   Assert(0, IsSubset(SL(r ^ m, q), GeneratorsOfGroup(G)));
->   Assert(0, DefaultFieldOfMatrixGroup(G) = GF(q));
->   Assert(0, hasSize);
 > end;;
 gap> TestExtraspecialNormalizerInSL([5, 1, 11]);
 gap> TestExtraspecialNormalizerInSL([3, 1, 7]);
@@ -25,16 +23,14 @@ gap> TestExtraspecialNormalizerInSL([2, 1, 7]);
 
 #
 gap> TestExtraspecialNormalizerInSU := function(args)
->   local r, m, q, G, hasSize;
+>   local r, m, q, G;
 >   r := args[1];
 >   m := args[2];
 >   q := args[3];
 >   G := ExtraspecialNormalizerInSU(r, m, q);
->   hasSize := HasSize(G);
+>   Assert(0, HasSize(G));
+>   Assert(0, IsSubsetSU(r ^ m, q, G));
 >   RECOG.TestGroup(G, false, Size(G));
->   Assert(0, IsSubset(SU(r ^ m, q), GeneratorsOfGroup(G)));
->   Assert(0, DefaultFieldOfMatrixGroup(G) = GF(q ^ 2));
->   Assert(0, hasSize);
 > end;;
 gap> TestExtraspecialNormalizerInSU([5, 1, 4]);
 gap> TestExtraspecialNormalizerInSU([2, 3, 3]);
@@ -49,15 +45,13 @@ gap> TestExtraspecialNormalizerInSU([3, 1, 5]);
 
 #
 gap> TestExtraspecialNormalizerInSp := function(args)
->   local m, q, G, hasSize;
+>   local m, q, G;
 >   m := args[1];
 >   q := args[2];
 >   G := ExtraspecialNormalizerInSp(m, q);
->   hasSize := HasSize(G);
+>   Assert(0, HasSize(G));
+>   Assert(0, IsSubsetSp(2 ^ m, q, G));
 >   RECOG.TestGroup(G, false, Size(G));
->   Assert(0, IsSubset(Sp(2 ^ m, q), GeneratorsOfGroup(G)));
->   Assert(0, DefaultFieldOfMatrixGroup(G) = GF(q));
->   Assert(0, hasSize);
 > end;;
 gap> TestExtraspecialNormalizerInSp([2, 3]);
 gap> TestExtraspecialNormalizerInSp([2, 5]);

--- a/tst/standard/ImprimitiveMatrixGroups.tst
+++ b/tst/standard/ImprimitiveMatrixGroups.tst
@@ -2,16 +2,14 @@ gap> START_TEST("ImprimitiveMatrixGroups.tst");
 
 #
 gap> TestImprimitivesMeetSL := function(args)
->   local n, q, t, G, hasSize;
+>   local n, q, t, G;
 >   n := args[1];
 >   q := args[2];
 >   t := args[3];
 >   G := ImprimitivesMeetSL(n, q, t);
->   hasSize := HasSize(G);
+>   Assert(0, HasSize(G));
+>   Assert(0, IsSubsetSL(n, q, G));
 >   RECOG.TestGroup(G, false, Size(G));
->   Assert(0, IsSubset(SL(n, q), GeneratorsOfGroup(G)));
->   Assert(0, DefaultFieldOfMatrixGroup(G) = GF(q));
->   Assert(0, hasSize);
 > end;;
 gap> TestImprimitivesMeetSL([2, 3, 2]);
 #@if IsBound(CLASSICAL_MAXIMALS_RUN_BROKEN_TESTS)
@@ -21,15 +19,13 @@ gap> TestImprimitivesMeetSL([6, 5, 3]);
 
 #
 gap> TestSUIsotropicImprimitives := function(args)
->   local n, q, G, hasSize;
+>   local n, q, G;
 >   n := args[1];
 >   q := args[2];
 >   G := SUIsotropicImprimitives(n, q);
->   hasSize := HasSize(G);
+>   Assert(0, HasSize(G));
+>   Assert(0, IsSubsetSU(n, q, G));
 >   RECOG.TestGroup(G, false, Size(G));
->   Assert(0, IsSubset(SU(n, q), GeneratorsOfGroup(G)));
->   Assert(0, DefaultFieldOfMatrixGroup(G) = GF(q ^ 2));
->   Assert(0, hasSize);
 > end;;
 gap> TestSUIsotropicImprimitives([6, 2]);
 gap> TestSUIsotropicImprimitives([4, 3]);
@@ -37,16 +33,14 @@ gap> TestSUIsotropicImprimitives([2, 5]);
 
 #
 gap> TestSUNonDegenerateImprimitives := function(args)
->   local n, q, t, G, hasSize;
+>   local n, q, t, G;
 >   n := args[1];
 >   q := args[2];
 >   t := args[3];
 >   G := SUNonDegenerateImprimitives(n, q, t);
->   hasSize := HasSize(G);
+>   Assert(0, HasSize(G));
+>   Assert(0, IsSubsetSU(n, q, G));
 >   RECOG.TestGroup(G, false, Size(G));
->   Assert(0, IsSubset(SU(n, q), GeneratorsOfGroup(G)));
->   Assert(0, DefaultFieldOfMatrixGroup(G) = GF(q ^ 2));
->   Assert(0, hasSize);
 > end;;
 gap> TestSUNonDegenerateImprimitives([6, 3, 3]);
 gap> TestSUNonDegenerateImprimitives([9, 2, 3]);
@@ -54,15 +48,13 @@ gap> TestSUNonDegenerateImprimitives([3, 5, 3]);
 
 #
 gap> TestSpIsotropicImprimitives := function(args)
->   local n, q, G, hasSize;
+>   local n, q, G;
 >   n := args[1];
 >   q := args[2];
 >   G := SpIsotropicImprimitives(n, q);
->   hasSize := HasSize(G);
+>   Assert(0, HasSize(G));
+>   Assert(0, IsSubsetSp(n, q, G));
 >   RECOG.TestGroup(G, false, Size(G));
->   Assert(0, IsSubset(Sp(n, q), GeneratorsOfGroup(G)));
->   Assert(0, DefaultFieldOfMatrixGroup(G) = GF(q));
->   Assert(0, hasSize);
 > end;;
 gap> TestSpIsotropicImprimitives([4, 3]);
 gap> TestSpIsotropicImprimitives([4, 7]);
@@ -77,16 +69,14 @@ Error, <q> must be odd
 
 #
 gap> TestSpNonDegenerateImprimitives := function(args)
->   local n, q, t, G, hasSize;
+>   local n, q, t, G;
 >   n := args[1];
 >   q := args[2];
 >   t := args[3];
 >   G := SpNonDegenerateImprimitives(n, q, t);
->   hasSize := HasSize(G);
+>   Assert(0, HasSize(G));
+>   Assert(0, IsSubsetSp(n, q, G));
 >   RECOG.TestGroup(G, false, Size(G));
->   Assert(0, IsSubset(Sp(n, q), GeneratorsOfGroup(G)));
->   Assert(0, DefaultFieldOfMatrixGroup(G) = GF(q));
->   Assert(0, hasSize);
 > end;;
 gap> TestSpNonDegenerateImprimitives([4, 2, 2]);
 gap> TestSpNonDegenerateImprimitives([6, 5, 3]);

--- a/tst/standard/ReducibleMatrixGroups.tst
+++ b/tst/standard/ReducibleMatrixGroups.tst
@@ -2,17 +2,15 @@ gap> START_TEST("ReducibleMatrixGroups.tst");
 
 #
 gap> TestSLStabilizerOfSubspace := function(args)
->   local n, q, k, G, hasSize;
+>   local n, q, k, G;
 >   Info(InfoClassicalMaximalsTests, 1, args);
 >   n := args[1];
 >   q := args[2];
 >   k := args[3];
 >   G := SLStabilizerOfSubspace(n, q, k);
->   hasSize := HasSize(G);
+>   Assert(0, HasSize(G));
+>   Assert(0, IsSubsetSL(n, q, G));
 >   RECOG.TestGroup(G, false, Size(G));
->   Assert(0, IsSubset(SL(n, q), GeneratorsOfGroup(G)));
->   Assert(0, DefaultFieldOfMatrixGroup(G) = GF(q));
->   Assert(0, hasSize);
 > end;;
 gap> TestSLStabilizerOfSubspace([4, 3, 2]);
 #@if IsBound(CLASSICAL_MAXIMALS_RUN_BROKEN_TESTS)
@@ -22,16 +20,14 @@ gap> TestSLStabilizerOfSubspace([2, 7, 1]);
 
 #
 gap> TestSUStabilizerOfIsotropicSubspace := function(args)
->   local n, q, k, G, hasSize;
+>   local n, q, k, G;
 >   n := args[1];
 >   q := args[2];
 >   k := args[3];
 >   G := SUStabilizerOfIsotropicSubspace(n, q, k);
->   hasSize := HasSize(G);
+>   Assert(0, HasSize(G));
+>   Assert(0, IsSubsetSU(n, q, G));
 >   RECOG.TestGroup(G, false, Size(G));
->   Assert(0, IsSubset(SU(n, q), GeneratorsOfGroup(G)));
->   Assert(0, DefaultFieldOfMatrixGroup(G) = GF(q ^ 2));
->   Assert(0, hasSize);
 > end;;
 gap> TestSUStabilizerOfIsotropicSubspace([4, 3, 2]);
 gap> TestSUStabilizerOfIsotropicSubspace([3, 5, 1]);
@@ -40,16 +36,14 @@ gap> TestSUStabilizerOfIsotropicSubspace([4, 3, 1]);
 
 #
 gap> TestSUStabilizerOfNonDegenerateSubspace := function(args)
->   local n, q, k, G, hasSize;
+>   local n, q, k, G;
 >   n := args[1];
 >   q := args[2];
 >   k := args[3];
 >   G := SUStabilizerOfNonDegenerateSubspace(n, q, k);
->   hasSize := HasSize(G);
+>   Assert(0, HasSize(G));
+>   Assert(0, IsSubsetSU(n, q, G));
 >   RECOG.TestGroup(G, false, Size(G));
->   Assert(0, IsSubset(SU(n, q), GeneratorsOfGroup(G)));
->   Assert(0, DefaultFieldOfMatrixGroup(G) = GF(q ^ 2));
->   Assert(0, hasSize);
 > end;;
 gap> TestSUStabilizerOfNonDegenerateSubspace([5, 3, 2]);
 gap> TestSUStabilizerOfNonDegenerateSubspace([6, 3, 2]);
@@ -58,16 +52,14 @@ gap> TestSUStabilizerOfNonDegenerateSubspace([5, 4, 1]);
 
 #
 gap> TestSpStabilizerOfIsotropicSubspace := function(args)
->   local n, q, k, G, hasSize;
+>   local n, q, k, G;
 >   n := args[1];
 >   q := args[2];
 >   k := args[3];
 >   G := SpStabilizerOfIsotropicSubspace(n, q, k);
->   hasSize := HasSize(G);
+>   Assert(0, HasSize(G));
+>   Assert(0, IsSubsetSp(n, q, G));
 >   RECOG.TestGroup(G, false, Size(G));
->   Assert(0, IsSubset(Sp(n, q), GeneratorsOfGroup(G)));
->   Assert(0, DefaultFieldOfMatrixGroup(G) = GF(q));
->   Assert(0, hasSize);
 > end;;
 gap> TestSpStabilizerOfIsotropicSubspace([4, 2, 1]);
 gap> TestSpStabilizerOfIsotropicSubspace([4, 9, 1]);
@@ -82,16 +74,14 @@ Error, <k> must be less than or equal to <d> / 2
 
 #
 gap> TestSpStabilizerOfNonDegenerateSubspace := function(args)
->   local n, q, k, G, hasSize;
+>   local n, q, k, G;
 >   n := args[1];
 >   q := args[2];
 >   k := args[3];
 >   G := SpStabilizerOfNonDegenerateSubspace(n, q, k);
->   hasSize := HasSize(G);
+>   Assert(0, HasSize(G));
+>   Assert(0, IsSubsetSp(n, q, G));
 >   RECOG.TestGroup(G, false, Size(G));
->   Assert(0, IsSubset(Sp(n, q), GeneratorsOfGroup(G)));
->   Assert(0, DefaultFieldOfMatrixGroup(G) = GF(q));
->   Assert(0, hasSize);
 > end;;
 gap> TestSpStabilizerOfNonDegenerateSubspace([4, 2, 1]);
 gap> TestSpStabilizerOfNonDegenerateSubspace([4, 9, 1]);
@@ -106,16 +96,15 @@ Error, <k> must be less than <d> / 2
 
 #
 gap> TestOmegaStabilizerOfNonSingularVector := function(args)
->   local epsilon, d, q, hasSize, G;
+>   local epsilon, d, q, G;
 >   epsilon := args[1];
 >   d := args[2];
 >   q := args[3];
 >   G := OmegaStabilizerOfNonSingularVector(epsilon, d, q);
->   hasSize := HasSize(G);
->   RECOG.TestGroup(G, false, Size(G));
+>   Assert(0, HasSize(G));
 >   Assert(0, IsSubset(Omega(epsilon, d, q), GeneratorsOfGroup(G)));
 >   Assert(0, DefaultFieldOfMatrixGroup(G) = GF(q));
->   Assert(0, hasSize);
+>   RECOG.TestGroup(G, false, Size(G));
 > end;;
 gap> TestOmegaStabilizerOfNonSingularVector([1, 6, 4]);
 gap> TestOmegaStabilizerOfNonSingularVector([-1, 6, 4]);

--- a/tst/standard/SemilinearMatrixGroups.tst
+++ b/tst/standard/SemilinearMatrixGroups.tst
@@ -2,16 +2,14 @@ gap> START_TEST("SemilinearMatrixGroups.tst");
 
 #
 gap> TestGammaLMeetSL := function(args)
->   local n, q, s, G, hasSize;
+>   local n, q, s, G;
 >   n := args[1];
 >   q := args[2];
 >   s := args[3];
 >   G := GammaLMeetSL(n, q, s);
->   hasSize := HasSize(G);
+>   Assert(0, HasSize(G));
+>   Assert(0, IsSubsetSL(n, q, G));
 >   RECOG.TestGroup(G, false, Size(G));
->   Assert(0, IsSubset(SL(n, q), GeneratorsOfGroup(G)));
->   Assert(0, DefaultFieldOfMatrixGroup(G) = GF(q));
->   Assert(0, hasSize);
 > end;;
 gap> TestGammaLMeetSL([4, 3, 2]);
 gap> TestGammaLMeetSL([2, 2, 2]);
@@ -20,16 +18,14 @@ gap> TestGammaLMeetSL([3, 4, 3]);
 
 #
 gap> TestGammaLMeetSU := function(args)
->   local n, q, s, G, hasSize;
+>   local n, q, s, G;
 >   n := args[1];
 >   q := args[2];
 >   s := args[3];
 >   G := GammaLMeetSU(n, q, s);
->   hasSize := HasSize(G);
+>   Assert(0, HasSize(G));
+>   Assert(0, IsSubsetSU(n, q, G));
 >   RECOG.TestGroup(G, false, Size(G));
->   Assert(0, IsSubset(SU(n, q), GeneratorsOfGroup(G)));
->   Assert(0, DefaultFieldOfMatrixGroup(G) = GF(q ^ 2));
->   Assert(0, hasSize);
 > end;;
 gap> TestGammaLMeetSU([3, 5, 3]);
 gap> TestGammaLMeetSU([6, 3, 3]);
@@ -37,16 +33,14 @@ gap> TestGammaLMeetSU([3, 7, 3]);
 
 #
 gap> TestSymplecticSemilinearSp := function(args)
->   local n, q, s, G, hasSize;
+>   local n, q, s, G;
 >   n := args[1];
 >   q := args[2];
 >   s := args[3];
 >   G := SymplecticSemilinearSp(n, q, s);
->   hasSize := HasSize(G);
+>   Assert(0, HasSize(G));
+>   Assert(0, IsSubsetSp(n, q, G));
 >   RECOG.TestGroup(G, false, Size(G));
->   Assert(0, IsSubset(Sp(n, q), GeneratorsOfGroup(G)));
->   Assert(0, DefaultFieldOfMatrixGroup(G) = GF(q));
->   Assert(0, hasSize);
 > end;;
 gap> TestSymplecticSemilinearSp([4, 7, 2]);
 gap> TestSymplecticSemilinearSp([6, 5, 3]);
@@ -54,15 +48,13 @@ gap> TestSymplecticSemilinearSp([8, 4, 2]);
 
 #
 gap> TestUnitarySemilinearSp := function(args)
->   local n, q, G, hasSize;
+>   local n, q, G;
 >   n := args[1];
 >   q := args[2];
 >   G := UnitarySemilinearSp(n, q);
->   hasSize := HasSize(G);
+>   Assert(0, HasSize(G));
+>   Assert(0, IsSubsetSp(n, q, G));
 >   RECOG.TestGroup(G, false, Size(G));
->   Assert(0, IsSubset(Sp(n, q), GeneratorsOfGroup(G)));
->   Assert(0, DefaultFieldOfMatrixGroup(G) = GF(q));
->   Assert(0, hasSize);
 > end;;
 gap> TestUnitarySemilinearSp([4, 7]);
 gap> TestUnitarySemilinearSp([8, 5]);

--- a/tst/standard/SubfieldMatrixGroups.tst
+++ b/tst/standard/SubfieldMatrixGroups.tst
@@ -2,17 +2,15 @@ gap> START_TEST("SubfieldMatrixGroups.tst");
 
 #
 gap> TestSubfieldSL := function(args)
->   local n, p, e, f, G, hasSize;
+>   local n, p, e, f, G;
 >   n := args[1];
 >   p := args[2];
 >   e := args[3];
 >   f := args[4];
 >   G := SubfieldSL(n, p, e, f);
->   hasSize := HasSize(G);
+>   Assert(0, HasSize(G));
+>   Assert(0, IsSubsetSL(n, p ^ e, G));
 >   RECOG.TestGroup(G, false, Size(G));
->   Assert(0, IsSubset(SL(n, p ^ e), GeneratorsOfGroup(G)));
->   Assert(0, DefaultFieldOfMatrixGroup(G) = GF(p ^ e));
->   Assert(0, hasSize);
 > end;;
 gap> TestSubfieldSL([4, 2, 4, 2]);
 #@if IsBound(CLASSICAL_MAXIMALS_RUN_BROKEN_TESTS)
@@ -30,17 +28,16 @@ Error, the quotient of <e> by <f> must be a prime
 
 #
 gap> TestUnitarySubfieldSU := function(args)
->   local n, p, e, f, G, hasSize;
+>   local n, p, e, f, G;
 >   n := args[1];
 >   p := args[2];
 >   e := args[3];
 >   f := args[4];
 >   G := UnitarySubfieldSU(n, p, e, f);
->   hasSize := HasSize(G);
->   RECOG.TestGroup(G, false, Size(G));
+>   Assert(0, HasSize(G));
 >   Assert(0, IsSubset(SU(n, p ^ e), GeneratorsOfGroup(G)));
 >   #Assert(0, DefaultFieldOfMatrixGroup(G) = GF(p ^ (2 * e))); # FIXME
->   Assert(0, hasSize);
+>   RECOG.TestGroup(G, false, Size(G));
 > end;;
 gap> TestUnitarySubfieldSU([2, 3, 6, 2]);
 gap> TestUnitarySubfieldSU([3, 7, 3, 1]);
@@ -56,15 +53,13 @@ Error, the quotient of <e> by <f> must be an odd prime
 
 #
 gap> TestSymplecticSubfieldSU := function(args)
->   local n, q, G, hasSize;
+>   local n, q, G;
 >   n := args[1];
 >   q := args[2];
 >   G := SymplecticSubfieldSU(n, q);
->   hasSize := HasSize(G);
+>   Assert(0, HasSize(G));
+>   Assert(0, IsSubsetSU(n, q, G));
 >   RECOG.TestGroup(G, false, Size(G));
->   Assert(0, IsSubset(SU(n, q), GeneratorsOfGroup(G)));
->   Assert(0, DefaultFieldOfMatrixGroup(G) = GF(q ^ 2));
->   Assert(0, hasSize);
 > end;;
 gap> TestSymplecticSubfieldSU([4, 5]);
 gap> TestSymplecticSubfieldSU([2, 4]);
@@ -76,13 +71,11 @@ Error, <d> must be even
 
 #
 gap> TestOrthogonalSubfieldSU := function(epsilon, n, q)
->   local G, hasSize;
+>   local G;
 >   G := OrthogonalSubfieldSU(epsilon, n, q);
->   hasSize := HasSize(G);
+>   Assert(0, HasSize(G));
+>   Assert(0, IsSubsetSU(n, q, G));
 >   RECOG.TestGroup(G, false, Size(G));
->   Assert(0, IsSubset(SU(n, q), GeneratorsOfGroup(G)));
->   Assert(0, DefaultFieldOfMatrixGroup(G) = GF(q ^ 2));
->   Assert(0, hasSize);
 > end;;
 gap> TestOrthogonalSubfieldSU(0, 3, 5);
 gap> TestOrthogonalSubfieldSU(0, 5, 3);
@@ -94,17 +87,15 @@ gap> TestOrthogonalSubfieldSU(-1, 4, 3);
 
 #
 gap> TestSubfieldSp := function(args)
->   local n, p, e, f, G, hasSize;
+>   local n, p, e, f, G;
 >   n := args[1];
 >   p := args[2];
 >   e := args[3];
 >   f := args[4];
 >   G := SubfieldSp(n, p, e, f);
->   hasSize := HasSize(G);
+>   Assert(0, HasSize(G));
+>   Assert(0, IsSubsetSp(n, p ^ e, G));
 >   RECOG.TestGroup(G, false, Size(G));
->   Assert(0, IsSubset(Sp(n, p ^ e), GeneratorsOfGroup(G)));
->   Assert(0, DefaultFieldOfMatrixGroup(G) = GF(p ^ e));
->   Assert(0, hasSize);
 > end;;
 gap> TestSubfieldSp([6, 2, 2, 1]);
 gap> TestSubfieldSp([4, 3, 2, 1]);

--- a/tst/standard/TensorInducedMatrixGroups.tst
+++ b/tst/standard/TensorInducedMatrixGroups.tst
@@ -2,16 +2,14 @@ gap> START_TEST("TensorInducedMatrixGroups.tst");
 
 #
 gap> TestTensorInducedDecompositionStabilizerInSL := function(args)
->   local m, t, q, G, hasSize;
+>   local m, t, q, G;
 >   m := args[1];
 >   t := args[2];
 >   q := args[3];
 >   G := TensorInducedDecompositionStabilizerInSL(m, t, q);
->   hasSize := HasSize(G);
+>   Assert(0, HasSize(G));
+>   Assert(0, IsSubsetSL(m ^ t, q, G));
 >   RECOG.TestGroup(G, false, Size(G));
->   Assert(0, IsSubset(SL(m ^ t, q), GeneratorsOfGroup(G)));
->   Assert(0, DefaultFieldOfMatrixGroup(G) = GF(q));
->   Assert(0, hasSize);
 > end;;
 gap> TestTensorInducedDecompositionStabilizerInSL([3, 2, 5]);
 gap> TestTensorInducedDecompositionStabilizerInSL([2, 2, 7]);
@@ -20,15 +18,13 @@ gap> TestTensorInducedDecompositionStabilizerInSL([3, 3, 3]);
 
 #
 gap> TestTensorInducedDecompositionStabilizerInSU := function(args)
->   local m, t, q, G, hasSize;
+>   local m, t, q, G;
 >   m := args[1];
 >   t := args[2];
 >   q := args[3];
 >   G := TensorInducedDecompositionStabilizerInSU(m, t, q);
->   hasSize := HasSize(G);
->   Assert(0, IsSubset(SU(m ^ t, q), GeneratorsOfGroup(G)));
->   Assert(0, DefaultFieldOfMatrixGroup(G) = GF(q ^ 2));
->   Assert(0, hasSize);
+>   Assert(0, IsSubsetSU(m ^ t, q, G));
+>   Assert(0, HasSize(G));
 > end;;
 gap> TestTensorInducedDecompositionStabilizerInSU([2, 2, 7]);
 gap> TestTensorInducedDecompositionStabilizerInSU([2, 2, 5]);
@@ -38,16 +34,14 @@ gap> TestTensorInducedDecompositionStabilizerInSU([3, 2, 5]);
 
 #
 gap> TestTensorInducedDecompositionStabilizerInSp := function(args)
->   local m, t, q, G, hasSize;
+>   local m, t, q, G;
 >   m := args[1];
 >   t := args[2];
 >   q := args[3];
 >   G := TensorInducedDecompositionStabilizerInSp(m, t, q);
->   hasSize := HasSize(G);
+>   Assert(0, HasSize(G));
+>   Assert(0, IsSubsetSp(m ^ t, q, G));
 >   RECOG.TestGroup(G, false, Size(G));
->   Assert(0, IsSubset(Sp(m ^ t, q), GeneratorsOfGroup(G)));
->   Assert(0, DefaultFieldOfMatrixGroup(G) = GF(q));
->   Assert(0, hasSize);
 > end;;
 gap> TestTensorInducedDecompositionStabilizerInSp([2, 3, 7]);
 gap> TestTensorInducedDecompositionStabilizerInSp([4, 3, 3]);

--- a/tst/standard/TensorProductMatrixGroups.tst
+++ b/tst/standard/TensorProductMatrixGroups.tst
@@ -2,16 +2,15 @@ gap> START_TEST("TensorProductMatrixGroups.tst");
 
 #
 gap> TestTensorProductStabilizerInSL := function(args)
->   local d1, d2, q, G, hasSize;
+>   local d1, d2, q, G;
 >   d1 := args[1];
 >   d2 := args[2];
 >   q := args[3];
 >   G := TensorProductStabilizerInSL(d1, d2, q);
->   hasSize := HasSize(G);
->   RECOG.TestGroup(G, false, Size(G));
->   Assert(0, IsSubset(SL(d1 * d2, q), GeneratorsOfGroup(G)));
+>   Assert(0, HasSize(G));
+>   Assert(0, IsSubsetSL(d1 * d2, q, G));
 >   Assert(0, DefaultFieldOfMatrixGroup(G) = GF(q));
->   Assert(0, hasSize);
+>   RECOG.TestGroup(G, false, Size(G));
 > end;;
 gap> TestTensorProductStabilizerInSL([2, 3, 2]);
 gap> TestTensorProductStabilizerInSL([2, 3, 3]);
@@ -23,16 +22,15 @@ gap> TestTensorProductStabilizerInSL([3, 4, 3]);
 
 #
 gap> TestTensorProductStabilizerInSU := function(args)
->   local d1, d2, q, G, hasSize;
+>   local d1, d2, q, G;
 >   d1 := args[1];
 >   d2 := args[2];
 >   q := args[3];
 >   G := TensorProductStabilizerInSU(d1, d2, q);
->   hasSize := HasSize(G);
->   RECOG.TestGroup(G, false, Size(G));
->   Assert(0, IsSubset(SU(d1 * d2, q), GeneratorsOfGroup(G)));
+>   Assert(0, HasSize(G));
+>   Assert(0, IsSubsetSU(d1 * d2, q, G));
 >   Assert(0, DefaultFieldOfMatrixGroup(G) = GF(q ^ 2));
->   Assert(0, hasSize);
+>   RECOG.TestGroup(G, false, Size(G));
 > end;;
 gap> TestTensorProductStabilizerInSU([2, 3, 2]);
 gap> TestTensorProductStabilizerInSU([2, 3, 3]);
@@ -43,17 +41,16 @@ gap> TestTensorProductStabilizerInSU([2, 4, 3]); # FIXME: see https://github.com
 
 #
 gap> TestTensorProductStabilizerInSp := function(args)
->   local epsilon, d1, d2, q, G, hasSize;
+>   local epsilon, d1, d2, q, G;
 >   epsilon := args[1];
 >   d1 := args[2];
 >   d2 := args[3];
 >   q := args[4];
 >   G := TensorProductStabilizerInSp(epsilon, d1, d2, q);
->   hasSize := HasSize(G);
->   RECOG.TestGroup(G, false, Size(G));
->   Assert(0, IsSubset(Sp(d1 * d2, q), GeneratorsOfGroup(G)));
+>   Assert(0, HasSize(G));
+>   Assert(0, IsSubsetSp(d1 * d2, q, G));
 >   Assert(0, DefaultFieldOfMatrixGroup(G) = GF(q));
->   Assert(0, hasSize);
+>   RECOG.TestGroup(G, false, Size(G));
 > end;;
 gap> TestTensorProductStabilizerInSp([0, 2, 3, 3]);
 gap> TestTensorProductStabilizerInSp([0, 4, 3, 5]);

--- a/tst/testall.g
+++ b/tst/testall.g
@@ -6,6 +6,7 @@
 #
 LoadPackage( "ClassicalMaximals" );
 
+ReadPackage( "ClassicalMaximals", "tst/utils.g" );
 TestDirectory(DirectoriesPackageLibrary( "ClassicalMaximals", "tst" ),
   rec(exitGAP := true));
 

--- a/tst/testbroken.g
+++ b/tst/testbroken.g
@@ -9,6 +9,7 @@ LoadPackage( "ClassicalMaximals" );
 # This has to be bound to any value to run the broken tests
 CLASSICAL_MAXIMALS_RUN_BROKEN_TESTS := 1;
 
+ReadPackage( "ClassicalMaximals", "tst/utils.g" );
 TestDirectory(DirectoriesPackageLibrary( "ClassicalMaximals", "tst" ),
   rec(exitGAP := true));
 

--- a/tst/testquick.g
+++ b/tst/testquick.g
@@ -6,6 +6,7 @@
 #
 LoadPackage( "ClassicalMaximals" );
 
+ReadPackage( "ClassicalMaximals", "tst/utils.g" );
 TestDirectory(DirectoriesPackageLibrary( "ClassicalMaximals", "tst/quick/" ),
   rec(exitGAP := true));
 

--- a/tst/utils.g
+++ b/tst/utils.g
@@ -1,0 +1,58 @@
+CheckGeneratorsInvertible := function(G)
+  return ForAll(GeneratorsOfGroup(G),
+              g -> not IsZero(Determinant(g)));
+end;
+
+CheckGeneratorsSpecial := function(G)
+  return ForAll(GeneratorsOfGroup(G),
+              g -> IsOne(Determinant(g)));
+end;
+
+# verify that forms are given and preserved
+CheckBilinearForm := function(G)
+  local M;
+  M := InvariantBilinearForm(G).matrix;
+  return ForAll(GeneratorsOfGroup(G),
+              g -> g*M*TransposedMat(g) = M);
+end;
+
+CheckQuadraticForm := function(G)
+  local M, Q;
+  M := InvariantBilinearForm(G).matrix;
+  Q := InvariantQuadraticForm(G).matrix;
+  return (Q+TransposedMat(Q) = M) and
+         ForAll(GeneratorsOfGroup(G),
+           g -> RespectsQuadraticForm(Q, g));
+end;
+
+CheckSesquilinearForm := function(G)
+  local M, F, q;
+  M := InvariantSesquilinearForm(G).matrix;
+  F := DefaultFieldOfMatrixGroup(G);
+  q := RootInt(Size(F));
+  return ForAll(GeneratorsOfGroup(G),
+              g -> g*M*HermitianConjugate(g,q) = M);
+end;
+
+IsSubsetSL := function(n, q, G)
+  Assert(0, DimensionOfMatrixGroup(G) = n);
+  Assert(0, DefaultFieldOfMatrixGroup(G) = GF(q));
+  Assert(0, CheckGeneratorsSpecial(G));
+  return true;
+end;
+
+IsSubsetSp := function(n, q, G)
+  Assert(0, DimensionOfMatrixGroup(G) = n);
+  Assert(0, DefaultFieldOfMatrixGroup(G) = GF(q));
+  Assert(0, CheckGeneratorsSpecial(G));
+  Assert(0, CheckBilinearForm(G));
+  return true;
+end;
+
+IsSubsetSU := function(n, q, G)
+  Assert(0, DimensionOfMatrixGroup(G) = n);
+  Assert(0, DefaultFieldOfMatrixGroup(G) = GF(q^2));
+  Assert(0, CheckGeneratorsSpecial(G));
+  Assert(0, CheckSesquilinearForm(G));
+  return true;
+end;


### PR DESCRIPTION
Testing `IsSubset(G, elm)` can be slow in GAP if G is a matrix group of
"large" degree. This is because GAP resorts to testing membership using a
stabilizer chain in an isomorphic permutation group, even if G is a
linear/unitary/orthogonal/symplectic group. So we replace that check with one
that actually tests using the invariant forms of the groups in question.

This is work in progress, and <s>waiting for PR #88</s> and needs a few functions such as `SpIsotropicImprimitives` to set invariant forms -- which PR #89 seems to do.


## Checklist for the reviewer
### General
- [ ] All functions have unit tests

### Functions constructing generators of maximal subgroups
- [ ] The code which computes and then stores the sizes is correct. To do this one confers to the tables referenced by the code. Tests for the group size should use `RECOG.TestGroup` from the recog package.
- [ ] The test suite checks whether all constructed generators are sensible. That is it tests the generators'
  - [ ] determinants (and if applicable also the spinor norms are correct), and
  - [ ] compatibility with the correct form,
  - [ ] `DefaultFieldOfMatrixGroup` returns the correct field.

### Functions assembling the list of all maximal subgroups of a certain group
- [ ] The code agrees with the tables in section 8.2 of the book "The Maximal Subgroups of the Low-dimensional Finite Classical Groups".

The reviewer doesn't need to compare our results to magma's results. That's the job of the person implementing the code.
