### PR TITLE
Replace RECOG.TestGroup by new CheckSize helper

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,7 +5,7 @@ _Description of your PR_
 - [ ] All functions have unit tests
 
 ### Functions constructing generators of maximal subgroups
-- [ ] The code which computes and then stores the sizes is correct. To do this one confers to the tables referenced by the code. Tests for the group size should use `RECOG.TestGroup` from the recog package.
+- [ ] The code which computes and then stores the sizes is correct. To do this one confers to the tables referenced by the code.
 - [ ] The test suite checks whether all constructed generators are sensible. That is it tests the generators'
   - [ ] determinants (and if applicable also the spinor norms are correct), and
   - [ ] compatibility with the correct form,

--- a/tst/standard/ClassicalNormalizerMatrixGroups.tst
+++ b/tst/standard/ClassicalNormalizerMatrixGroups.tst
@@ -4,9 +4,8 @@ gap> START_TEST("ClassicalNormalizerMatrixGroups.tst");
 gap> TestSymplecticNormalizerInSL := function(n, q)
 >   local G;
 >   G := SymplecticNormalizerInSL(n, q);
->   Assert(0, HasSize(G));
+>   Assert(0, CheckSize(G));
 >   Assert(0, IsSubsetSL(n, q, G));
->   RECOG.TestGroup(G, false, Size(G));
 > end;;
 gap> TestSymplecticNormalizerInSL(4, 3);
 gap> TestSymplecticNormalizerInSL(4, 5);
@@ -16,9 +15,8 @@ gap> TestSymplecticNormalizerInSL(6, 4);
 gap> TestUnitaryNormalizerInSL := function(n, q)
 >   local G;
 >   G := UnitaryNormalizerInSL(n, q);
->   Assert(0, HasSize(G));
+>   Assert(0, CheckSize(G));
 >   Assert(0, IsSubsetSL(n, q, G));
->   RECOG.TestGroup(G, false, Size(G));
 > end;;
 gap> TestUnitaryNormalizerInSL(4, 9);
 gap> TestUnitaryNormalizerInSL(3, 9);
@@ -28,9 +26,8 @@ gap> TestUnitaryNormalizerInSL(4, 4);
 gap> TestOrthogonalNormalizerInSL := function(epsilon, n, q)
 >   local G;
 >   G := OrthogonalNormalizerInSL(epsilon, n, q);
->   Assert(0, HasSize(G));
+>   Assert(0, CheckSize(G));
 >   Assert(0, IsSubsetSL(n, q, G));
->   RECOG.TestGroup(G, false, Size(G));
 > end;;
 gap> TestOrthogonalNormalizerInSL(0, 3, 5);
 gap> TestOrthogonalNormalizerInSL(-1, 6, 5);
@@ -45,9 +42,8 @@ gap> TestOrthogonalNormalizerInSL(-1, 6, 3);
 gap> TestOrthogonalInSp := function(epsilon, n, q)
 >   local G;
 >   G := OrthogonalInSp(epsilon, n, q);
->   Assert(0, HasSize(G));
+>   Assert(0, CheckSize(G));
 >   Assert(0, IsSubsetSp(n, q, G));
->   RECOG.TestGroup(G, false, Size(G));
 > end;;
 #@if IsBound(CLASSICAL_MAXIMALS_RUN_BROKEN_TESTS)
 gap> TestOrthogonalInSp(1, 4, 8);

--- a/tst/standard/ExtraspecialNormalizerMatrixGroups.tst
+++ b/tst/standard/ExtraspecialNormalizerMatrixGroups.tst
@@ -4,9 +4,8 @@ gap> START_TEST("ExtraspecialNormalizerMatrixGroups.tst");
 gap> TestExtraspecialNormalizerInSL := function(r, m, q)
 >   local G;
 >   G := ExtraspecialNormalizerInSL(r, m, q);
->   Assert(0, HasSize(G));
+>   Assert(0, CheckSize(G));
 >   Assert(0, IsSubsetSL(r ^ m, q, G));
->   RECOG.TestGroup(G, false, Size(G));
 > end;;
 gap> TestExtraspecialNormalizerInSL(5, 1, 11);
 gap> TestExtraspecialNormalizerInSL(3, 1, 7);
@@ -22,16 +21,15 @@ gap> TestExtraspecialNormalizerInSL(2, 1, 7);
 gap> TestExtraspecialNormalizerInSU := function(r, m, q)
 >   local G;
 >   G := ExtraspecialNormalizerInSU(r, m, q);
->   Assert(0, HasSize(G));
+>   Assert(0, CheckSize(G));
 >   Assert(0, IsSubsetSU(r ^ m, q, G));
->   RECOG.TestGroup(G, false, Size(G));
 > end;;
 gap> TestExtraspecialNormalizerInSU(5, 1, 4);
-gap> TestExtraspecialNormalizerInSU(2, 3, 3);
 #@if IsBound(CLASSICAL_MAXIMALS_RUN_BROKEN_TESTS)
-gap> TestExtraspecialNormalizerInSU(2, 3, 7); # FIXME: `Giving up, Schreier tree is not shallow.`
-gap> TestExtraspecialNormalizerInSU(2, 2, 3); # FIXME: `Error, the recognition described by this recognition node has failed!`
+gap> TestExtraspecialNormalizerInSU(2, 3, 3); # FIXME: `Giving up, Schreier tree is not shallow.`
+gap> TestExtraspecialNormalizerInSU(2, 3, 7); # FIXME: `Error, the recognition described by this recognition node has failed!`
 #@fi
+gap> TestExtraspecialNormalizerInSU(2, 2, 3);
 gap> TestExtraspecialNormalizerInSU(2, 2, 7);
 gap> TestExtraspecialNormalizerInSU(3, 2, 5);
 gap> TestExtraspecialNormalizerInSU(3, 1, 8);
@@ -41,9 +39,8 @@ gap> TestExtraspecialNormalizerInSU(3, 1, 5);
 gap> TestExtraspecialNormalizerInSp := function(m, q)
 >   local G;
 >   G := ExtraspecialNormalizerInSp(m, q);
->   Assert(0, HasSize(G));
+>   Assert(0, CheckSize(G));
 >   Assert(0, IsSubsetSp(2 ^ m, q, G));
->   RECOG.TestGroup(G, false, Size(G));
 > end;;
 gap> TestExtraspecialNormalizerInSp(2, 3);
 gap> TestExtraspecialNormalizerInSp(2, 5);

--- a/tst/standard/ImprimitiveMatrixGroups.tst
+++ b/tst/standard/ImprimitiveMatrixGroups.tst
@@ -4,9 +4,8 @@ gap> START_TEST("ImprimitiveMatrixGroups.tst");
 gap> TestImprimitivesMeetSL := function(n, q, t)
 >   local G;
 >   G := ImprimitivesMeetSL(n, q, t);
->   Assert(0, HasSize(G));
+>   Assert(0, CheckSize(G));
 >   Assert(0, IsSubsetSL(n, q, G));
->   RECOG.TestGroup(G, false, Size(G));
 > end;;
 gap> TestImprimitivesMeetSL(2, 3, 2);
 #@if IsBound(CLASSICAL_MAXIMALS_RUN_BROKEN_TESTS)
@@ -18,9 +17,8 @@ gap> TestImprimitivesMeetSL(6, 5, 3);
 gap> TestSUIsotropicImprimitives := function(n, q)
 >   local G;
 >   G := SUIsotropicImprimitives(n, q);
->   Assert(0, HasSize(G));
+>   Assert(0, CheckSize(G));
 >   Assert(0, IsSubsetSU(n, q, G));
->   RECOG.TestGroup(G, false, Size(G));
 > end;;
 gap> TestSUIsotropicImprimitives(6, 2);
 gap> TestSUIsotropicImprimitives(4, 3);
@@ -30,9 +28,8 @@ gap> TestSUIsotropicImprimitives(2, 5);
 gap> TestSUNonDegenerateImprimitives := function(n, q, t)
 >   local G;
 >   G := SUNonDegenerateImprimitives(n, q, t);
->   Assert(0, HasSize(G));
+>   Assert(0, CheckSize(G));
 >   Assert(0, IsSubsetSU(n, q, G));
->   RECOG.TestGroup(G, false, Size(G));
 > end;;
 gap> TestSUNonDegenerateImprimitives(6, 3, 3);
 gap> TestSUNonDegenerateImprimitives(9, 2, 3);
@@ -42,9 +39,8 @@ gap> TestSUNonDegenerateImprimitives(3, 5, 3);
 gap> TestSpIsotropicImprimitives := function(n, q)
 >   local G;
 >   G := SpIsotropicImprimitives(n, q);
->   Assert(0, HasSize(G));
+>   Assert(0, CheckSize(G));
 >   Assert(0, IsSubsetSp(n, q, G));
->   RECOG.TestGroup(G, false, Size(G));
 > end;;
 gap> TestSpIsotropicImprimitives(4, 3);
 gap> TestSpIsotropicImprimitives(4, 7);
@@ -61,9 +57,8 @@ Error, <q> must be odd
 gap> TestSpNonDegenerateImprimitives := function(n, q, t)
 >   local G;
 >   G := SpNonDegenerateImprimitives(n, q, t);
->   Assert(0, HasSize(G));
+>   Assert(0, CheckSize(G));
 >   Assert(0, IsSubsetSp(n, q, G));
->   RECOG.TestGroup(G, false, Size(G));
 > end;;
 gap> TestSpNonDegenerateImprimitives(4, 2, 2);
 gap> TestSpNonDegenerateImprimitives(6, 5, 3);

--- a/tst/standard/ReducibleMatrixGroups.tst
+++ b/tst/standard/ReducibleMatrixGroups.tst
@@ -5,9 +5,8 @@ gap> TestSLStabilizerOfSubspace := function(n, q, k)
 >   local G;
 >   Info(InfoClassicalMaximalsTests, 1, [n,q,k]);
 >   G := SLStabilizerOfSubspace(n, q, k);
->   Assert(0, HasSize(G));
+>   Assert(0, CheckSize(G));
 >   Assert(0, IsSubsetSL(n, q, G));
->   RECOG.TestGroup(G, false, Size(G));
 > end;;
 gap> TestSLStabilizerOfSubspace(4, 3, 2);
 #@if IsBound(CLASSICAL_MAXIMALS_RUN_BROKEN_TESTS)
@@ -19,9 +18,8 @@ gap> TestSLStabilizerOfSubspace(2, 7, 1);
 gap> TestSUStabilizerOfIsotropicSubspace := function(n, q, k)
 >   local G;
 >   G := SUStabilizerOfIsotropicSubspace(n, q, k);
->   Assert(0, HasSize(G));
+>   Assert(0, CheckSize(G));
 >   Assert(0, IsSubsetSU(n, q, G));
->   RECOG.TestGroup(G, false, Size(G));
 > end;;
 gap> TestSUStabilizerOfIsotropicSubspace(4, 3, 2);
 gap> TestSUStabilizerOfIsotropicSubspace(3, 5, 1);
@@ -32,9 +30,8 @@ gap> TestSUStabilizerOfIsotropicSubspace(4, 3, 1);
 gap> TestSUStabilizerOfNonDegenerateSubspace := function(n, q, k)
 >   local G;
 >   G := SUStabilizerOfNonDegenerateSubspace(n, q, k);
->   Assert(0, HasSize(G));
+>   Assert(0, CheckSize(G));
 >   Assert(0, IsSubsetSU(n, q, G));
->   RECOG.TestGroup(G, false, Size(G));
 > end;;
 gap> TestSUStabilizerOfNonDegenerateSubspace(5, 3, 2);
 gap> TestSUStabilizerOfNonDegenerateSubspace(6, 3, 2);
@@ -45,9 +42,8 @@ gap> TestSUStabilizerOfNonDegenerateSubspace(5, 4, 1);
 gap> TestSpStabilizerOfIsotropicSubspace := function(n, q, k)
 >   local G;
 >   G := SpStabilizerOfIsotropicSubspace(n, q, k);
->   Assert(0, HasSize(G));
+>   Assert(0, CheckSize(G));
 >   Assert(0, IsSubsetSp(n, q, G));
->   RECOG.TestGroup(G, false, Size(G));
 > end;;
 gap> TestSpStabilizerOfIsotropicSubspace(4, 2, 1);
 gap> TestSpStabilizerOfIsotropicSubspace(4, 9, 1);
@@ -64,9 +60,8 @@ Error, <k> must be less than or equal to <d> / 2
 gap> TestSpStabilizerOfNonDegenerateSubspace := function(n, q, k)
 >   local G;
 >   G := SpStabilizerOfNonDegenerateSubspace(n, q, k);
->   Assert(0, HasSize(G));
+>   Assert(0, CheckSize(G));
 >   Assert(0, IsSubsetSp(n, q, G));
->   RECOG.TestGroup(G, false, Size(G));
 > end;;
 gap> TestSpStabilizerOfNonDegenerateSubspace(4, 2, 1);
 gap> TestSpStabilizerOfNonDegenerateSubspace(4, 9, 1);
@@ -83,10 +78,9 @@ Error, <k> must be less than <d> / 2
 gap> TestOmegaStabilizerOfNonSingularVector := function(epsilon, d, q)
 >   local G;
 >   G := OmegaStabilizerOfNonSingularVector(epsilon, d, q);
->   Assert(0, HasSize(G));
+>   Assert(0, CheckSize(G));
 >   Assert(0, IsSubset(Omega(epsilon, d, q), GeneratorsOfGroup(G)));
 >   Assert(0, DefaultFieldOfMatrixGroup(G) = GF(q));
->   RECOG.TestGroup(G, false, Size(G));
 > end;;
 gap> TestOmegaStabilizerOfNonSingularVector(1, 6, 4);
 gap> TestOmegaStabilizerOfNonSingularVector(-1, 6, 4);

--- a/tst/standard/SemilinearMatrixGroups.tst
+++ b/tst/standard/SemilinearMatrixGroups.tst
@@ -4,9 +4,8 @@ gap> START_TEST("SemilinearMatrixGroups.tst");
 gap> TestGammaLMeetSL := function(n, q, s)
 >   local G;
 >   G := GammaLMeetSL(n, q, s);
->   Assert(0, HasSize(G));
+>   Assert(0, CheckSize(G));
 >   Assert(0, IsSubsetSL(n, q, G));
->   RECOG.TestGroup(G, false, Size(G));
 > end;;
 gap> TestGammaLMeetSL(4, 3, 2);
 gap> TestGammaLMeetSL(2, 2, 2);
@@ -17,9 +16,8 @@ gap> TestGammaLMeetSL(3, 4, 3);
 gap> TestGammaLMeetSU := function(n, q, s)
 >   local G;
 >   G := GammaLMeetSU(n, q, s);
->   Assert(0, HasSize(G));
+>   Assert(0, CheckSize(G));
 >   Assert(0, IsSubsetSU(n, q, G));
->   RECOG.TestGroup(G, false, Size(G));
 > end;;
 gap> TestGammaLMeetSU(3, 5, 3);
 gap> TestGammaLMeetSU(6, 3, 3);
@@ -29,9 +27,8 @@ gap> TestGammaLMeetSU(3, 7, 3);
 gap> TestSymplecticSemilinearSp := function(n, q, s)
 >   local G;
 >   G := SymplecticSemilinearSp(n, q, s);
->   Assert(0, HasSize(G));
+>   Assert(0, CheckSize(G));
 >   Assert(0, IsSubsetSp(n, q, G));
->   RECOG.TestGroup(G, false, Size(G));
 > end;;
 gap> TestSymplecticSemilinearSp(4, 7, 2);
 gap> TestSymplecticSemilinearSp(6, 5, 3);
@@ -41,9 +38,8 @@ gap> TestSymplecticSemilinearSp(8, 4, 2);
 gap> TestUnitarySemilinearSp := function(n, q)
 >   local G;
 >   G := UnitarySemilinearSp(n, q);
->   Assert(0, HasSize(G));
+>   Assert(0, CheckSize(G));
 >   Assert(0, IsSubsetSp(n, q, G));
->   RECOG.TestGroup(G, false, Size(G));
 > end;;
 gap> TestUnitarySemilinearSp(4, 7);
 gap> TestUnitarySemilinearSp(8, 5);

--- a/tst/standard/SubfieldMatrixGroups.tst
+++ b/tst/standard/SubfieldMatrixGroups.tst
@@ -4,9 +4,8 @@ gap> START_TEST("SubfieldMatrixGroups.tst");
 gap> TestSubfieldSL := function(n, p, e, f)
 >   local G;
 >   G := SubfieldSL(n, p, e, f);
->   Assert(0, HasSize(G));
+>   Assert(0, CheckSize(G));
 >   Assert(0, IsSubsetSL(n, p ^ e, G));
->   RECOG.TestGroup(G, false, Size(G));
 > end;;
 gap> TestSubfieldSL(4, 2, 4, 2);
 #@if IsBound(CLASSICAL_MAXIMALS_RUN_BROKEN_TESTS)
@@ -26,10 +25,9 @@ Error, the quotient of <e> by <f> must be a prime
 gap> TestUnitarySubfieldSU := function(n, p, e, f)
 >   local G;
 >   G := UnitarySubfieldSU(n, p, e, f);
->   Assert(0, HasSize(G));
+>   Assert(0, CheckSize(G));
 >   Assert(0, IsSubset(SU(n, p ^ e), GeneratorsOfGroup(G)));
 >   #Assert(0, DefaultFieldOfMatrixGroup(G) = GF(p ^ (2 * e))); # FIXME
->   RECOG.TestGroup(G, false, Size(G));
 > end;;
 gap> TestUnitarySubfieldSU(2, 3, 6, 2);
 gap> TestUnitarySubfieldSU(3, 7, 3, 1);
@@ -47,9 +45,8 @@ Error, the quotient of <e> by <f> must be an odd prime
 gap> TestSymplecticSubfieldSU := function(n, q)
 >   local G;
 >   G := SymplecticSubfieldSU(n, q);
->   Assert(0, HasSize(G));
+>   Assert(0, CheckSize(G));
 >   Assert(0, IsSubsetSU(n, q, G));
->   RECOG.TestGroup(G, false, Size(G));
 > end;;
 gap> TestSymplecticSubfieldSU(4, 5);
 gap> TestSymplecticSubfieldSU(2, 4);
@@ -63,9 +60,8 @@ Error, <d> must be even
 gap> TestOrthogonalSubfieldSU := function(epsilon, n, q)
 >   local G;
 >   G := OrthogonalSubfieldSU(epsilon, n, q);
->   Assert(0, HasSize(G));
+>   Assert(0, CheckSize(G));
 >   Assert(0, IsSubsetSU(n, q, G));
->   RECOG.TestGroup(G, false, Size(G));
 > end;;
 gap> TestOrthogonalSubfieldSU(0, 3, 5);
 gap> TestOrthogonalSubfieldSU(0, 5, 3);
@@ -79,9 +75,8 @@ gap> TestOrthogonalSubfieldSU(-1, 4, 3);
 gap> TestSubfieldSp := function(n, p, e, f)
 >   local G;
 >   G := SubfieldSp(n, p, e, f);
->   Assert(0, HasSize(G));
+>   Assert(0, CheckSize(G));
 >   Assert(0, IsSubsetSp(n, p ^ e, G));
->   RECOG.TestGroup(G, false, Size(G));
 > end;;
 gap> TestSubfieldSp(6, 2, 2, 1);
 gap> TestSubfieldSp(4, 3, 2, 1);

--- a/tst/standard/TensorInducedMatrixGroups.tst
+++ b/tst/standard/TensorInducedMatrixGroups.tst
@@ -4,9 +4,8 @@ gap> START_TEST("TensorInducedMatrixGroups.tst");
 gap> TestTensorInducedDecompositionStabilizerInSL := function(m, t, q)
 >   local G;
 >   G := TensorInducedDecompositionStabilizerInSL(m, t, q);
->   Assert(0, HasSize(G));
+>   Assert(0, CheckSize(G));
 >   Assert(0, IsSubsetSL(m ^ t, q, G));
->   RECOG.TestGroup(G, false, Size(G));
 > end;;
 gap> TestTensorInducedDecompositionStabilizerInSL(3, 2, 5);
 gap> TestTensorInducedDecompositionStabilizerInSL(2, 2, 7);
@@ -18,7 +17,7 @@ gap> TestTensorInducedDecompositionStabilizerInSU := function(m, t, q)
 >   local G;
 >   G := TensorInducedDecompositionStabilizerInSU(m, t, q);
 >   Assert(0, IsSubsetSU(m ^ t, q, G));
->   Assert(0, HasSize(G));
+>   Assert(0, CheckSize(G));
 > end;;
 gap> TestTensorInducedDecompositionStabilizerInSU(2, 2, 7);
 gap> TestTensorInducedDecompositionStabilizerInSU(2, 2, 5);
@@ -30,9 +29,8 @@ gap> TestTensorInducedDecompositionStabilizerInSU(3, 2, 5);
 gap> TestTensorInducedDecompositionStabilizerInSp := function(m, t, q)
 >   local G;
 >   G := TensorInducedDecompositionStabilizerInSp(m, t, q);
->   Assert(0, HasSize(G));
+>   Assert(0, CheckSize(G));
 >   Assert(0, IsSubsetSp(m ^ t, q, G));
->   RECOG.TestGroup(G, false, Size(G));
 > end;;
 gap> TestTensorInducedDecompositionStabilizerInSp(2, 3, 7);
 gap> TestTensorInducedDecompositionStabilizerInSp(4, 3, 3);

--- a/tst/standard/TensorProductMatrixGroups.tst
+++ b/tst/standard/TensorProductMatrixGroups.tst
@@ -4,10 +4,9 @@ gap> START_TEST("TensorProductMatrixGroups.tst");
 gap> TestTensorProductStabilizerInSL := function(d1, d2, q)
 >   local G;
 >   G := TensorProductStabilizerInSL(d1, d2, q);
->   Assert(0, HasSize(G));
+>   Assert(0, CheckSize(G));
 >   Assert(0, IsSubsetSL(d1 * d2, q, G));
 >   Assert(0, DefaultFieldOfMatrixGroup(G) = GF(q));
->   RECOG.TestGroup(G, false, Size(G));
 > end;;
 gap> TestTensorProductStabilizerInSL(2, 3, 2);
 gap> TestTensorProductStabilizerInSL(2, 3, 3);
@@ -21,10 +20,9 @@ gap> TestTensorProductStabilizerInSL(3, 4, 3);
 gap> TestTensorProductStabilizerInSU := function(d1, d2, q)
 >   local G;
 >   G := TensorProductStabilizerInSU(d1, d2, q);
->   Assert(0, HasSize(G));
+>   Assert(0, CheckSize(G));
 >   Assert(0, IsSubsetSU(d1 * d2, q, G));
 >   Assert(0, DefaultFieldOfMatrixGroup(G) = GF(q ^ 2));
->   RECOG.TestGroup(G, false, Size(G));
 > end;;
 gap> TestTensorProductStabilizerInSU(2, 3, 2);
 gap> TestTensorProductStabilizerInSU(2, 3, 3);
@@ -37,10 +35,9 @@ gap> TestTensorProductStabilizerInSU(2, 4, 3); # FIXME: see https://github.com/g
 gap> TestTensorProductStabilizerInSp := function(epsilon, d1, d2, q)
 >   local G;
 >   G := TensorProductStabilizerInSp(epsilon, d1, d2, q);
->   Assert(0, HasSize(G));
+>   Assert(0, CheckSize(G));
 >   Assert(0, IsSubsetSp(d1 * d2, q, G));
 >   Assert(0, DefaultFieldOfMatrixGroup(G) = GF(q));
->   RECOG.TestGroup(G, false, Size(G));
 > end;;
 gap> TestTensorProductStabilizerInSp(0, 2, 3, 3);
 gap> TestTensorProductStabilizerInSp(0, 4, 3, 5);

--- a/tst/utils.g
+++ b/tst/utils.g
@@ -1,3 +1,13 @@
+CheckSize := function(G)
+  local lvl, ri;
+  Assert(0, HasSize(G));
+  lvl:=InfoLevel(InfoRecog);
+  SetInfoLevel(InfoRecog, 0);
+  ri := RecogniseGroup(G);
+  SetInfoLevel(InfoRecog, lvl);
+  return Size(ri) = Size(G);
+end;
+
 CheckGeneratorsInvertible := function(G)
   return ForAll(GeneratorsOfGroup(G),
               g -> not IsZero(Determinant(g)));


### PR DESCRIPTION
It is not the job of this package to test recog, but the function
`RECOG.TestGroup` is written for that task, and e.g. performs group
recognition multiple times. But we really only want to use recog to compute a
group size in order to test *our* code. So let's do just that, and nothing
more.

_Description of your PR_

## Checklist for the reviewer
### General
- [ ] All functions have unit tests

### Functions constructing generators of maximal subgroups
- [ ] The code which computes and then stores the sizes is correct. To do this one confers to the tables referenced by the code. Tests for the group size should use `RECOG.TestGroup` from the recog package.
- [ ] The test suite checks whether all constructed generators are sensible. That is it tests the generators'
  - [ ] determinants (and if applicable also the spinor norms are correct), and
  - [ ] compatibility with the correct form,
  - [ ] `DefaultFieldOfMatrixGroup` returns the correct field.

### Functions assembling the list of all maximal subgroups of a certain group
- [ ] The code agrees with the tables in section 8.2 of the book "The Maximal Subgroups of the Low-dimensional Finite Classical Groups".

The reviewer doesn't need to compare our results to magma's results. That's the job of the person implementing the code.
