### PR TITLE
More test tweaks

### DIFF
--- a/tst/standard/ClassicalMaximals.tst
+++ b/tst/standard/ClassicalMaximals.tst
@@ -1,269 +1,510 @@
 gap> START_TEST("ClassicalMaximals.tst");
 
 #
-gap> TestClassicalMaximalsLinear := function(args)
->   Assert(0, Length(ClassicalMaximalsGeneric("L", args[1], args[2])) = args[3]);
-> end;;
-gap> TestClassicalMaximalsLinear([2, 4, 3]);
-gap> TestClassicalMaximalsLinear([2, 5, 3]);
-gap> TestClassicalMaximalsLinear([2, 7, 3]);
-gap> TestClassicalMaximalsLinear([2, 8, 3]);
-gap> TestClassicalMaximalsLinear([2, 9, 3]);
-gap> TestClassicalMaximalsLinear([2, 11, 2]);
-gap> TestClassicalMaximalsLinear([2, 13, 4]);
-gap> TestClassicalMaximalsLinear([2, 16, 4]);
-gap> TestClassicalMaximalsLinear([2, 17, 5]);
-gap> TestClassicalMaximalsLinear([2, 19, 3]);
-gap> TestClassicalMaximalsLinear([3, 2, 3]);
-gap> TestClassicalMaximalsLinear([3, 3, 4]);
-gap> TestClassicalMaximalsLinear([3, 4, 6]);
-gap> TestClassicalMaximalsLinear([3, 5, 5]);
-gap> TestClassicalMaximalsLinear([3, 7, 8]);
-gap> TestClassicalMaximalsLinear([3, 8, 5]);
-gap> TestClassicalMaximalsLinear([3, 9, 7]);
-gap> TestClassicalMaximalsLinear([3, 11, 5]);
-gap> TestClassicalMaximalsLinear([3, 13, 8]);
-gap> TestClassicalMaximalsLinear([3, 16, 8]);
-gap> TestClassicalMaximalsLinear([3, 17, 5]);
-gap> TestClassicalMaximalsLinear([3, 19, 10]);
-gap> TestClassicalMaximalsLinear([4, 2, 5]);
-gap> TestClassicalMaximalsLinear([4, 3, 8]);
-gap> TestClassicalMaximalsLinear([4, 4, 8]);
-gap> TestClassicalMaximalsLinear([4, 5, 13]);
-gap> TestClassicalMaximalsLinear([4, 7, 10]);
-gap> TestClassicalMaximalsLinear([4, 8, 8]);
-gap> TestClassicalMaximalsLinear([4, 9, 18]);
-gap> TestClassicalMaximalsLinear([4, 11, 10]);
-gap> TestClassicalMaximalsLinear([4, 13, 14]);
-gap> TestClassicalMaximalsLinear([4, 16, 9]);
-gap> TestClassicalMaximalsLinear([4, 17, 16]);
-gap> TestClassicalMaximalsLinear([4, 19, 10]);
-gap> TestClassicalMaximalsLinear([5, 2, 5]);
-gap> TestClassicalMaximalsLinear([5, 3, 6]);
-gap> TestClassicalMaximalsLinear([5, 4, 7]);
-gap> TestClassicalMaximalsLinear([5, 5, 7]);
-gap> TestClassicalMaximalsLinear([5, 7, 7]);
-gap> TestClassicalMaximalsLinear([5, 8, 7]);
-gap> TestClassicalMaximalsLinear([5, 9, 9]);
-gap> TestClassicalMaximalsLinear([5, 11, 16]);
-gap> TestClassicalMaximalsLinear([5, 13, 7]);
-gap> TestClassicalMaximalsLinear([5, 16, 12]);
-gap> TestClassicalMaximalsLinear([5, 17, 7]);
-gap> TestClassicalMaximalsLinear([5, 19, 7]);
-gap> TestClassicalMaximalsLinear([6, 2, 9]);
-gap> TestClassicalMaximalsLinear([6, 3, 13]);
-gap> TestClassicalMaximalsLinear([6, 4, 17]);
-gap> TestClassicalMaximalsLinear([6, 5, 14]);
-gap> TestClassicalMaximalsLinear([6, 7, 20]);
-gap> TestClassicalMaximalsLinear([6, 8, 13]);
-gap> TestClassicalMaximalsLinear([6, 9, 18]);
-gap> TestClassicalMaximalsLinear([6, 11, 14]);
-gap> TestClassicalMaximalsLinear([6, 13, 20]);
-gap> TestClassicalMaximalsLinear([6, 16, 18]);
-gap> TestClassicalMaximalsLinear([6, 17, 14]);
-gap> TestClassicalMaximalsLinear([6, 19, 20]);
-gap> TestClassicalMaximalsLinear([7, 2, 7]);
-gap> TestClassicalMaximalsLinear([7, 3, 8]);
-gap> TestClassicalMaximalsLinear([7, 4, 9]);
-gap> TestClassicalMaximalsLinear([7, 5, 9]);
-gap> TestClassicalMaximalsLinear([7, 7, 9]);
-gap> TestClassicalMaximalsLinear([7, 8, 22]);
-gap> TestClassicalMaximalsLinear([7, 9, 11]);
-gap> TestClassicalMaximalsLinear([7, 11, 9]);
-gap> TestClassicalMaximalsLinear([7, 13, 9]);
-gap> TestClassicalMaximalsLinear([7, 16, 10]);
-gap> TestClassicalMaximalsLinear([7, 17, 9]);
-gap> TestClassicalMaximalsLinear([7, 19, 9]);
-gap> TestClassicalMaximalsLinear([8, 2, 10]);
-gap> TestClassicalMaximalsLinear([8, 3, 16]);
-gap> TestClassicalMaximalsLinear([8, 4, 14]);
-gap> TestClassicalMaximalsLinear([8, 5, 25]);
-gap> TestClassicalMaximalsLinear([8, 7, 17]);
-gap> TestClassicalMaximalsLinear([8, 8, 14]);
-gap> TestClassicalMaximalsLinear([8, 9, 31]);
-gap> TestClassicalMaximalsLinear([8, 11, 17]);
-gap> TestClassicalMaximalsLinear([8, 13, 25]);
-gap> TestClassicalMaximalsLinear([8, 16, 15]);
-gap> TestClassicalMaximalsLinear([8, 17, 33]);
-gap> TestClassicalMaximalsLinear([8, 19, 17]);
-gap> TestClassicalMaximalsLinear([9, 2, 11]);
-gap> TestClassicalMaximalsLinear([9, 3, 12]);
-gap> TestClassicalMaximalsLinear([9, 4, 17]);
-gap> TestClassicalMaximalsLinear([9, 5, 13]);
-gap> TestClassicalMaximalsLinear([9, 7, 20]);
-gap> TestClassicalMaximalsLinear([9, 8, 13]);
-gap> TestClassicalMaximalsLinear([9, 9, 15]);
-gap> TestClassicalMaximalsLinear([9, 11, 13]);
-gap> TestClassicalMaximalsLinear([9, 13, 20]);
-gap> TestClassicalMaximalsLinear([9, 16, 18]);
-gap> TestClassicalMaximalsLinear([9, 17, 13]);
-gap> TestClassicalMaximalsLinear([9, 19, 32]);
-gap> TestClassicalMaximalsLinear([10, 2, 13]);
-gap> TestClassicalMaximalsLinear([10, 3, 17]);
-gap> TestClassicalMaximalsLinear([10, 4, 17]);
-gap> TestClassicalMaximalsLinear([10, 5, 18]);
-gap> TestClassicalMaximalsLinear([10, 7, 18]);
-gap> TestClassicalMaximalsLinear([10, 8, 17]);
-gap> TestClassicalMaximalsLinear([10, 9, 22]);
-gap> TestClassicalMaximalsLinear([10, 11, 30]);
-gap> TestClassicalMaximalsLinear([10, 13, 18]);
-gap> TestClassicalMaximalsLinear([10, 16, 26]);
-gap> TestClassicalMaximalsLinear([10, 17, 18]);
-gap> TestClassicalMaximalsLinear([10, 19, 18]);
-gap> TestClassicalMaximalsLinear([11, 2, 11]);
-gap> TestClassicalMaximalsLinear([11, 3, 12]);
-gap> TestClassicalMaximalsLinear([11, 4, 13]);
-gap> TestClassicalMaximalsLinear([11, 5, 13]);
-gap> TestClassicalMaximalsLinear([11, 7, 13]);
-gap> TestClassicalMaximalsLinear([11, 8, 13]);
-gap> TestClassicalMaximalsLinear([11, 9, 15]);
-gap> TestClassicalMaximalsLinear([11, 11, 13]);
-gap> TestClassicalMaximalsLinear([11, 13, 13]);
-gap> TestClassicalMaximalsLinear([11, 16, 14]);
-gap> TestClassicalMaximalsLinear([11, 17, 13]);
-gap> TestClassicalMaximalsLinear([11, 19, 13]);
-gap> TestClassicalMaximalsLinear([12, 2, 18]);
-gap> TestClassicalMaximalsLinear([12, 3, 24]);
-gap> TestClassicalMaximalsLinear([12, 4, 26]);
-gap> TestClassicalMaximalsLinear([12, 5, 27]);
-gap> TestClassicalMaximalsLinear([12, 7, 33]);
-gap> TestClassicalMaximalsLinear([12, 8, 22]);
-gap> TestClassicalMaximalsLinear([12, 9, 33]);
-gap> TestClassicalMaximalsLinear([12, 11, 25]);
-gap> TestClassicalMaximalsLinear([12, 13, 39]);
-gap> TestClassicalMaximalsLinear([12, 16, 27]);
-gap> TestClassicalMaximalsLinear([12, 17, 27]);
-gap> TestClassicalMaximalsLinear([12, 19, 33]);
+gap> Length(ClassicalMaximalsGeneric("L", 2, 4));
+3
+gap> Length(ClassicalMaximalsGeneric("L", 2, 5));
+3
+gap> Length(ClassicalMaximalsGeneric("L", 2, 7));
+3
+gap> Length(ClassicalMaximalsGeneric("L", 2, 8));
+3
+gap> Length(ClassicalMaximalsGeneric("L", 2, 9));
+3
+gap> Length(ClassicalMaximalsGeneric("L", 2, 11));
+2
+gap> Length(ClassicalMaximalsGeneric("L", 2, 13));
+4
+gap> Length(ClassicalMaximalsGeneric("L", 2, 16));
+4
+gap> Length(ClassicalMaximalsGeneric("L", 2, 17));
+5
+gap> Length(ClassicalMaximalsGeneric("L", 2, 19));
+3
+gap> Length(ClassicalMaximalsGeneric("L", 3, 2));
+3
+gap> Length(ClassicalMaximalsGeneric("L", 3, 3));
+4
+gap> Length(ClassicalMaximalsGeneric("L", 3, 4));
+6
+gap> Length(ClassicalMaximalsGeneric("L", 3, 5));
+5
+gap> Length(ClassicalMaximalsGeneric("L", 3, 7));
+8
+gap> Length(ClassicalMaximalsGeneric("L", 3, 8));
+5
+gap> Length(ClassicalMaximalsGeneric("L", 3, 9));
+7
+gap> Length(ClassicalMaximalsGeneric("L", 3, 11));
+5
+gap> Length(ClassicalMaximalsGeneric("L", 3, 13));
+8
+gap> Length(ClassicalMaximalsGeneric("L", 3, 16));
+8
+gap> Length(ClassicalMaximalsGeneric("L", 3, 17));
+5
+gap> Length(ClassicalMaximalsGeneric("L", 3, 19));
+10
+gap> Length(ClassicalMaximalsGeneric("L", 4, 2));
+5
+gap> Length(ClassicalMaximalsGeneric("L", 4, 3));
+8
+gap> Length(ClassicalMaximalsGeneric("L", 4, 4));
+8
+gap> Length(ClassicalMaximalsGeneric("L", 4, 5));
+13
+gap> Length(ClassicalMaximalsGeneric("L", 4, 7));
+10
+gap> Length(ClassicalMaximalsGeneric("L", 4, 8));
+8
+gap> Length(ClassicalMaximalsGeneric("L", 4, 9));
+18
+gap> Length(ClassicalMaximalsGeneric("L", 4, 11));
+10
+gap> Length(ClassicalMaximalsGeneric("L", 4, 13));
+14
+gap> Length(ClassicalMaximalsGeneric("L", 4, 16));
+9
+gap> Length(ClassicalMaximalsGeneric("L", 4, 17));
+16
+gap> Length(ClassicalMaximalsGeneric("L", 4, 19));
+10
+gap> Length(ClassicalMaximalsGeneric("L", 5, 2));
+5
+gap> Length(ClassicalMaximalsGeneric("L", 5, 3));
+6
+gap> Length(ClassicalMaximalsGeneric("L", 5, 4));
+7
+gap> Length(ClassicalMaximalsGeneric("L", 5, 5));
+7
+gap> Length(ClassicalMaximalsGeneric("L", 5, 7));
+7
+gap> Length(ClassicalMaximalsGeneric("L", 5, 8));
+7
+gap> Length(ClassicalMaximalsGeneric("L", 5, 9));
+9
+gap> Length(ClassicalMaximalsGeneric("L", 5, 11));
+16
+gap> Length(ClassicalMaximalsGeneric("L", 5, 13));
+7
+gap> Length(ClassicalMaximalsGeneric("L", 5, 16));
+12
+gap> Length(ClassicalMaximalsGeneric("L", 5, 17));
+7
+gap> Length(ClassicalMaximalsGeneric("L", 5, 19));
+7
+gap> Length(ClassicalMaximalsGeneric("L", 6, 2));
+9
+gap> Length(ClassicalMaximalsGeneric("L", 6, 3));
+13
+gap> Length(ClassicalMaximalsGeneric("L", 6, 4));
+17
+gap> Length(ClassicalMaximalsGeneric("L", 6, 5));
+14
+gap> Length(ClassicalMaximalsGeneric("L", 6, 7));
+20
+gap> Length(ClassicalMaximalsGeneric("L", 6, 8));
+13
+gap> Length(ClassicalMaximalsGeneric("L", 6, 9));
+18
+gap> Length(ClassicalMaximalsGeneric("L", 6, 11));
+14
+gap> Length(ClassicalMaximalsGeneric("L", 6, 13));
+20
+gap> Length(ClassicalMaximalsGeneric("L", 6, 16));
+18
+gap> Length(ClassicalMaximalsGeneric("L", 6, 17));
+14
+gap> Length(ClassicalMaximalsGeneric("L", 6, 19));
+20
+gap> Length(ClassicalMaximalsGeneric("L", 7, 2));
+7
+gap> Length(ClassicalMaximalsGeneric("L", 7, 3));
+8
+gap> Length(ClassicalMaximalsGeneric("L", 7, 4));
+9
+gap> Length(ClassicalMaximalsGeneric("L", 7, 5));
+9
+gap> Length(ClassicalMaximalsGeneric("L", 7, 7));
+9
+gap> Length(ClassicalMaximalsGeneric("L", 7, 8));
+22
+gap> Length(ClassicalMaximalsGeneric("L", 7, 9));
+11
+gap> Length(ClassicalMaximalsGeneric("L", 7, 11));
+9
+gap> Length(ClassicalMaximalsGeneric("L", 7, 13));
+9
+gap> Length(ClassicalMaximalsGeneric("L", 7, 16));
+10
+gap> Length(ClassicalMaximalsGeneric("L", 7, 17));
+9
+gap> Length(ClassicalMaximalsGeneric("L", 7, 19));
+9
+gap> Length(ClassicalMaximalsGeneric("L", 8, 2));
+10
+gap> Length(ClassicalMaximalsGeneric("L", 8, 3));
+16
+gap> Length(ClassicalMaximalsGeneric("L", 8, 4));
+14
+gap> Length(ClassicalMaximalsGeneric("L", 8, 5));
+25
+gap> Length(ClassicalMaximalsGeneric("L", 8, 7));
+17
+gap> Length(ClassicalMaximalsGeneric("L", 8, 8));
+14
+gap> Length(ClassicalMaximalsGeneric("L", 8, 9));
+31
+gap> Length(ClassicalMaximalsGeneric("L", 8, 11));
+17
+gap> Length(ClassicalMaximalsGeneric("L", 8, 13));
+25
+gap> Length(ClassicalMaximalsGeneric("L", 8, 16));
+15
+gap> Length(ClassicalMaximalsGeneric("L", 8, 17));
+33
+gap> Length(ClassicalMaximalsGeneric("L", 8, 19));
+17
+gap> Length(ClassicalMaximalsGeneric("L", 9, 2));
+11
+gap> Length(ClassicalMaximalsGeneric("L", 9, 3));
+12
+gap> Length(ClassicalMaximalsGeneric("L", 9, 4));
+17
+gap> Length(ClassicalMaximalsGeneric("L", 9, 5));
+13
+gap> Length(ClassicalMaximalsGeneric("L", 9, 7));
+20
+gap> Length(ClassicalMaximalsGeneric("L", 9, 8));
+13
+gap> Length(ClassicalMaximalsGeneric("L", 9, 9));
+15
+gap> Length(ClassicalMaximalsGeneric("L", 9, 11));
+13
+gap> Length(ClassicalMaximalsGeneric("L", 9, 13));
+20
+gap> Length(ClassicalMaximalsGeneric("L", 9, 16));
+18
+gap> Length(ClassicalMaximalsGeneric("L", 9, 17));
+13
+gap> Length(ClassicalMaximalsGeneric("L", 9, 19));
+32
+gap> Length(ClassicalMaximalsGeneric("L", 10, 2));
+13
+gap> Length(ClassicalMaximalsGeneric("L", 10, 3));
+17
+gap> Length(ClassicalMaximalsGeneric("L", 10, 4));
+17
+gap> Length(ClassicalMaximalsGeneric("L", 10, 5));
+18
+gap> Length(ClassicalMaximalsGeneric("L", 10, 7));
+18
+gap> Length(ClassicalMaximalsGeneric("L", 10, 8));
+17
+gap> Length(ClassicalMaximalsGeneric("L", 10, 9));
+22
+gap> Length(ClassicalMaximalsGeneric("L", 10, 11));
+30
+gap> Length(ClassicalMaximalsGeneric("L", 10, 13));
+18
+gap> Length(ClassicalMaximalsGeneric("L", 10, 16));
+26
+gap> Length(ClassicalMaximalsGeneric("L", 10, 17));
+18
+gap> Length(ClassicalMaximalsGeneric("L", 10, 19));
+18
+gap> Length(ClassicalMaximalsGeneric("L", 11, 2));
+11
+gap> Length(ClassicalMaximalsGeneric("L", 11, 3));
+12
+gap> Length(ClassicalMaximalsGeneric("L", 11, 4));
+13
+gap> Length(ClassicalMaximalsGeneric("L", 11, 5));
+13
+gap> Length(ClassicalMaximalsGeneric("L", 11, 7));
+13
+gap> Length(ClassicalMaximalsGeneric("L", 11, 8));
+13
+gap> Length(ClassicalMaximalsGeneric("L", 11, 9));
+15
+gap> Length(ClassicalMaximalsGeneric("L", 11, 11));
+13
+gap> Length(ClassicalMaximalsGeneric("L", 11, 13));
+13
+gap> Length(ClassicalMaximalsGeneric("L", 11, 16));
+14
+gap> Length(ClassicalMaximalsGeneric("L", 11, 17));
+13
+gap> Length(ClassicalMaximalsGeneric("L", 11, 19));
+13
+gap> Length(ClassicalMaximalsGeneric("L", 12, 2));
+18
+gap> Length(ClassicalMaximalsGeneric("L", 12, 3));
+24
+gap> Length(ClassicalMaximalsGeneric("L", 12, 4));
+26
+gap> Length(ClassicalMaximalsGeneric("L", 12, 5));
+27
+gap> Length(ClassicalMaximalsGeneric("L", 12, 7));
+33
+gap> Length(ClassicalMaximalsGeneric("L", 12, 8));
+22
+gap> Length(ClassicalMaximalsGeneric("L", 12, 9));
+33
+gap> Length(ClassicalMaximalsGeneric("L", 12, 11));
+25
+gap> Length(ClassicalMaximalsGeneric("L", 12, 13));
+39
+gap> Length(ClassicalMaximalsGeneric("L", 12, 16));
+27
+gap> Length(ClassicalMaximalsGeneric("L", 12, 17));
+27
+gap> Length(ClassicalMaximalsGeneric("L", 12, 19));
+33
 
 #
-gap> TestClassicalMaximalsUnitary := function(args)
->   Assert(0, Length(ClassicalMaximalsGeneric("U", args[1], args[2])) = args[3]);
-> end;;
-gap> TestClassicalMaximalsUnitary([3, 3, 3]);
-gap> TestClassicalMaximalsUnitary([3, 4, 4]);
-gap> TestClassicalMaximalsUnitary([3, 5, 2]);
-gap> TestClassicalMaximalsUnitary([3, 7, 5]);
-gap> TestClassicalMaximalsUnitary([3, 8, 7]);
-gap> TestClassicalMaximalsUnitary([3, 9, 5]);
-gap> TestClassicalMaximalsUnitary([3, 11, 8]);
-gap> TestClassicalMaximalsUnitary([3, 13, 5]);
-gap> TestClassicalMaximalsUnitary([3, 16, 4]);
-gap> TestClassicalMaximalsUnitary([3, 17, 10]);
-gap> TestClassicalMaximalsUnitary([3, 19, 5]);
-gap> TestClassicalMaximalsUnitary([4, 2, 5]);
-gap> TestClassicalMaximalsUnitary([4, 3, 10]);
-gap> TestClassicalMaximalsUnitary([4, 4, 7]);
-gap> TestClassicalMaximalsUnitary([4, 5, 10]);
-gap> TestClassicalMaximalsUnitary([4, 7, 16]);
-gap> TestClassicalMaximalsUnitary([4, 8, 8]);
-gap> TestClassicalMaximalsUnitary([4, 9, 10]);
-gap> TestClassicalMaximalsUnitary([4, 11, 14]);
-gap> TestClassicalMaximalsUnitary([4, 13, 10]);
-gap> TestClassicalMaximalsUnitary([4, 16, 7]);
-gap> TestClassicalMaximalsUnitary([4, 17, 10]);
-gap> TestClassicalMaximalsUnitary([4, 19, 14]);
-gap> TestClassicalMaximalsUnitary([5, 2, 5]);
-gap> TestClassicalMaximalsUnitary([5, 3, 7]);
-gap> TestClassicalMaximalsUnitary([5, 4, 11]);
-gap> TestClassicalMaximalsUnitary([5, 5, 7]);
-gap> TestClassicalMaximalsUnitary([5, 7, 7]);
-gap> TestClassicalMaximalsUnitary([5, 8, 7]);
-gap> TestClassicalMaximalsUnitary([5, 9, 16]);
-gap> TestClassicalMaximalsUnitary([5, 11, 7]);
-gap> TestClassicalMaximalsUnitary([5, 13, 7]);
-gap> TestClassicalMaximalsUnitary([5, 16, 6]);
-gap> TestClassicalMaximalsUnitary([5, 17, 7]);
-gap> TestClassicalMaximalsUnitary([5, 19, 16]);
-gap> TestClassicalMaximalsUnitary([6, 2, 10]);
-gap> TestClassicalMaximalsUnitary([6, 3, 14]);
-gap> TestClassicalMaximalsUnitary([6, 4, 12]);
-gap> TestClassicalMaximalsUnitary([6, 5, 20]);
-gap> TestClassicalMaximalsUnitary([6, 7, 14]);
-gap> TestClassicalMaximalsUnitary([6, 8, 17]);
-gap> TestClassicalMaximalsUnitary([7, 2, 8]);
-gap> TestClassicalMaximalsUnitary([7, 3, 9]);
-gap> TestClassicalMaximalsUnitary([7, 8, 9]);
-gap> TestClassicalMaximalsUnitary([7, 13, 22]);
-gap> TestClassicalMaximalsUnitary([8, 2, 11]);
-gap> TestClassicalMaximalsUnitary([8, 3, 25]);
-gap> TestClassicalMaximalsUnitary([8, 4, 13]);
-gap> TestClassicalMaximalsUnitary([8, 5, 17]);
-gap> TestClassicalMaximalsUnitary([8, 8, 14]);
-gap> TestClassicalMaximalsUnitary([9, 2, 14]);
-gap> TestClassicalMaximalsUnitary([9, 3, 13]);
-gap> TestClassicalMaximalsUnitary([9, 4, 12]);
-gap> TestClassicalMaximalsUnitary([9, 5, 20]);
-gap> TestClassicalMaximalsUnitary([9, 8, 17]);
-gap> TestClassicalMaximalsUnitary([10, 2, 14]);
-gap> TestClassicalMaximalsUnitary([10, 3, 18]);
-gap> TestClassicalMaximalsUnitary([11, 2, 12]);
-gap> TestClassicalMaximalsUnitary([11, 3, 13]);
-gap> TestClassicalMaximalsUnitary([12, 2, 21]);
-gap> TestClassicalMaximalsUnitary([12, 3, 27]);
+gap> Length(ClassicalMaximalsGeneric("U", 3, 3));
+3
+gap> Length(ClassicalMaximalsGeneric("U", 3, 4));
+4
+gap> Length(ClassicalMaximalsGeneric("U", 3, 5));
+2
+gap> Length(ClassicalMaximalsGeneric("U", 3, 7));
+5
+gap> Length(ClassicalMaximalsGeneric("U", 3, 8));
+7
+gap> Length(ClassicalMaximalsGeneric("U", 3, 9));
+5
+gap> Length(ClassicalMaximalsGeneric("U", 3, 11));
+8
+gap> Length(ClassicalMaximalsGeneric("U", 3, 13));
+5
+gap> Length(ClassicalMaximalsGeneric("U", 3, 16));
+4
+gap> Length(ClassicalMaximalsGeneric("U", 3, 17));
+10
+gap> Length(ClassicalMaximalsGeneric("U", 3, 19));
+5
+gap> Length(ClassicalMaximalsGeneric("U", 4, 2));
+5
+gap> Length(ClassicalMaximalsGeneric("U", 4, 3));
+10
+gap> Length(ClassicalMaximalsGeneric("U", 4, 4));
+7
+gap> Length(ClassicalMaximalsGeneric("U", 4, 5));
+10
+gap> Length(ClassicalMaximalsGeneric("U", 4, 7));
+16
+gap> Length(ClassicalMaximalsGeneric("U", 4, 8));
+8
+gap> Length(ClassicalMaximalsGeneric("U", 4, 9));
+10
+gap> Length(ClassicalMaximalsGeneric("U", 4, 11));
+14
+gap> Length(ClassicalMaximalsGeneric("U", 4, 13));
+10
+gap> Length(ClassicalMaximalsGeneric("U", 4, 16));
+7
+gap> Length(ClassicalMaximalsGeneric("U", 4, 17));
+10
+gap> Length(ClassicalMaximalsGeneric("U", 4, 19));
+14
+gap> Length(ClassicalMaximalsGeneric("U", 5, 2));
+5
+gap> Length(ClassicalMaximalsGeneric("U", 5, 3));
+7
+gap> Length(ClassicalMaximalsGeneric("U", 5, 4));
+11
+gap> Length(ClassicalMaximalsGeneric("U", 5, 5));
+7
+gap> Length(ClassicalMaximalsGeneric("U", 5, 7));
+7
+gap> Length(ClassicalMaximalsGeneric("U", 5, 8));
+7
+gap> Length(ClassicalMaximalsGeneric("U", 5, 9));
+16
+gap> Length(ClassicalMaximalsGeneric("U", 5, 11));
+7
+gap> Length(ClassicalMaximalsGeneric("U", 5, 13));
+7
+gap> Length(ClassicalMaximalsGeneric("U", 5, 16));
+6
+gap> Length(ClassicalMaximalsGeneric("U", 5, 17));
+7
+gap> Length(ClassicalMaximalsGeneric("U", 5, 19));
+16
+gap> Length(ClassicalMaximalsGeneric("U", 6, 2));
+10
+gap> Length(ClassicalMaximalsGeneric("U", 6, 3));
+14
+gap> Length(ClassicalMaximalsGeneric("U", 6, 4));
+12
+gap> Length(ClassicalMaximalsGeneric("U", 6, 5));
+20
+gap> Length(ClassicalMaximalsGeneric("U", 6, 7));
+14
+gap> Length(ClassicalMaximalsGeneric("U", 6, 8));
+17
+gap> Length(ClassicalMaximalsGeneric("U", 7, 2));
+8
+gap> Length(ClassicalMaximalsGeneric("U", 7, 3));
+9
+gap> Length(ClassicalMaximalsGeneric("U", 7, 8));
+9
+gap> Length(ClassicalMaximalsGeneric("U", 7, 13));
+22
+gap> Length(ClassicalMaximalsGeneric("U", 8, 2));
+11
+gap> Length(ClassicalMaximalsGeneric("U", 8, 3));
+25
+gap> Length(ClassicalMaximalsGeneric("U", 8, 4));
+13
+gap> Length(ClassicalMaximalsGeneric("U", 8, 5));
+17
+gap> Length(ClassicalMaximalsGeneric("U", 8, 8));
+14
+gap> Length(ClassicalMaximalsGeneric("U", 9, 2));
+14
+gap> Length(ClassicalMaximalsGeneric("U", 9, 3));
+13
+gap> Length(ClassicalMaximalsGeneric("U", 9, 4));
+12
+gap> Length(ClassicalMaximalsGeneric("U", 9, 5));
+20
+gap> Length(ClassicalMaximalsGeneric("U", 9, 8));
+17
+gap> Length(ClassicalMaximalsGeneric("U", 10, 2));
+14
+gap> Length(ClassicalMaximalsGeneric("U", 10, 3));
+18
+gap> Length(ClassicalMaximalsGeneric("U", 11, 2));
+12
+gap> Length(ClassicalMaximalsGeneric("U", 11, 3));
+13
+gap> Length(ClassicalMaximalsGeneric("U", 12, 2));
+21
+gap> Length(ClassicalMaximalsGeneric("U", 12, 3));
+27
 
 #
-gap> TestClassicalMaximalsSymplectic := function(args)
->   Assert(0, Length(ClassicalMaximalsGeneric("S", args[1], args[2])) = args[3]);
-> end;;
-gap> TestClassicalMaximalsSymplectic([4, 3, 5]);
-gap> TestClassicalMaximalsSymplectic([4, 4, 7]);
-gap> TestClassicalMaximalsSymplectic([4, 5, 7]);
-gap> TestClassicalMaximalsSymplectic([4, 7, 8]);
-gap> TestClassicalMaximalsSymplectic([4, 8, 7]);
-gap> TestClassicalMaximalsSymplectic([4, 9, 8]);
-gap> TestClassicalMaximalsSymplectic([4, 11, 7]);
-gap> TestClassicalMaximalsSymplectic([4, 13, 7]);
-gap> TestClassicalMaximalsSymplectic([4, 16, 7]);
-gap> TestClassicalMaximalsSymplectic([4, 17, 8]);
-gap> TestClassicalMaximalsSymplectic([4, 19, 7]);
-gap> TestClassicalMaximalsSymplectic([6, 2, 7]);
-gap> TestClassicalMaximalsSymplectic([6, 3, 8]);
-gap> TestClassicalMaximalsSymplectic([6, 4, 9]);
-gap> TestClassicalMaximalsSymplectic([6, 5, 9]);
-gap> TestClassicalMaximalsSymplectic([6, 7, 9]);
-gap> TestClassicalMaximalsSymplectic([6, 8, 9]);
-gap> TestClassicalMaximalsSymplectic([6, 9, 11]);
-gap> TestClassicalMaximalsSymplectic([6, 11, 9]);
-gap> TestClassicalMaximalsSymplectic([6, 13, 9]);
-gap> TestClassicalMaximalsSymplectic([6, 16, 9]);
-gap> TestClassicalMaximalsSymplectic([6, 17, 9]);
-gap> TestClassicalMaximalsSymplectic([6, 19, 9]);
-gap> TestClassicalMaximalsSymplectic([8, 2, 9]);
-gap> TestClassicalMaximalsSymplectic([8, 3, 12]);
-gap> TestClassicalMaximalsSymplectic([8, 4, 11]);
-gap> TestClassicalMaximalsSymplectic([8, 5, 13]);
-gap> TestClassicalMaximalsSymplectic([8, 7, 14]);
-gap> TestClassicalMaximalsSymplectic([8, 8, 11]);
-gap> TestClassicalMaximalsSymplectic([8, 9, 14]);
-gap> TestClassicalMaximalsSymplectic([8, 11, 13]);
-gap> TestClassicalMaximalsSymplectic([8, 13, 13]);
-gap> TestClassicalMaximalsSymplectic([8, 16, 11]);
-gap> TestClassicalMaximalsSymplectic([8, 17, 14]);
-gap> TestClassicalMaximalsSymplectic([8, 19, 13]);
-gap> TestClassicalMaximalsSymplectic([10, 2, 10]);
-gap> TestClassicalMaximalsSymplectic([10, 3, 12]);
-gap> TestClassicalMaximalsSymplectic([10, 4, 12]);
-gap> TestClassicalMaximalsSymplectic([10, 5, 12]);
-gap> TestClassicalMaximalsSymplectic([10, 7, 12]);
-gap> TestClassicalMaximalsSymplectic([10, 8, 12]);
-gap> TestClassicalMaximalsSymplectic([10, 9, 14]);
-gap> TestClassicalMaximalsSymplectic([10, 11, 12]);
-gap> TestClassicalMaximalsSymplectic([10, 13, 12]);
-gap> TestClassicalMaximalsSymplectic([10, 16, 12]);
-gap> TestClassicalMaximalsSymplectic([10, 17, 12]);
-gap> TestClassicalMaximalsSymplectic([10, 19, 12]);
-gap> TestClassicalMaximalsSymplectic([12, 2, 14]);
-gap> TestClassicalMaximalsSymplectic([12, 3, 17]);
-gap> TestClassicalMaximalsSymplectic([12, 4, 16]);
-gap> TestClassicalMaximalsSymplectic([12, 5, 18]);
-gap> TestClassicalMaximalsSymplectic([12, 7, 18]);
-gap> TestClassicalMaximalsSymplectic([12, 8, 16]);
-gap> TestClassicalMaximalsSymplectic([12, 9, 20]);
-gap> TestClassicalMaximalsSymplectic([12, 11, 18]);
-gap> TestClassicalMaximalsSymplectic([12, 13, 18]);
-gap> TestClassicalMaximalsSymplectic([12, 16, 16]);
-gap> TestClassicalMaximalsSymplectic([12, 17, 18]);
-gap> TestClassicalMaximalsSymplectic([12, 19, 18]);
+gap> Length(ClassicalMaximalsGeneric("S", 4, 3));
+5
+gap> Length(ClassicalMaximalsGeneric("S", 4, 4));
+7
+gap> Length(ClassicalMaximalsGeneric("S", 4, 5));
+7
+gap> Length(ClassicalMaximalsGeneric("S", 4, 7));
+8
+gap> Length(ClassicalMaximalsGeneric("S", 4, 8));
+7
+gap> Length(ClassicalMaximalsGeneric("S", 4, 9));
+8
+gap> Length(ClassicalMaximalsGeneric("S", 4, 11));
+7
+gap> Length(ClassicalMaximalsGeneric("S", 4, 13));
+7
+gap> Length(ClassicalMaximalsGeneric("S", 4, 16));
+7
+gap> Length(ClassicalMaximalsGeneric("S", 4, 17));
+8
+gap> Length(ClassicalMaximalsGeneric("S", 4, 19));
+7
+gap> Length(ClassicalMaximalsGeneric("S", 6, 2));
+7
+gap> Length(ClassicalMaximalsGeneric("S", 6, 3));
+8
+gap> Length(ClassicalMaximalsGeneric("S", 6, 4));
+9
+gap> Length(ClassicalMaximalsGeneric("S", 6, 5));
+9
+gap> Length(ClassicalMaximalsGeneric("S", 6, 7));
+9
+gap> Length(ClassicalMaximalsGeneric("S", 6, 8));
+9
+gap> Length(ClassicalMaximalsGeneric("S", 6, 9));
+11
+gap> Length(ClassicalMaximalsGeneric("S", 6, 11));
+9
+gap> Length(ClassicalMaximalsGeneric("S", 6, 13));
+9
+gap> Length(ClassicalMaximalsGeneric("S", 6, 16));
+9
+gap> Length(ClassicalMaximalsGeneric("S", 6, 17));
+9
+gap> Length(ClassicalMaximalsGeneric("S", 6, 19));
+9
+gap> Length(ClassicalMaximalsGeneric("S", 8, 2));
+9
+gap> Length(ClassicalMaximalsGeneric("S", 8, 3));
+12
+gap> Length(ClassicalMaximalsGeneric("S", 8, 4));
+11
+gap> Length(ClassicalMaximalsGeneric("S", 8, 5));
+13
+gap> Length(ClassicalMaximalsGeneric("S", 8, 7));
+14
+gap> Length(ClassicalMaximalsGeneric("S", 8, 8));
+11
+gap> Length(ClassicalMaximalsGeneric("S", 8, 9));
+14
+gap> Length(ClassicalMaximalsGeneric("S", 8, 11));
+13
+gap> Length(ClassicalMaximalsGeneric("S", 8, 13));
+13
+gap> Length(ClassicalMaximalsGeneric("S", 8, 16));
+11
+gap> Length(ClassicalMaximalsGeneric("S", 8, 17));
+14
+gap> Length(ClassicalMaximalsGeneric("S", 8, 19));
+13
+gap> Length(ClassicalMaximalsGeneric("S", 10, 2));
+10
+gap> Length(ClassicalMaximalsGeneric("S", 10, 3));
+12
+gap> Length(ClassicalMaximalsGeneric("S", 10, 4));
+12
+gap> Length(ClassicalMaximalsGeneric("S", 10, 5));
+12
+gap> Length(ClassicalMaximalsGeneric("S", 10, 7));
+12
+gap> Length(ClassicalMaximalsGeneric("S", 10, 8));
+12
+gap> Length(ClassicalMaximalsGeneric("S", 10, 9));
+14
+gap> Length(ClassicalMaximalsGeneric("S", 10, 11));
+12
+gap> Length(ClassicalMaximalsGeneric("S", 10, 13));
+12
+gap> Length(ClassicalMaximalsGeneric("S", 10, 16));
+12
+gap> Length(ClassicalMaximalsGeneric("S", 10, 17));
+12
+gap> Length(ClassicalMaximalsGeneric("S", 10, 19));
+12
+gap> Length(ClassicalMaximalsGeneric("S", 12, 2));
+14
+gap> Length(ClassicalMaximalsGeneric("S", 12, 3));
+17
+gap> Length(ClassicalMaximalsGeneric("S", 12, 4));
+16
+gap> Length(ClassicalMaximalsGeneric("S", 12, 5));
+18
+gap> Length(ClassicalMaximalsGeneric("S", 12, 7));
+18
+gap> Length(ClassicalMaximalsGeneric("S", 12, 8));
+16
+gap> Length(ClassicalMaximalsGeneric("S", 12, 9));
+20
+gap> Length(ClassicalMaximalsGeneric("S", 12, 11));
+18
+gap> Length(ClassicalMaximalsGeneric("S", 12, 13));
+18
+gap> Length(ClassicalMaximalsGeneric("S", 12, 16));
+16
+gap> Length(ClassicalMaximalsGeneric("S", 12, 17));
+18
+gap> Length(ClassicalMaximalsGeneric("S", 12, 19));
+18
 
 #
 gap> STOP_TEST("ClassicalMaximals.tst", 0);

--- a/tst/standard/ClassicalNormalizerMatrixGroups.tst
+++ b/tst/standard/ClassicalNormalizerMatrixGroups.tst
@@ -1,70 +1,60 @@
 gap> START_TEST("ClassicalNormalizerMatrixGroups.tst");
 
 #
-gap> TestSymplecticNormalizerInSL := function(args)
->   local n, q, G;
->   n := args[1];
->   q := args[2];
+gap> TestSymplecticNormalizerInSL := function(n, q)
+>   local G;
 >   G := SymplecticNormalizerInSL(n, q);
 >   Assert(0, HasSize(G));
 >   Assert(0, IsSubsetSL(n, q, G));
 >   RECOG.TestGroup(G, false, Size(G));
 > end;;
-gap> TestSymplecticNormalizerInSL([4, 3]);
-gap> TestSymplecticNormalizerInSL([4, 5]);
-gap> TestSymplecticNormalizerInSL([6, 4]);
+gap> TestSymplecticNormalizerInSL(4, 3);
+gap> TestSymplecticNormalizerInSL(4, 5);
+gap> TestSymplecticNormalizerInSL(6, 4);
 
 #
-gap> TestUnitaryNormalizerInSL := function(args)
->   local n, q, G;
->   n := args[1];
->   q := args[2];
+gap> TestUnitaryNormalizerInSL := function(n, q)
+>   local G;
 >   G := UnitaryNormalizerInSL(n, q);
 >   Assert(0, HasSize(G));
 >   Assert(0, IsSubsetSL(n, q, G));
 >   RECOG.TestGroup(G, false, Size(G));
 > end;;
-gap> TestUnitaryNormalizerInSL([4, 9]);
-gap> TestUnitaryNormalizerInSL([3, 9]);
-gap> TestUnitaryNormalizerInSL([4, 4]);
+gap> TestUnitaryNormalizerInSL(4, 9);
+gap> TestUnitaryNormalizerInSL(3, 9);
+gap> TestUnitaryNormalizerInSL(4, 4);
 
 #
-gap> TestOrthogonalNormalizerInSL := function(args)
->   local epsilon, n, q, G;
->   epsilon := args[1];
->   n := args[2];
->   q := args[3];
+gap> TestOrthogonalNormalizerInSL := function(epsilon, n, q)
+>   local G;
 >   G := OrthogonalNormalizerInSL(epsilon, n, q);
 >   Assert(0, HasSize(G));
 >   Assert(0, IsSubsetSL(n, q, G));
 >   RECOG.TestGroup(G, false, Size(G));
 > end;;
-gap> TestOrthogonalNormalizerInSL([0, 3, 5]);
-gap> TestOrthogonalNormalizerInSL([-1, 6, 5]);
-gap> TestOrthogonalNormalizerInSL([1, 6, 5]);
-gap> TestOrthogonalNormalizerInSL([-1, 4, 3]);
-gap> TestOrthogonalNormalizerInSL([1, 4, 3]);
-gap> TestOrthogonalNormalizerInSL([-1, 4, 5]);
-gap> TestOrthogonalNormalizerInSL([1, 4, 5]);
-gap> TestOrthogonalNormalizerInSL([-1, 6, 3]);
+gap> TestOrthogonalNormalizerInSL(0, 3, 5);
+gap> TestOrthogonalNormalizerInSL(-1, 6, 5);
+gap> TestOrthogonalNormalizerInSL(1, 6, 5);
+gap> TestOrthogonalNormalizerInSL(-1, 4, 3);
+gap> TestOrthogonalNormalizerInSL(1, 4, 3);
+gap> TestOrthogonalNormalizerInSL(-1, 4, 5);
+gap> TestOrthogonalNormalizerInSL(1, 4, 5);
+gap> TestOrthogonalNormalizerInSL(-1, 6, 3);
 
 #
-gap> TestOrthogonalInSp := function(args)
->   local epsilon, n, q, G;
->   epsilon := args[1];
->   n := args[2];
->   q := args[3];
+gap> TestOrthogonalInSp := function(epsilon, n, q)
+>   local G;
 >   G := OrthogonalInSp(epsilon, n, q);
 >   Assert(0, HasSize(G));
 >   Assert(0, IsSubsetSp(n, q, G));
 >   RECOG.TestGroup(G, false, Size(G));
 > end;;
 #@if IsBound(CLASSICAL_MAXIMALS_RUN_BROKEN_TESTS)
-gap> TestOrthogonalInSp([1, 4, 8]);
-gap> TestOrthogonalInSp([-1, 6, 2]);
+gap> TestOrthogonalInSp(1, 4, 8);
+gap> TestOrthogonalInSp(-1, 6, 2);
 #@fi
-gap> TestOrthogonalInSp([-1, 4, 4]);
-gap> TestOrthogonalInSp([1, 6, 2]);
+gap> TestOrthogonalInSp(-1, 4, 4);
+gap> TestOrthogonalInSp(1, 6, 2);
 
 #
 gap> STOP_TEST("ClassicalNormalizerMatrixGroups.tst", 0);

--- a/tst/standard/ExtraspecialNormalizerMatrixGroups.tst
+++ b/tst/standard/ExtraspecialNormalizerMatrixGroups.tst
@@ -1,90 +1,75 @@
 gap> START_TEST("ExtraspecialNormalizerMatrixGroups.tst");
 
 #
-gap> TestExtraspecialNormalizerInSL := function(args)
->   local r, m, q, G;
->   r := args[1];
->   m := args[2];
->   q := args[3];
+gap> TestExtraspecialNormalizerInSL := function(r, m, q)
+>   local G;
 >   G := ExtraspecialNormalizerInSL(r, m, q);
 >   Assert(0, HasSize(G));
 >   Assert(0, IsSubsetSL(r ^ m, q, G));
 >   RECOG.TestGroup(G, false, Size(G));
 > end;;
-gap> TestExtraspecialNormalizerInSL([5, 1, 11]);
-gap> TestExtraspecialNormalizerInSL([3, 1, 7]);
-gap> TestExtraspecialNormalizerInSL([3, 2, 13]);
-gap> TestExtraspecialNormalizerInSL([2, 3, 5]);
-gap> TestExtraspecialNormalizerInSL([2, 2, 5]);
-gap> TestExtraspecialNormalizerInSL([2, 2, 9]);
-gap> TestExtraspecialNormalizerInSL([2, 1, 9]);
-gap> TestExtraspecialNormalizerInSL([2, 1, 5]);
-gap> TestExtraspecialNormalizerInSL([2, 1, 7]);
+gap> TestExtraspecialNormalizerInSL(5, 1, 11);
+gap> TestExtraspecialNormalizerInSL(3, 1, 7);
+gap> TestExtraspecialNormalizerInSL(3, 2, 13);
+gap> TestExtraspecialNormalizerInSL(2, 3, 5);
+gap> TestExtraspecialNormalizerInSL(2, 2, 5);
+gap> TestExtraspecialNormalizerInSL(2, 2, 9);
+gap> TestExtraspecialNormalizerInSL(2, 1, 9);
+gap> TestExtraspecialNormalizerInSL(2, 1, 5);
+gap> TestExtraspecialNormalizerInSL(2, 1, 7);
 
 #
-gap> TestExtraspecialNormalizerInSU := function(args)
->   local r, m, q, G;
->   r := args[1];
->   m := args[2];
->   q := args[3];
+gap> TestExtraspecialNormalizerInSU := function(r, m, q)
+>   local G;
 >   G := ExtraspecialNormalizerInSU(r, m, q);
 >   Assert(0, HasSize(G));
 >   Assert(0, IsSubsetSU(r ^ m, q, G));
 >   RECOG.TestGroup(G, false, Size(G));
 > end;;
-gap> TestExtraspecialNormalizerInSU([5, 1, 4]);
-gap> TestExtraspecialNormalizerInSU([2, 3, 3]);
+gap> TestExtraspecialNormalizerInSU(5, 1, 4);
+gap> TestExtraspecialNormalizerInSU(2, 3, 3);
 #@if IsBound(CLASSICAL_MAXIMALS_RUN_BROKEN_TESTS)
-gap> TestExtraspecialNormalizerInSU([2, 3, 7]); # FIXME: `Giving up, Schreier tree is not shallow.`
-gap> TestExtraspecialNormalizerInSU([2, 2, 3]); # FIXME: `Error, the recognition described by this recognition node has failed!`
+gap> TestExtraspecialNormalizerInSU(2, 3, 7); # FIXME: `Giving up, Schreier tree is not shallow.`
+gap> TestExtraspecialNormalizerInSU(2, 2, 3); # FIXME: `Error, the recognition described by this recognition node has failed!`
 #@fi
-gap> TestExtraspecialNormalizerInSU([2, 2, 7]);
-gap> TestExtraspecialNormalizerInSU([3, 2, 5]);
-gap> TestExtraspecialNormalizerInSU([3, 1, 8]);
-gap> TestExtraspecialNormalizerInSU([3, 1, 5]);
+gap> TestExtraspecialNormalizerInSU(2, 2, 7);
+gap> TestExtraspecialNormalizerInSU(3, 2, 5);
+gap> TestExtraspecialNormalizerInSU(3, 1, 8);
+gap> TestExtraspecialNormalizerInSU(3, 1, 5);
 
 #
-gap> TestExtraspecialNormalizerInSp := function(args)
->   local m, q, G;
->   m := args[1];
->   q := args[2];
+gap> TestExtraspecialNormalizerInSp := function(m, q)
+>   local G;
 >   G := ExtraspecialNormalizerInSp(m, q);
 >   Assert(0, HasSize(G));
 >   Assert(0, IsSubsetSp(2 ^ m, q, G));
 >   RECOG.TestGroup(G, false, Size(G));
 > end;;
-gap> TestExtraspecialNormalizerInSp([2, 3]);
-gap> TestExtraspecialNormalizerInSp([2, 5]);
-gap> TestExtraspecialNormalizerInSp([2, 7]);
+gap> TestExtraspecialNormalizerInSp(2, 3);
+gap> TestExtraspecialNormalizerInSp(2, 5);
+gap> TestExtraspecialNormalizerInSp(2, 7);
 #@if IsBound(CLASSICAL_MAXIMALS_RUN_BROKEN_TESTS)
-gap> TestExtraspecialNormalizerInSp([3, 3]); # FIXME: `Error, the recognition described by this recognition node has failed!`
+gap> TestExtraspecialNormalizerInSp(3, 3); # FIXME: `Error, the recognition described by this recognition node has failed!`
 #@fi
-gap> TestExtraspecialNormalizerInSp([3, 5]);
+gap> TestExtraspecialNormalizerInSp(3, 5);
 #@if IsBound(CLASSICAL_MAXIMALS_RUN_BROKEN_TESTS)
-gap> TestExtraspecialNormalizerInSp([3, 7]); # FIXME: `Error, the recognition described by this recognition node has failed!`
+gap> TestExtraspecialNormalizerInSp(3, 7); # FIXME: `Error, the recognition described by this recognition node has failed!`
 #@fi
 
 #
-gap> TestOddExtraspecialGroup := function(args)
->   local r, m, q, gens, G;
->   r := args[1];
->   m := args[2];
->   q := args[3];
+gap> TestOddExtraspecialGroup := function(r, m, q)
+>   local gens, G;
 >   gens := OddExtraspecialGroup(r, m, q);
 >   G := Group(Concatenation(gens.listOfXi, gens.listOfYi));
 >   RECOG.TestGroup(G, false, r ^ (2 * m + 1));
 > end;;
-gap> TestOddExtraspecialGroup([5, 1, 11]);
-gap> TestOddExtraspecialGroup([3, 1, 7]);
-gap> TestOddExtraspecialGroup([3, 2, 13]);
+gap> TestOddExtraspecialGroup(5, 1, 11);
+gap> TestOddExtraspecialGroup(3, 1, 7);
+gap> TestOddExtraspecialGroup(3, 2, 13);
 
 #
-gap> TestOddExtraspecialNormalizerInGL := function(args)
->   local r, m, q, gensNormalizer, gensExtraspecial, extraspecialGroup,
->   normalizer;
->   r := args[1];
->   m := args[2];
->   q := args[3];
+gap> TestOddExtraspecialNormalizerInGL := function(r, m, q)
+>   local gensNormalizer, gensExtraspecial, extraspecialGroup, normalizer;
 >   gensNormalizer := OddExtraspecialNormalizerInGL(r, m, q);
 >   gensExtraspecial := OddExtraspecialGroup(r, m, q);
 >   extraspecialGroup := Group(Concatenation(gensExtraspecial.listOfXi,
@@ -97,17 +82,15 @@ gap> TestOddExtraspecialNormalizerInGL := function(args)
 >                                     [gensNormalizer.generatingScalar]));
 >   Assert(0, ForAll(GeneratorsOfGroup(normalizer), g -> extraspecialGroup ^ g = extraspecialGroup));
 > end;;
-gap> TestOddExtraspecialNormalizerInGL([5, 1, 11]);
-gap> TestOddExtraspecialNormalizerInGL([3, 1, 7]);
-gap> TestOddExtraspecialNormalizerInGL([3, 2, 13]);
+gap> TestOddExtraspecialNormalizerInGL(5, 1, 11);
+gap> TestOddExtraspecialNormalizerInGL(3, 1, 7);
+gap> TestOddExtraspecialNormalizerInGL(3, 2, 13);
 
 #
-gap> TestSymplecticTypeNormalizerInGL := function(args)
->   local r, m, q, gensNormalizer, gensExtraspecial, extraspecialGroup,
+gap> TestSymplecticTypeNormalizerInGL := function(m, q)
+>   local r, gensNormalizer, gensExtraspecial, extraspecialGroup,
 >   normalizer, zeta, F;
 >   r := 2;
->   m := args[1];
->   q := args[2];
 >   F := GF(q);
 >   zeta := PrimitiveElement(F);
 >   gensNormalizer := SymplecticTypeNormalizerInGL(m, q);
@@ -123,16 +106,14 @@ gap> TestSymplecticTypeNormalizerInGL := function(args)
 >                                     [gensNormalizer.generatingScalar]));
 >   Assert(0, ForAll(GeneratorsOfGroup(normalizer), g -> extraspecialGroup ^ g = extraspecialGroup));
 > end;;
-gap> TestSymplecticTypeNormalizerInGL([3, 5]);
-gap> TestSymplecticTypeNormalizerInGL([2, 5]);
-gap> TestSymplecticTypeNormalizerInGL([2, 9]);
+gap> TestSymplecticTypeNormalizerInGL(3, 5);
+gap> TestSymplecticTypeNormalizerInGL(2, 5);
+gap> TestSymplecticTypeNormalizerInGL(2, 9);
 
 #
-gap> TestExtraspecial2MinusTypeNormalizerInGL := function(args)
->   local r, m, q, gensNormalizer, extraspecialGroup, normalizer, zeta, F;
+gap> TestExtraspecial2MinusTypeNormalizerInGL := function(m, q)
+>   local r, gensNormalizer, extraspecialGroup, normalizer, zeta, F;
 >   r := 2;
->   m := args[1];
->   q := args[2];
 >   F := GF(q);
 >   zeta := PrimitiveElement(F);
 >   gensNormalizer := Extraspecial2MinusTypeNormalizerInGL(m, q);
@@ -146,10 +127,10 @@ gap> TestExtraspecial2MinusTypeNormalizerInGL := function(args)
 >                                     [gensNormalizer.generatingScalar]));
 >   Assert(0, ForAll(GeneratorsOfGroup(normalizer), g -> extraspecialGroup ^ g = extraspecialGroup));
 > end;;
-gap> TestExtraspecial2MinusTypeNormalizerInGL([1, 9]);
-gap> TestExtraspecial2MinusTypeNormalizerInGL([1, 5]);
-gap> TestExtraspecial2MinusTypeNormalizerInGL([1, 7]);
-gap> TestExtraspecial2MinusTypeNormalizerInGL([2, 5]);
+gap> TestExtraspecial2MinusTypeNormalizerInGL(1, 9);
+gap> TestExtraspecial2MinusTypeNormalizerInGL(1, 5);
+gap> TestExtraspecial2MinusTypeNormalizerInGL(1, 7);
+gap> TestExtraspecial2MinusTypeNormalizerInGL(2, 5);
 
 #
 gap> STOP_TEST("ExtraspecialNormalizerMatrixGroups.tst", 0);

--- a/tst/standard/ImprimitiveMatrixGroups.tst
+++ b/tst/standard/ImprimitiveMatrixGroups.tst
@@ -1,65 +1,55 @@
 gap> START_TEST("ImprimitiveMatrixGroups.tst");
 
 #
-gap> TestImprimitivesMeetSL := function(args)
->   local n, q, t, G;
->   n := args[1];
->   q := args[2];
->   t := args[3];
+gap> TestImprimitivesMeetSL := function(n, q, t)
+>   local G;
 >   G := ImprimitivesMeetSL(n, q, t);
 >   Assert(0, HasSize(G));
 >   Assert(0, IsSubsetSL(n, q, G));
 >   RECOG.TestGroup(G, false, Size(G));
 > end;;
-gap> TestImprimitivesMeetSL([2, 3, 2]);
+gap> TestImprimitivesMeetSL(2, 3, 2);
 #@if IsBound(CLASSICAL_MAXIMALS_RUN_BROKEN_TESTS)
-gap> TestImprimitivesMeetSL([4, 8, 2]); # FIXME: `Error, !!!`, see https://github.com/gap-packages/recog/issues/12
+gap> TestImprimitivesMeetSL(4, 8, 2); # FIXME: `Error, !!!`, see https://github.com/gap-packages/recog/issues/12
 #@fi
-gap> TestImprimitivesMeetSL([6, 5, 3]);
+gap> TestImprimitivesMeetSL(6, 5, 3);
 
 #
-gap> TestSUIsotropicImprimitives := function(args)
->   local n, q, G;
->   n := args[1];
->   q := args[2];
+gap> TestSUIsotropicImprimitives := function(n, q)
+>   local G;
 >   G := SUIsotropicImprimitives(n, q);
 >   Assert(0, HasSize(G));
 >   Assert(0, IsSubsetSU(n, q, G));
 >   RECOG.TestGroup(G, false, Size(G));
 > end;;
-gap> TestSUIsotropicImprimitives([6, 2]);
-gap> TestSUIsotropicImprimitives([4, 3]);
-gap> TestSUIsotropicImprimitives([2, 5]);
+gap> TestSUIsotropicImprimitives(6, 2);
+gap> TestSUIsotropicImprimitives(4, 3);
+gap> TestSUIsotropicImprimitives(2, 5);
 
 #
-gap> TestSUNonDegenerateImprimitives := function(args)
->   local n, q, t, G;
->   n := args[1];
->   q := args[2];
->   t := args[3];
+gap> TestSUNonDegenerateImprimitives := function(n, q, t)
+>   local G;
 >   G := SUNonDegenerateImprimitives(n, q, t);
 >   Assert(0, HasSize(G));
 >   Assert(0, IsSubsetSU(n, q, G));
 >   RECOG.TestGroup(G, false, Size(G));
 > end;;
-gap> TestSUNonDegenerateImprimitives([6, 3, 3]);
-gap> TestSUNonDegenerateImprimitives([9, 2, 3]);
-gap> TestSUNonDegenerateImprimitives([3, 5, 3]);
+gap> TestSUNonDegenerateImprimitives(6, 3, 3);
+gap> TestSUNonDegenerateImprimitives(9, 2, 3);
+gap> TestSUNonDegenerateImprimitives(3, 5, 3);
 
 #
-gap> TestSpIsotropicImprimitives := function(args)
->   local n, q, G;
->   n := args[1];
->   q := args[2];
+gap> TestSpIsotropicImprimitives := function(n, q)
+>   local G;
 >   G := SpIsotropicImprimitives(n, q);
 >   Assert(0, HasSize(G));
 >   Assert(0, IsSubsetSp(n, q, G));
 >   RECOG.TestGroup(G, false, Size(G));
 > end;;
-gap> TestSpIsotropicImprimitives([4, 3]);
-gap> TestSpIsotropicImprimitives([4, 7]);
-gap> TestSpIsotropicImprimitives([6, 5]);
-gap> TestSpIsotropicImprimitives([8, 3]);
+gap> TestSpIsotropicImprimitives(4, 3);
+gap> TestSpIsotropicImprimitives(4, 7);
+gap> TestSpIsotropicImprimitives(6, 5);
+gap> TestSpIsotropicImprimitives(8, 3);
 
 # Test error handling
 gap> SpIsotropicImprimitives(3, 3);
@@ -68,20 +58,17 @@ gap> SpIsotropicImprimitives(4, 2);
 Error, <q> must be odd
 
 #
-gap> TestSpNonDegenerateImprimitives := function(args)
->   local n, q, t, G;
->   n := args[1];
->   q := args[2];
->   t := args[3];
+gap> TestSpNonDegenerateImprimitives := function(n, q, t)
+>   local G;
 >   G := SpNonDegenerateImprimitives(n, q, t);
 >   Assert(0, HasSize(G));
 >   Assert(0, IsSubsetSp(n, q, G));
 >   RECOG.TestGroup(G, false, Size(G));
 > end;;
-gap> TestSpNonDegenerateImprimitives([4, 2, 2]);
-gap> TestSpNonDegenerateImprimitives([6, 5, 3]);
-gap> TestSpNonDegenerateImprimitives([10, 3, 5]);
-gap> TestSpNonDegenerateImprimitives([12, 3, 3]);
+gap> TestSpNonDegenerateImprimitives(4, 2, 2);
+gap> TestSpNonDegenerateImprimitives(6, 5, 3);
+gap> TestSpNonDegenerateImprimitives(10, 3, 5);
+gap> TestSpNonDegenerateImprimitives(12, 3, 3);
 
 # Test error handling
 gap> SpNonDegenerateImprimitives(3, 3, 3);

--- a/tst/standard/ReducibleMatrixGroups.tst
+++ b/tst/standard/ReducibleMatrixGroups.tst
@@ -1,70 +1,58 @@
 gap> START_TEST("ReducibleMatrixGroups.tst");
 
 #
-gap> TestSLStabilizerOfSubspace := function(args)
->   local n, q, k, G;
->   Info(InfoClassicalMaximalsTests, 1, args);
->   n := args[1];
->   q := args[2];
->   k := args[3];
+gap> TestSLStabilizerOfSubspace := function(n, q, k)
+>   local G;
+>   Info(InfoClassicalMaximalsTests, 1, [n,q,k]);
 >   G := SLStabilizerOfSubspace(n, q, k);
 >   Assert(0, HasSize(G));
 >   Assert(0, IsSubsetSL(n, q, G));
 >   RECOG.TestGroup(G, false, Size(G));
 > end;;
-gap> TestSLStabilizerOfSubspace([4, 3, 2]);
+gap> TestSLStabilizerOfSubspace(4, 3, 2);
 #@if IsBound(CLASSICAL_MAXIMALS_RUN_BROKEN_TESTS)
-gap> TestSLStabilizerOfSubspace([3, 8, 2]); # FIXME: `Error, !!!`, see https://github.com/gap-packages/recog/issues/12
+gap> TestSLStabilizerOfSubspace(3, 8, 2); # FIXME: `Error, !!!`, see https://github.com/gap-packages/recog/issues/12
 #@fi
-gap> TestSLStabilizerOfSubspace([2, 7, 1]);
+gap> TestSLStabilizerOfSubspace(2, 7, 1);
 
 #
-gap> TestSUStabilizerOfIsotropicSubspace := function(args)
->   local n, q, k, G;
->   n := args[1];
->   q := args[2];
->   k := args[3];
+gap> TestSUStabilizerOfIsotropicSubspace := function(n, q, k)
+>   local G;
 >   G := SUStabilizerOfIsotropicSubspace(n, q, k);
 >   Assert(0, HasSize(G));
 >   Assert(0, IsSubsetSU(n, q, G));
 >   RECOG.TestGroup(G, false, Size(G));
 > end;;
-gap> TestSUStabilizerOfIsotropicSubspace([4, 3, 2]);
-gap> TestSUStabilizerOfIsotropicSubspace([3, 5, 1]);
-gap> TestSUStabilizerOfIsotropicSubspace([3, 4, 1]);
-gap> TestSUStabilizerOfIsotropicSubspace([4, 3, 1]);
+gap> TestSUStabilizerOfIsotropicSubspace(4, 3, 2);
+gap> TestSUStabilizerOfIsotropicSubspace(3, 5, 1);
+gap> TestSUStabilizerOfIsotropicSubspace(3, 4, 1);
+gap> TestSUStabilizerOfIsotropicSubspace(4, 3, 1);
 
 #
-gap> TestSUStabilizerOfNonDegenerateSubspace := function(args)
->   local n, q, k, G;
->   n := args[1];
->   q := args[2];
->   k := args[3];
+gap> TestSUStabilizerOfNonDegenerateSubspace := function(n, q, k)
+>   local G;
 >   G := SUStabilizerOfNonDegenerateSubspace(n, q, k);
 >   Assert(0, HasSize(G));
 >   Assert(0, IsSubsetSU(n, q, G));
 >   RECOG.TestGroup(G, false, Size(G));
 > end;;
-gap> TestSUStabilizerOfNonDegenerateSubspace([5, 3, 2]);
-gap> TestSUStabilizerOfNonDegenerateSubspace([6, 3, 2]);
-gap> TestSUStabilizerOfNonDegenerateSubspace([4, 5, 1]);
-gap> TestSUStabilizerOfNonDegenerateSubspace([5, 4, 1]);
+gap> TestSUStabilizerOfNonDegenerateSubspace(5, 3, 2);
+gap> TestSUStabilizerOfNonDegenerateSubspace(6, 3, 2);
+gap> TestSUStabilizerOfNonDegenerateSubspace(4, 5, 1);
+gap> TestSUStabilizerOfNonDegenerateSubspace(5, 4, 1);
 
 #
-gap> TestSpStabilizerOfIsotropicSubspace := function(args)
->   local n, q, k, G;
->   n := args[1];
->   q := args[2];
->   k := args[3];
+gap> TestSpStabilizerOfIsotropicSubspace := function(n, q, k)
+>   local G;
 >   G := SpStabilizerOfIsotropicSubspace(n, q, k);
 >   Assert(0, HasSize(G));
 >   Assert(0, IsSubsetSp(n, q, G));
 >   RECOG.TestGroup(G, false, Size(G));
 > end;;
-gap> TestSpStabilizerOfIsotropicSubspace([4, 2, 1]);
-gap> TestSpStabilizerOfIsotropicSubspace([4, 9, 1]);
-gap> TestSpStabilizerOfIsotropicSubspace([6, 4, 1]);
-gap> TestSpStabilizerOfIsotropicSubspace([6, 7, 2]);
+gap> TestSpStabilizerOfIsotropicSubspace(4, 2, 1);
+gap> TestSpStabilizerOfIsotropicSubspace(4, 9, 1);
+gap> TestSpStabilizerOfIsotropicSubspace(6, 4, 1);
+gap> TestSpStabilizerOfIsotropicSubspace(6, 7, 2);
 
 # Test error handling
 gap> SpStabilizerOfIsotropicSubspace(5, 2, 1);
@@ -73,20 +61,17 @@ gap> SpStabilizerOfIsotropicSubspace(4, 2, 3);
 Error, <k> must be less than or equal to <d> / 2
 
 #
-gap> TestSpStabilizerOfNonDegenerateSubspace := function(args)
->   local n, q, k, G;
->   n := args[1];
->   q := args[2];
->   k := args[3];
+gap> TestSpStabilizerOfNonDegenerateSubspace := function(n, q, k)
+>   local G;
 >   G := SpStabilizerOfNonDegenerateSubspace(n, q, k);
 >   Assert(0, HasSize(G));
 >   Assert(0, IsSubsetSp(n, q, G));
 >   RECOG.TestGroup(G, false, Size(G));
 > end;;
-gap> TestSpStabilizerOfNonDegenerateSubspace([4, 2, 1]);
-gap> TestSpStabilizerOfNonDegenerateSubspace([4, 9, 1]);
-gap> TestSpStabilizerOfNonDegenerateSubspace([6, 4, 1]);
-gap> TestSpStabilizerOfNonDegenerateSubspace([6, 7, 2]);
+gap> TestSpStabilizerOfNonDegenerateSubspace(4, 2, 1);
+gap> TestSpStabilizerOfNonDegenerateSubspace(4, 9, 1);
+gap> TestSpStabilizerOfNonDegenerateSubspace(6, 4, 1);
+gap> TestSpStabilizerOfNonDegenerateSubspace(6, 7, 2);
 
 # Test error handling
 gap> SpStabilizerOfNonDegenerateSubspace(5, 2, 1);
@@ -95,23 +80,20 @@ gap> SpStabilizerOfNonDegenerateSubspace(4, 2, 3);
 Error, <k> must be less than <d> / 2
 
 #
-gap> TestOmegaStabilizerOfNonSingularVector := function(args)
->   local epsilon, d, q, G;
->   epsilon := args[1];
->   d := args[2];
->   q := args[3];
+gap> TestOmegaStabilizerOfNonSingularVector := function(epsilon, d, q)
+>   local G;
 >   G := OmegaStabilizerOfNonSingularVector(epsilon, d, q);
 >   Assert(0, HasSize(G));
 >   Assert(0, IsSubset(Omega(epsilon, d, q), GeneratorsOfGroup(G)));
 >   Assert(0, DefaultFieldOfMatrixGroup(G) = GF(q));
 >   RECOG.TestGroup(G, false, Size(G));
 > end;;
-gap> TestOmegaStabilizerOfNonSingularVector([1, 6, 4]);
-gap> TestOmegaStabilizerOfNonSingularVector([-1, 6, 4]);
-gap> TestOmegaStabilizerOfNonSingularVector([1, 8, 2]);
-gap> TestOmegaStabilizerOfNonSingularVector([-1, 8, 2]);
-gap> TestOmegaStabilizerOfNonSingularVector([1, 4, 8]);
-gap> TestOmegaStabilizerOfNonSingularVector([-1, 4, 8]);
+gap> TestOmegaStabilizerOfNonSingularVector(1, 6, 4);
+gap> TestOmegaStabilizerOfNonSingularVector(-1, 6, 4);
+gap> TestOmegaStabilizerOfNonSingularVector(1, 8, 2);
+gap> TestOmegaStabilizerOfNonSingularVector(-1, 8, 2);
+gap> TestOmegaStabilizerOfNonSingularVector(1, 4, 8);
+gap> TestOmegaStabilizerOfNonSingularVector(-1, 4, 8);
 
 # Test error handling
 gap> OmegaStabilizerOfNonSingularVector(0, 2, 4);

--- a/tst/standard/SemilinearMatrixGroups.tst
+++ b/tst/standard/SemilinearMatrixGroups.tst
@@ -1,78 +1,65 @@
 gap> START_TEST("SemilinearMatrixGroups.tst");
 
 #
-gap> TestGammaLMeetSL := function(args)
->   local n, q, s, G;
->   n := args[1];
->   q := args[2];
->   s := args[3];
+gap> TestGammaLMeetSL := function(n, q, s)
+>   local G;
 >   G := GammaLMeetSL(n, q, s);
 >   Assert(0, HasSize(G));
 >   Assert(0, IsSubsetSL(n, q, G));
 >   RECOG.TestGroup(G, false, Size(G));
 > end;;
-gap> TestGammaLMeetSL([4, 3, 2]);
-gap> TestGammaLMeetSL([2, 2, 2]);
-gap> TestGammaLMeetSL([6, 5, 3]);
-gap> TestGammaLMeetSL([3, 4, 3]);
+gap> TestGammaLMeetSL(4, 3, 2);
+gap> TestGammaLMeetSL(2, 2, 2);
+gap> TestGammaLMeetSL(6, 5, 3);
+gap> TestGammaLMeetSL(3, 4, 3);
 
 #
-gap> TestGammaLMeetSU := function(args)
->   local n, q, s, G;
->   n := args[1];
->   q := args[2];
->   s := args[3];
+gap> TestGammaLMeetSU := function(n, q, s)
+>   local G;
 >   G := GammaLMeetSU(n, q, s);
 >   Assert(0, HasSize(G));
 >   Assert(0, IsSubsetSU(n, q, G));
 >   RECOG.TestGroup(G, false, Size(G));
 > end;;
-gap> TestGammaLMeetSU([3, 5, 3]);
-gap> TestGammaLMeetSU([6, 3, 3]);
-gap> TestGammaLMeetSU([3, 7, 3]);
+gap> TestGammaLMeetSU(3, 5, 3);
+gap> TestGammaLMeetSU(6, 3, 3);
+gap> TestGammaLMeetSU(3, 7, 3);
 
 #
-gap> TestSymplecticSemilinearSp := function(args)
->   local n, q, s, G;
->   n := args[1];
->   q := args[2];
->   s := args[3];
+gap> TestSymplecticSemilinearSp := function(n, q, s)
+>   local G;
 >   G := SymplecticSemilinearSp(n, q, s);
 >   Assert(0, HasSize(G));
 >   Assert(0, IsSubsetSp(n, q, G));
 >   RECOG.TestGroup(G, false, Size(G));
 > end;;
-gap> TestSymplecticSemilinearSp([4, 7, 2]);
-gap> TestSymplecticSemilinearSp([6, 5, 3]);
-gap> TestSymplecticSemilinearSp([8, 4, 2]);
+gap> TestSymplecticSemilinearSp(4, 7, 2);
+gap> TestSymplecticSemilinearSp(6, 5, 3);
+gap> TestSymplecticSemilinearSp(8, 4, 2);
 
 #
-gap> TestUnitarySemilinearSp := function(args)
->   local n, q, G;
->   n := args[1];
->   q := args[2];
+gap> TestUnitarySemilinearSp := function(n, q)
+>   local G;
 >   G := UnitarySemilinearSp(n, q);
 >   Assert(0, HasSize(G));
 >   Assert(0, IsSubsetSp(n, q, G));
 >   RECOG.TestGroup(G, false, Size(G));
 > end;;
-gap> TestUnitarySemilinearSp([4, 7]);
-gap> TestUnitarySemilinearSp([8, 5]);
-gap> TestUnitarySemilinearSp([6, 5]);
+gap> TestUnitarySemilinearSp(4, 7);
+gap> TestUnitarySemilinearSp(8, 5);
+gap> TestUnitarySemilinearSp(6, 5);
 
 #
-gap> TestMatricesInducingGaloisGroupOfGFQToSOverGFQ := function(args)
->   local q, s, gens;
->   q := args[1];
->   s := args[2];
+gap> TestMatricesInducingGaloisGroupOfGFQToSOverGFQ := function(q, s)
+>   local gens;
 >   gens := MatricesInducingGaloisGroupOfGFQToSOverGFQ(s, q);
 >   Assert(0, Order(gens.A) = (q ^ s - 1));
 >   Assert(0, Order(gens.B) = s);
 > end;;
-gap> TestMatricesInducingGaloisGroupOfGFQToSOverGFQ([3, 2]);
-gap> TestMatricesInducingGaloisGroupOfGFQToSOverGFQ([2, 2]);
-gap> TestMatricesInducingGaloisGroupOfGFQToSOverGFQ([5, 3]);
-gap> TestMatricesInducingGaloisGroupOfGFQToSOverGFQ([4, 3]);
+gap> TestMatricesInducingGaloisGroupOfGFQToSOverGFQ(3, 2);
+gap> TestMatricesInducingGaloisGroupOfGFQToSOverGFQ(2, 2);
+gap> TestMatricesInducingGaloisGroupOfGFQToSOverGFQ(5, 3);
+gap> TestMatricesInducingGaloisGroupOfGFQToSOverGFQ(4, 3);
 
 #
 gap> STOP_TEST("SemilinearMatrixGroups.tst", 0);

--- a/tst/standard/SubfieldMatrixGroups.tst
+++ b/tst/standard/SubfieldMatrixGroups.tst
@@ -1,21 +1,17 @@
 gap> START_TEST("SubfieldMatrixGroups.tst");
 
 #
-gap> TestSubfieldSL := function(args)
->   local n, p, e, f, G;
->   n := args[1];
->   p := args[2];
->   e := args[3];
->   f := args[4];
+gap> TestSubfieldSL := function(n, p, e, f)
+>   local G;
 >   G := SubfieldSL(n, p, e, f);
 >   Assert(0, HasSize(G));
 >   Assert(0, IsSubsetSL(n, p ^ e, G));
 >   RECOG.TestGroup(G, false, Size(G));
 > end;;
-gap> TestSubfieldSL([4, 2, 4, 2]);
+gap> TestSubfieldSL(4, 2, 4, 2);
 #@if IsBound(CLASSICAL_MAXIMALS_RUN_BROKEN_TESTS)
-gap> TestSubfieldSL([2, 3, 6, 2]);
-gap> TestSubfieldSL([3, 7, 3, 1]);
+gap> TestSubfieldSL(2, 3, 6, 2);
+gap> TestSubfieldSL(3, 7, 3, 1);
 #@fi
 
 # Test error handling
@@ -27,21 +23,17 @@ gap> SubfieldSL(1, 1, 1, 4);
 Error, the quotient of <e> by <f> must be a prime
 
 #
-gap> TestUnitarySubfieldSU := function(args)
->   local n, p, e, f, G;
->   n := args[1];
->   p := args[2];
->   e := args[3];
->   f := args[4];
+gap> TestUnitarySubfieldSU := function(n, p, e, f)
+>   local G;
 >   G := UnitarySubfieldSU(n, p, e, f);
 >   Assert(0, HasSize(G));
 >   Assert(0, IsSubset(SU(n, p ^ e), GeneratorsOfGroup(G)));
 >   #Assert(0, DefaultFieldOfMatrixGroup(G) = GF(p ^ (2 * e))); # FIXME
 >   RECOG.TestGroup(G, false, Size(G));
 > end;;
-gap> TestUnitarySubfieldSU([2, 3, 6, 2]);
-gap> TestUnitarySubfieldSU([3, 7, 3, 1]);
-gap> TestUnitarySubfieldSU([3, 5, 3, 1]);
+gap> TestUnitarySubfieldSU(2, 3, 6, 2);
+gap> TestUnitarySubfieldSU(3, 7, 3, 1);
+gap> TestUnitarySubfieldSU(3, 5, 3, 1);
 
 # Test error handling
 gap> UnitarySubfieldSU(1, 1, 1, 1);
@@ -52,18 +44,16 @@ gap> UnitarySubfieldSU(1, 1, 1, 2);
 Error, the quotient of <e> by <f> must be an odd prime
 
 #
-gap> TestSymplecticSubfieldSU := function(args)
->   local n, q, G;
->   n := args[1];
->   q := args[2];
+gap> TestSymplecticSubfieldSU := function(n, q)
+>   local G;
 >   G := SymplecticSubfieldSU(n, q);
 >   Assert(0, HasSize(G));
 >   Assert(0, IsSubsetSU(n, q, G));
 >   RECOG.TestGroup(G, false, Size(G));
 > end;;
-gap> TestSymplecticSubfieldSU([4, 5]);
-gap> TestSymplecticSubfieldSU([2, 4]);
-gap> TestSymplecticSubfieldSU([4, 3]);
+gap> TestSymplecticSubfieldSU(4, 5);
+gap> TestSymplecticSubfieldSU(2, 4);
+gap> TestSymplecticSubfieldSU(4, 3);
 
 # Test error handling
 gap> SymplecticSubfieldSU(3, 3);
@@ -86,21 +76,17 @@ gap> TestOrthogonalSubfieldSU(-1, 2, 5);
 gap> TestOrthogonalSubfieldSU(-1, 4, 3);
 
 #
-gap> TestSubfieldSp := function(args)
->   local n, p, e, f, G;
->   n := args[1];
->   p := args[2];
->   e := args[3];
->   f := args[4];
+gap> TestSubfieldSp := function(n, p, e, f)
+>   local G;
 >   G := SubfieldSp(n, p, e, f);
 >   Assert(0, HasSize(G));
 >   Assert(0, IsSubsetSp(n, p ^ e, G));
 >   RECOG.TestGroup(G, false, Size(G));
 > end;;
-gap> TestSubfieldSp([6, 2, 2, 1]);
-gap> TestSubfieldSp([4, 3, 2, 1]);
-gap> TestSubfieldSp([4, 3, 4, 2]);
-gap> TestSubfieldSp([4, 7, 2, 1]);
+gap> TestSubfieldSp(6, 2, 2, 1);
+gap> TestSubfieldSp(4, 3, 2, 1);
+gap> TestSubfieldSp(4, 3, 4, 2);
+gap> TestSubfieldSp(4, 7, 2, 1);
 
 # Test error handling
 gap> SubfieldSp(3, 2, 2, 1);

--- a/tst/standard/TensorInducedMatrixGroups.tst
+++ b/tst/standard/TensorInducedMatrixGroups.tst
@@ -1,52 +1,43 @@
 gap> START_TEST("TensorInducedMatrixGroups.tst");
 
 #
-gap> TestTensorInducedDecompositionStabilizerInSL := function(args)
->   local m, t, q, G;
->   m := args[1];
->   t := args[2];
->   q := args[3];
+gap> TestTensorInducedDecompositionStabilizerInSL := function(m, t, q)
+>   local G;
 >   G := TensorInducedDecompositionStabilizerInSL(m, t, q);
 >   Assert(0, HasSize(G));
 >   Assert(0, IsSubsetSL(m ^ t, q, G));
 >   RECOG.TestGroup(G, false, Size(G));
 > end;;
-gap> TestTensorInducedDecompositionStabilizerInSL([3, 2, 5]);
-gap> TestTensorInducedDecompositionStabilizerInSL([2, 2, 7]);
-gap> TestTensorInducedDecompositionStabilizerInSL([2, 2, 5]);
-gap> TestTensorInducedDecompositionStabilizerInSL([3, 3, 3]);
+gap> TestTensorInducedDecompositionStabilizerInSL(3, 2, 5);
+gap> TestTensorInducedDecompositionStabilizerInSL(2, 2, 7);
+gap> TestTensorInducedDecompositionStabilizerInSL(2, 2, 5);
+gap> TestTensorInducedDecompositionStabilizerInSL(3, 3, 3);
 
 #
-gap> TestTensorInducedDecompositionStabilizerInSU := function(args)
->   local m, t, q, G;
->   m := args[1];
->   t := args[2];
->   q := args[3];
+gap> TestTensorInducedDecompositionStabilizerInSU := function(m, t, q)
+>   local G;
 >   G := TensorInducedDecompositionStabilizerInSU(m, t, q);
 >   Assert(0, IsSubsetSU(m ^ t, q, G));
 >   Assert(0, HasSize(G));
 > end;;
-gap> TestTensorInducedDecompositionStabilizerInSU([2, 2, 7]);
-gap> TestTensorInducedDecompositionStabilizerInSU([2, 2, 5]);
-gap> TestTensorInducedDecompositionStabilizerInSU([3, 2, 3]);
-gap> TestTensorInducedDecompositionStabilizerInSU([3, 3, 3]);
-gap> TestTensorInducedDecompositionStabilizerInSU([3, 2, 5]);
+gap> TestTensorInducedDecompositionStabilizerInSU(2, 2, 7);
+gap> TestTensorInducedDecompositionStabilizerInSU(2, 2, 5);
+gap> TestTensorInducedDecompositionStabilizerInSU(3, 2, 3);
+gap> TestTensorInducedDecompositionStabilizerInSU(3, 3, 3);
+gap> TestTensorInducedDecompositionStabilizerInSU(3, 2, 5);
 
 #
-gap> TestTensorInducedDecompositionStabilizerInSp := function(args)
->   local m, t, q, G;
->   m := args[1];
->   t := args[2];
->   q := args[3];
+gap> TestTensorInducedDecompositionStabilizerInSp := function(m, t, q)
+>   local G;
 >   G := TensorInducedDecompositionStabilizerInSp(m, t, q);
 >   Assert(0, HasSize(G));
 >   Assert(0, IsSubsetSp(m ^ t, q, G));
 >   RECOG.TestGroup(G, false, Size(G));
 > end;;
-gap> TestTensorInducedDecompositionStabilizerInSp([2, 3, 7]);
-gap> TestTensorInducedDecompositionStabilizerInSp([4, 3, 3]);
+gap> TestTensorInducedDecompositionStabilizerInSp(2, 3, 7);
+gap> TestTensorInducedDecompositionStabilizerInSp(4, 3, 3);
 #@if IsBound(CLASSICAL_MAXIMALS_RUN_BROKEN_TESTS)
-gap> TestTensorInducedDecompositionStabilizerInSp([2, 5, 3]); # FIXME: see https://github.com/gap-packages/recog/issues/302
+gap> TestTensorInducedDecompositionStabilizerInSp(2, 5, 3); # FIXME: see https://github.com/gap-packages/recog/issues/302
 #@fi
 
 # Test error handling

--- a/tst/standard/TensorProductMatrixGroups.tst
+++ b/tst/standard/TensorProductMatrixGroups.tst
@@ -1,61 +1,51 @@
 gap> START_TEST("TensorProductMatrixGroups.tst");
 
 #
-gap> TestTensorProductStabilizerInSL := function(args)
->   local d1, d2, q, G;
->   d1 := args[1];
->   d2 := args[2];
->   q := args[3];
+gap> TestTensorProductStabilizerInSL := function(d1, d2, q)
+>   local G;
 >   G := TensorProductStabilizerInSL(d1, d2, q);
 >   Assert(0, HasSize(G));
 >   Assert(0, IsSubsetSL(d1 * d2, q, G));
 >   Assert(0, DefaultFieldOfMatrixGroup(G) = GF(q));
 >   RECOG.TestGroup(G, false, Size(G));
 > end;;
-gap> TestTensorProductStabilizerInSL([2, 3, 2]);
-gap> TestTensorProductStabilizerInSL([2, 3, 3]);
-gap> TestTensorProductStabilizerInSL([2, 3, 4]);
-gap> TestTensorProductStabilizerInSL([2, 3, 5]);
-gap> TestTensorProductStabilizerInSL([2, 4, 3]);
-gap> TestTensorProductStabilizerInSL([3, 4, 2]);
-gap> TestTensorProductStabilizerInSL([3, 4, 3]);
+gap> TestTensorProductStabilizerInSL(2, 3, 2);
+gap> TestTensorProductStabilizerInSL(2, 3, 3);
+gap> TestTensorProductStabilizerInSL(2, 3, 4);
+gap> TestTensorProductStabilizerInSL(2, 3, 5);
+gap> TestTensorProductStabilizerInSL(2, 4, 3);
+gap> TestTensorProductStabilizerInSL(3, 4, 2);
+gap> TestTensorProductStabilizerInSL(3, 4, 3);
 
 #
-gap> TestTensorProductStabilizerInSU := function(args)
->   local d1, d2, q, G;
->   d1 := args[1];
->   d2 := args[2];
->   q := args[3];
+gap> TestTensorProductStabilizerInSU := function(d1, d2, q)
+>   local G;
 >   G := TensorProductStabilizerInSU(d1, d2, q);
 >   Assert(0, HasSize(G));
 >   Assert(0, IsSubsetSU(d1 * d2, q, G));
 >   Assert(0, DefaultFieldOfMatrixGroup(G) = GF(q ^ 2));
 >   RECOG.TestGroup(G, false, Size(G));
 > end;;
-gap> TestTensorProductStabilizerInSU([2, 3, 2]);
-gap> TestTensorProductStabilizerInSU([2, 3, 3]);
-gap> TestTensorProductStabilizerInSU([2, 3, 4]);
+gap> TestTensorProductStabilizerInSU(2, 3, 2);
+gap> TestTensorProductStabilizerInSU(2, 3, 3);
+gap> TestTensorProductStabilizerInSU(2, 3, 4);
 #@if IsBound(CLASSICAL_MAXIMALS_RUN_BROKEN_TESTS)
-gap> TestTensorProductStabilizerInSU([2, 4, 3]); # FIXME: see https://github.com/gap-packages/recog/issues/302
+gap> TestTensorProductStabilizerInSU(2, 4, 3); # FIXME: see https://github.com/gap-packages/recog/issues/302
 #@fi
 
 #
-gap> TestTensorProductStabilizerInSp := function(args)
->   local epsilon, d1, d2, q, G;
->   epsilon := args[1];
->   d1 := args[2];
->   d2 := args[3];
->   q := args[4];
+gap> TestTensorProductStabilizerInSp := function(epsilon, d1, d2, q)
+>   local G;
 >   G := TensorProductStabilizerInSp(epsilon, d1, d2, q);
 >   Assert(0, HasSize(G));
 >   Assert(0, IsSubsetSp(d1 * d2, q, G));
 >   Assert(0, DefaultFieldOfMatrixGroup(G) = GF(q));
 >   RECOG.TestGroup(G, false, Size(G));
 > end;;
-gap> TestTensorProductStabilizerInSp([0, 2, 3, 3]);
-gap> TestTensorProductStabilizerInSp([0, 4, 3, 5]);
-gap> TestTensorProductStabilizerInSp([1, 2, 4, 5]);
-gap> TestTensorProductStabilizerInSp([-1, 2, 4, 5]);
+gap> TestTensorProductStabilizerInSp(0, 2, 3, 3);
+gap> TestTensorProductStabilizerInSp(0, 4, 3, 5);
+gap> TestTensorProductStabilizerInSp(1, 2, 4, 5);
+gap> TestTensorProductStabilizerInSp(-1, 2, 4, 5);
 
 # Test error handling
 gap> TensorProductStabilizerInSp(0, 1, 3, 3);


### PR DESCRIPTION
- Rewrite tst/standard/ClassicalMaximals.tst
- tests: avoid needless use of variadic functions
