### PR TITLE
Implement StandardOrthogonalForm and StandardGeneratorsOfOrthogonalGroup

### DIFF
--- a/doc/ClassicalMaximals.bib
+++ b/doc/ClassicalMaximals.bib
@@ -77,3 +77,16 @@ MRREVIEWER = {R. W. Carter},
 MRREVIEWER = {Irina Suprunenko},
        URL = {http://projecteuclid.org/euclid.em/1090350930},
 }
+
+@article {MR11,
+    AUTHOR = {Murray, Scott H. and Roney-Dougal, Colva M.},
+     TITLE = {Constructive homomorphisms for classical groups},
+   JOURNAL = {J. Symb. Comp.},
+  FJOURNAL = {Journal of Symbolic Computation},
+    VOLUME = {46},
+      YEAR = {2011},
+    NUMBER = {4},
+     PAGES = {371--384},
+       URL = {https://doi.org/10.1016/j.jsc.2010.09.003},
+}
+

--- a/gap/ClassicalMaximals.gi
+++ b/gap/ClassicalMaximals.gi
@@ -1,7 +1,7 @@
 #
 # ClassicalMaximals: Maximal subgroups of classical groups
 #
-# Code along the lines of [BHR13], [KL90], HR05] and [HR10].
+# Code along the lines of [BHR13], [KL90], [HR05] and [HR10].
 #
 # Implementations
 #

--- a/gap/ClassicalMaximals.gi
+++ b/gap/ClassicalMaximals.gi
@@ -1,7 +1,7 @@
 #
 # ClassicalMaximals: Maximal subgroups of classical groups
 #
-# Code along the lines of [BHR13], [HR05] and [KL90].
+# Code along the lines of [BHR13], [KL90], HR05] and [HR10].
 #
 # Implementations
 #

--- a/gap/Forms.gd
+++ b/gap/Forms.gd
@@ -1,5 +1,6 @@
 DeclareGlobalFunction("ConjugateToSesquilinearForm");
 DeclareGlobalFunction("ConjugateToStandardForm");
+DeclareGlobalFunction("StandardOrthogonalForm");
 DeclareGlobalFunction("UnitaryForm");
 DeclareGlobalFunction("BilinearForm");
 DeclareGlobalFunction("SymplecticForm");

--- a/gap/Forms.gi
+++ b/gap/Forms.gi
@@ -220,6 +220,56 @@ function(forms, F)
     return newForm;
 end);
 
+# Return the standard orthogonal and corresponding bilinear form as used for
+# constructions in [HR10], cf. section 3.1 loc. cit.
+BindGlobal("StandardOrthogonalForm",
+function(epsilon, d, q)
+    local field, m, F, Q, gamma, xi;
+    
+    if not epsilon in [-1, 0, 1] then
+        ErrorNoReturn("<epsilon> must be one of -1, 0, 1");
+    fi;
+    if epsilon = 0 and IsEvenInt(d) then
+        ErrorNoReturn("<epsilon> must be one of -1 or 1 if <d> is even");
+    fi;
+    if epsilon <> 0 and IsOddInt(d) then
+        ErrorNoReturn("<epsilon> must be 0 if <d> is odd");
+    fi;
+    if IsEvenInt(q) and IsOddInt(d) then
+        ErrorNoReturn("<d> must be even if <q> is even");
+    fi;
+
+    field := GF(q);
+    m := QuoInt(d, 2);
+    F := AntidiagonalMat(d, field);
+
+    if IsOddInt(d * q) then
+        Q := AntidiagonalMat(One(field) * Concatenation(ListWithIdenticalEntries(m, 1),
+                                                        [1 / 2],
+                                                        ListWithIdenticalEntries(m, 0)),
+                             field);
+    else
+        Q := AntidiagonalMat(One(field) * Concatenation(ListWithIdenticalEntries(m, 1),
+                                                        ListWithIdenticalEntries(m, 0)),
+                             field);
+        if epsilon = -1 then
+            if IsEvenInt(q) then
+                gamma := FindGamma(q);
+            else
+                xi := PrimitiveElement(GF(q ^ 2));
+                gamma := xi ^ (q + 1) * (xi + xi ^ q) ^ (-2);
+            fi;
+
+            F[m, m] := 2 * gamma ^ 0;
+            F[m + 1, m + 1] := 2 * gamma;
+            Q[m, m] := gamma ^ 0;
+            Q[m + 1, m + 1] := gamma;
+        fi;
+    fi;
+
+    return rec(Q := Q, F := F);
+end);
+
 BindGlobal("ConjugateModule",
 function(M, q)
   return GModuleByMats(List(MTX.Generators(M), A -> ApplyFunctionToEntries(A, x -> x ^ q)), 

--- a/gap/Forms.gi
+++ b/gap/Forms.gi
@@ -222,7 +222,7 @@ end);
 
 # Return the standard orthogonal and corresponding bilinear form as used for
 # constructions in [HR10], cf. section 3.1 loc. cit.
-BindGlobal("StandardOrthogonalForm",
+InstallGlobalFunction("StandardOrthogonalForm",
 function(epsilon, d, q)
     local field, m, F, Q, gamma, xi;
     

--- a/gap/ReducibleMatrixGroups.gi
+++ b/gap/ReducibleMatrixGroups.gi
@@ -503,7 +503,7 @@ end);
 # Construction as in Lemma 4.4 of [HR10]
 BindGlobal("OmegaStabilizerOfNonSingularVector",
 function(epsilon, d, q)
-    local field, m, one, zero, gamma, F, Q, w, L, HStar, N, H, j, wj,
+    local field, one, zero, standardForm, F, Q, w, L, HStar, N, H, j, wj,
         matForLinSys, rightSideForLinSys, particularSol, nullspace, basisVector, z,
         alpha, gens, result;
     
@@ -518,21 +518,14 @@ function(epsilon, d, q)
     fi;
 
     field := GF(q);
-    m := QuoInt(d, 2);
     one := One(field);
     zero := Zero(field);
 
     # Q and F are the matrices of the quadratic form and corresponding polar
     # bilinear form we will use in what follows
-    F := AntidiagonalMat(d, field);
-    Q := AntidiagonalMat(Concatenation(ListWithIdenticalEntries(m, one),
-                                       ListWithIdenticalEntries(m, zero)),
-                         field);
-    if epsilon = -1 then
-        gamma := FindGamma(q);
-        Q[m, m] := one;
-        Q[m + 1, m + 1] := gamma;
-    fi;
+    standardForm := StandardOrthogonalForm(epsilon, d, q);
+    F := standardForm.F;
+    Q := standardForm.Q;
 
     # This is the vector we will stabilise; we have w * Q * w^T = 1
     w := Concatenation([one], ListWithIdenticalEntries(d - 2, zero), [one]);

--- a/gap/Utils.gi
+++ b/gap/Utils.gi
@@ -486,6 +486,107 @@ function(epsilon, n, q)
     return rec(generatorsOfSO := generatorsOfSO, D := D, E := E);
 end);
 
+# Construct standard generators generatorsOfOmega, S, G, D for the orthogonal 
+# groups as used in [HR10], with the following properties:
+#   * generatorsOfOmega generate Omega(epsilon, d, q)
+#   * generatorsOfOmega and S generate SO(epsilon, d, q)
+#   * generatorsOfOmega, S and G generate GO(epsilon, d, q)
+#   * the spinor norm of G is 1 
+#   * D generates CO(epsilon, d, q) mod GO(epsilon, d, q)
+# Construction as in Theorem 3.9 loc. cit.
+BindGlobal("StandardGeneratorsOfOrthogonalGroup",
+function(epsilon, d, q)
+    local field, one, zeta, standardForm, Q, m, conjugatedOmega, 
+    generatorsOfOmega, e, p, R0, R1, S, G, D, xi;
+    
+    if not epsilon in [-1, 0, 1] then
+        ErrorNoReturn("<epsilon> must be one of -1, 0, 1");
+    fi;
+    if epsilon = 0 and IsEvenInt(d) then
+        ErrorNoReturn("<epsilon> must be one of -1 or 1 if <d> is even");
+    fi;
+    if epsilon <> 0 and IsOddInt(d) then
+        ErrorNoReturn("<epsilon> must be 0 if <d> is odd");
+    fi;
+    if IsEvenInt(q) and IsOddInt(d) then
+        ErrorNoReturn("<d> must be even if <q> is even");
+    fi;
+
+    field := GF(q);
+    one := One(field);
+    zeta := PrimitiveElement(field);
+    standardForm := StandardOrthogonalForm(epsilon, d, q);
+    Q := standardForm.Q;
+    m := QuoInt(d, 2);
+
+    conjugatedOmega := ConjugateToSesquilinearForm(Omega(epsilon, d, q), "O-Q", Q);
+    generatorsOfOmega := ShallowCopy(GeneratorsOfGroup(conjugatedOmega));
+    if Length(generatorsOfOmega) = 1 then
+        # this is in particular the case if d = 2
+        Add(generatorsOfOmega, IdentityMat(d, GF(q)));
+    fi;
+
+    if IsOddInt(q) then
+        if d = 2 and epsilon = -1 then
+            e := DegreeOverPrimeField(field);
+            p := Root(q, e);
+            if IsEvenInt(e) or p mod 8 = 1 or p mod 8 = 7 then
+                # by quadratic reciprocity, this is the case where 2 is a
+                # square in GF(q)
+                R0 := ReflectionMatrix(2, q, Q, "Q", one * [1, 0]);
+                R1 := ReflectionMatrix(2, q, Q, "Q", one * [0, 1]);
+            else
+                R0 := ReflectionMatrix(2, q, Q, "Q", one * [0, 1]);
+                R1 := ReflectionMatrix(2, q, Q, "Q", one * [1, 0]);
+            fi;
+        else
+            R0 := ReflectionMatrix(d, q, Q, "Q", 
+                                   one * Concatenation([1], 
+                                                       ListWithIdenticalEntries(d - 2, 0), 
+                                                       [1 / 2]));
+            R1 := ReflectionMatrix(d, q, Q, "Q",
+                                   one * Concatenation([1], 
+                                                       ListWithIdenticalEntries(d - 2, 0),
+                                                       [zeta / 2]));
+        fi;
+
+        S := R0 * R1;
+        G := R0;
+
+    else
+        # q even
+        if d = 2 and epsilon = -1 then
+            S := ReflectionMatrix(2, q, Q, "Q", [one, 0]);
+        else
+            S := ReflectionMatrix(d, q, Q, "Q", 
+                                  one * Concatenation([1],
+                                                      ListWithIdenticalEntries(d - 2, 0),
+                                                      [1]));
+        fi;
+
+        # SO(epsilon, d, q) = GO(epsilon, d, q) since q is even
+        G := IdentityMat(d, GF(q));
+    fi;
+
+    if epsilon = 0 then
+        D := DiagonalMat(Concatenation(ListWithIdenticalEntries(m, zeta ^ 2),
+                                       [zeta],
+                                       ListWithIdenticalEntries(m, one)));
+    elif epsilon = 1 then
+        D := DiagonalMat(Concatenation(ListWithIdenticalEntries(m, zeta),
+                                       ListWithIdenticalEntries(m, one)));
+    else
+        xi := PrimitiveElement(GF(q ^ 2));
+        D := DiagonalMat(Concatenation(ListWithIdenticalEntries(m - 1, zeta),
+                                       one * [0, 0],
+                                       ListWithIdenticalEntries(m - 1, one)));
+        D[m, m + 1] := xi + xi ^ q;
+        D[m + 1, m] := zeta * (xi + xi ^ q) ^ (-1);
+    fi;
+
+    return rec(generatorsOfOmega := generatorsOfOmega, S := S, G := G, D := D);        
+end);
+
 # Compute the spinor norm of an element of an orthogonal group.
 # We use Lemma 3.5 (2) from [HR10] for q even.
 #

--- a/gap/Utils.gi
+++ b/gap/Utils.gi
@@ -556,7 +556,7 @@ function(epsilon, d, q)
     else
         # q even
         if d = 2 and epsilon = -1 then
-            S := ReflectionMatrix(2, q, Q, "Q", [one, 0]);
+            S := ReflectionMatrix(2, q, Q, "Q", one * [1, 0]);
         else
             S := ReflectionMatrix(d, q, Q, "Q", 
                                   one * Concatenation([1],
@@ -566,6 +566,9 @@ function(epsilon, d, q)
 
         # SO(epsilon, d, q) = GO(epsilon, d, q) since q is even
         G := IdentityMat(d, GF(q));
+
+        # as given in Table 2 of [MR11]
+        D := zeta ^ (q / 2) * IdentityMat(d, field);
     fi;
 
     if epsilon = 0 then
@@ -575,7 +578,7 @@ function(epsilon, d, q)
     elif epsilon = 1 then
         D := DiagonalMat(Concatenation(ListWithIdenticalEntries(m, zeta),
                                        ListWithIdenticalEntries(m, one)));
-    else
+    elif IsOddInt(q) then
         xi := PrimitiveElement(GF(q ^ 2));
         D := DiagonalMat(Concatenation(ListWithIdenticalEntries(m - 1, zeta),
                                        one * [0, 0],

--- a/tst/quick/Forms.tst
+++ b/tst/quick/Forms.tst
@@ -88,6 +88,15 @@ gap> TestFormChangingFunctions([6, 4, "O+", AntidiagonalMat(Z(4) ^ 0 * [1, 1, 1,
 gap> Q := QuadraticForm(Group(GeneratorsOfGroup(SO(5, 5))));;
 gap> Q / Q[5, 5] = InvariantQuadraticForm(SO(5, 5)).matrix;
 true
+gap> TestStandardOrthogonalForm := function(epsilon, d, q)
+>   local standardForm;
+>   standardForm := StandardOrthogonalForm(epsilon, d, q);
+>   Assert(0, standardForm.F = standardForm.Q + TransposedMat(standardForm.Q));
+> end;;
+gap> TestStandardOrthogonalForm(0, 5, 7);
+gap> TestStandardOrthogonalForm(1, 6, 9);
+gap> TestStandardOrthogonalForm(-1, 6, 9);
+gap> TestStandardOrthogonalForm(-1, 6, 4);
 
 #
 gap> STOP_TEST("Forms.tst", 0);

--- a/tst/quick/Utils.tst
+++ b/tst/quick/Utils.tst
@@ -158,6 +158,47 @@ gap> for n in [2, 4 .. 10] do for q in [2, 3, 4, 5, 7, 8, 9] do if SizeGO(-1, n,
 gap> for n in [3, 5 .. 9] do for q in [2, 3, 4, 5, 7, 8, 9] do if SizeSO(0, n, q) <> Size(SO(0, n, q)) then Error("bad result for SO(0, ", n, ", ", q, ")"); fi; od; od;
 gap> for n in [2, 4 .. 10] do for q in [2, 3, 4, 5, 7, 8, 9] do if SizeSO(1, n, q) <> Size(SO(1, n, q)) then Error("bad result for SO(1, ", n, ", ", q, ")"); fi; od; od;
 gap> for n in [2, 4 .. 10] do for q in [2, 3, 4, 5, 7, 8, 9] do if SizeSO(-1, n, q) <> Size(SO(-1, n, q)) then Error("bad result for SO(1, ", n, ", ", q, ")"); fi; od; od;
+gap> TestStandardGeneratorsOfOrthogonalGroup := function(epsilon, d, q)
+>   local gens, generatorsOfOmega, S, G, D, standardForms, F, Q, field, one,
+>   e, p, applyDToF, applyDToQ;
+>   gens := StandardGeneratorsOfOrthogonalGroup(epsilon, d, q);
+>   generatorsOfOmega := gens.generatorsOfOmega;
+>   S := gens.S;
+>   G := gens.G;
+>   D := gens.D;
+>   standardForms := StandardOrthogonalForm(epsilon, d, q);
+>   F := standardForms.F;
+>   Q := standardForms.Q;
+>   field := GF(q);
+>   one := One(field);
+>   Assert(0, ForAll(generatorsOfOmega, g -> FancySpinorNorm(F, field, g) = 1));
+>   Assert(0, S * F * TransposedMat(S) = F);
+>   Assert(0, DiagonalOfMat(S * Q * TransposedMat(S)) = DiagonalOfMat(Q));
+>   Assert(0, Determinant(S) = one);
+>   Assert(0, FancySpinorNorm(F, field, S) = -1);
+>   Assert(0, G * F * TransposedMat(G) = F);
+>   Assert(0, DiagonalOfMat(G * Q * TransposedMat(G)) = DiagonalOfMat(Q));
+>   Assert(0, Determinant(G) = -one);
+>   e := DegreeOverPrimeField(field);
+>   p := Root(q, e);
+>   if IsEvenInt(q) or IsEvenInt(e) or p mod 8 = 1 or p mod 8 = 7 then
+>       Assert(0, FancySpinorNorm(F, field, G) = 1);
+>   else
+>       Assert(0, FancySpinorNorm(F, field, G) = -1);
+>   fi;
+>   applyDToF := D * F * TransposedMat(D);
+>   Assert(0, applyDToF * F[1, d] / applyDToF[1, d] = F);
+>   applyDToQ := D * Q * TransposedMat(D);
+>   Assert(0, DiagonalOfMat(applyDToQ * F[1, d] / applyDToF[1, d]) = DiagonalOfMat(Q)); 
+> end;;
+gap> TestStandardGeneratorsOfOrthogonalGroup(-1, 2, 7);
+gap> TestStandardGeneratorsOfOrthogonalGroup(-1, 2, 5);
+gap> TestStandardGeneratorsOfOrthogonalGroup(1, 6, 9);
+gap> TestStandardGeneratorsOfOrthogonalGroup(-1, 6, 9);
+gap> TestStandardGeneratorsOfOrthogonalGroup(0, 5, 11);
+gap> TestStandardGeneratorsOfOrthogonalGroup(-1, 2, 8);
+gap> TestStandardGeneratorsOfOrthogonalGroup(1, 6, 8);
+gap> TestStandardGeneratorsOfOrthogonalGroup(-1, 6, 8);
 
 #
 gap> STOP_TEST("Utils.tst", 0);


### PR DESCRIPTION
Add functions to construct the standard orthogonal forms and the standard generators of the orthogonal groups used in the constructions in [HR10].

## Checklist for the reviewer
### General
- [ ] All functions have unit tests

### Functions constructing generators of maximal subgroups
- [ ] The code which computes and then stores the sizes is correct. To do this one confers to the tables referenced by the code. Tests for the group size should use `RECOG.TestGroup` from the recog package.
- [ ] The test suite checks whether all constructed generators are sensible. That is it tests the generators'
  - [ ] determinants (and if applicable also the spinor norms are correct), and
  - [ ] compatibility with the correct form,
  - [ ] `DefaultFieldOfMatrixGroup` returns the correct field.

### Functions assembling the list of all maximal subgroups of a certain group
- [ ] The code agrees with the tables in section 8.2 of the book "The Maximal Subgroups of the Low-dimensional Finite Classical Groups".

The reviewer doesn't need to compare our results to magma's results. That's the job of the person implementing the code.
