### PR TITLE
Orthogonal C1 NonDegenerate

### DIFF
--- a/gap/ReducibleMatrixGroups.gi
+++ b/gap/ReducibleMatrixGroups.gi
@@ -512,7 +512,7 @@ function(epsilon, d, q, epsilon_0, k)
     if not epsilon in [-1, 0, 1] then
         ErrorNoReturn("<epsilon> must be in [-1, 0, 1]");
     elif not epsilon_0 in [-1, 0, 1] then
-        ErrorNoReturn("<epsilon_1> must be in [-1, 0, 1]");
+        ErrorNoReturn("<epsilon_0> must be in [-1, 0, 1]");
     fi;
     if IsEvenInt(q) and IsOddInt(d) then
         ErrorNoReturn("<d> must be even if <q> is even");
@@ -525,7 +525,7 @@ function(epsilon, d, q, epsilon_0, k)
         if IsEvenInt(d) then
             ErrorNoReturn("<d> must be odd");
         elif not epsilon_0 in [-1, 1] then
-            ErrorNoReturn("<epsilon_1> must be -1 or 1");
+            ErrorNoReturn("<epsilon_0> must be -1 or 1");
         elif IsEvenInt(k) then
             ErrorNoReturn("<k> must be odd");
         elif k >= d then
@@ -541,21 +541,21 @@ function(epsilon, d, q, epsilon_0, k)
             ErrorNoReturn("<d> must be even");
         fi;
         if IsOddInt(k) then
-            if IsEvenInt(k) then
-                ErrorNoReturn("<q> must be odd");
+            if IsEvenInt(q) then
+                ErrorNoReturn("<q> must be odd if <k> is odd");
             fi;
         fi;
         if epsilon_0 = 0 then
             if IsEvenInt(k) then
-                ErrorNoReturn("<k> must be odd");
+                ErrorNoReturn("<k> must be odd if <epsilon_0> is 0");
             fi;
         elif epsilon_0 in [-1, 1] then
             if IsOddInt(k) then
-                ErrorNoReturn("<k> must be even");
+                ErrorNoReturn("<k> must be even if <epsilon_0> is 1 or -1");
             fi;
         fi;
         if k >= m then
-            ErrorNoReturn("<k> must be less than m");
+            ErrorNoReturn("<k> must be less than <d> / 2");
         fi;
 
         epsilon_1 := epsilon_0;
@@ -567,24 +567,24 @@ function(epsilon, d, q, epsilon_0, k)
             ErrorNoReturn("<d> must be even");
         fi;
         if IsOddInt(k) then
-            if IsEvenInt(k) then
-                ErrorNoReturn("<q> must be odd");
+            if IsEvenInt(q) then
+                ErrorNoReturn("<q> must be odd if <k> is odd");
             fi;
         fi;
         if epsilon_0 = 0 then
             if IsEvenInt(k) then
-                ErrorNoReturn("<k> must be odd");
+                ErrorNoReturn("<k> must be odd if <epsilon_0> is 0");
             fi;
             if k = m then
-                ErrorNoReturn("<k> must not be equal to <m>");
+                ErrorNoReturn("<k> must not be equal to <d> / 2 if <epsilon_0> is 0");
             fi;
         elif epsilon_0 in [-1, 1] then
             if IsOddInt(k) then
-                ErrorNoReturn("<k> must be even");
+                ErrorNoReturn("<k> must be even if <epsilon_0> is 1 or -1");
             fi;
         fi;
         if k > m then
-            ErrorNoReturn("<k> must be less than or equal to m");
+            ErrorNoReturn("<k> must be less than or equal to <d> / 2");
         fi;
 
         epsilon_1 := epsilon_0;

--- a/gap/ReducibleMatrixGroups.gi
+++ b/gap/ReducibleMatrixGroups.gi
@@ -514,6 +514,9 @@ function(epsilon, d, q, epsilon_0, k)
     elif not epsilon_0 in [-1, 0, 1] then
         ErrorNoReturn("<epsilon_1> must be in [-1, 0, 1]");
     fi;
+    if IsEvenInt(q) and IsOddInt(d) then
+        ErrorNoReturn("<d> must be even if <q> is even");
+    fi;
 
     m := QuoInt(d, 2);
 
@@ -604,7 +607,11 @@ function(epsilon, d, q, epsilon_0, k)
         od;
     od;
 
-    # Size according to Table 2.3 of [BHR13]
+    # Size according to Table 2.3 of [BHR13], in case q even
+    # we will divide by 2. Because we use the size of SO instead
+    # of Omega and Omega = SO (not |SO| = 2 * |Omega|) in case
+    # k = 1, we do not need to divide by 2 for k = 1, but this
+    # is still consistent with [HR10].
     size := SizeSO(epsilon_1, k, q) * SizeSO(epsilon_2, d - k, q);
 
     if IsEvenInt(q) then
@@ -617,7 +624,7 @@ function(epsilon, d, q, epsilon_0, k)
         # The constructed group preserves this form matrix.
         Q := IdentityMat(d, field);
         Q{[1..k]}{[1..k]} := StandardOrthogonalForm(epsilon_1, k, q).Q;
-        Q{[k + 1..d]}{[k + 1..d]} := StandardOrthogonalForm(epsilon_2, k, q).Q;
+        Q{[k + 1..d]}{[k + 1..d]} := StandardOrthogonalForm(epsilon_2, d - k, q).Q;
 
         result := MatrixGroupWithSize(field, gens, QuoInt(size, 2));
         SetInvariantQuadraticForm(result, rec(matrix := Q));
@@ -637,8 +644,6 @@ function(epsilon, d, q, epsilon_0, k)
             H_6{[1..k]}{[1..k]} := orthogonal_gens_1.S;
             H_6{[k + 1..d]}{[k + 1..d]} := orthogonal_gens_2.S;
             Add(gens, H_6);
-        else
-            size := QuoInt(size, 2);
         fi;
 
         # The constructed group preserves this form matrix.

--- a/gap/ReducibleMatrixGroups.gi
+++ b/gap/ReducibleMatrixGroups.gi
@@ -625,8 +625,8 @@ function(epsilon, d, q, epsilon_0, k)
     else
 
         # The matrices G have spinor norm 1 and determinant -1
-        # respectively, so the result has spinor norm 1 and
-        # determinant 1 and is therefore in SO(epsilon, d, q).
+        # respectively, so the matrix H_6 has spinor norm 1 and
+        # determinant 1 and is therefore in Omega(epsilon, d, q).
         H_5 := IdentityMat(d, field);
         H_5{[1..k]}{[1..k]} := orthogonal_gens_1.G;
         H_5{[k + 1..d]}{[k + 1..d]} := orthogonal_gens_2.G;

--- a/gap/ReducibleMatrixGroups.gi
+++ b/gap/ReducibleMatrixGroups.gi
@@ -500,6 +500,167 @@ function(d, q, k)
     return ConjugateToStandardForm(result, "S");
 end);
 
+# Construction as in Lemma 4.3 of [HR10]
+BindGlobal("OmegaStabilizerOfNonDegenerateSubspace",
+function(epsilon, d, q, epsilon_0, k)
+    local m, epsilon_1, epsilon_2, orthogonal_gens_1, orthogonal_gens_2, field, gens, gen_1, gen_2, H, size, H_5, H_6, Q, F, result;
+
+    # All of the conditions below follow from the general rules of
+    # orthogonal groups as well as Table 1 from [HR10], except we
+    # use epsilon_0 where the table uses epsilon_1 since Lemma 4.3
+    # repurposes that name.
+    if not epsilon in [-1, 0, 1] then
+        ErrorNoReturn("<epsilon> must be in [-1, 0, 1]");
+    elif not epsilon_0 in [-1, 0, 1] then
+        ErrorNoReturn("<epsilon_1> must be in [-1, 0, 1]");
+    fi;
+
+    m := QuoInt(d, 2);
+
+    if epsilon = 0 then
+
+        if IsEvenInt(d) then
+            ErrorNoReturn("<d> must be odd");
+        elif not epsilon_0 in [-1, 1] then
+            ErrorNoReturn("<epsilon_1> must be -1 or 1");
+        elif IsEvenInt(k) then
+            ErrorNoReturn("<k> must be odd");
+        elif k >= d then
+            ErrorNoReturn("<k> must be less than <d>");
+        fi;
+
+        epsilon_1 := 0;
+        epsilon_2 := epsilon_0;
+
+    elif epsilon = 1 then
+
+        if IsOddInt(d) then
+            ErrorNoReturn("<d> must be even");
+        fi;
+        if IsOddInt(k) then
+            if IsEvenInt(k) then
+                ErrorNoReturn("<q> must be odd");
+            fi;
+        fi;
+        if epsilon_0 = 0 then
+            if IsEvenInt(k) then
+                ErrorNoReturn("<k> must be odd");
+            fi;
+        elif epsilon_0 in [-1, 1] then
+            if IsOddInt(k) then
+                ErrorNoReturn("<k> must be even");
+            fi;
+        fi;
+        if k >= m then
+            ErrorNoReturn("<k> must be less than m");
+        fi;
+
+        epsilon_1 := epsilon_0;
+        epsilon_2 := epsilon_0;
+
+    elif epsilon = -1 then
+
+        if IsOddInt(d) then
+            ErrorNoReturn("<d> must be even");
+        fi;
+        if IsOddInt(k) then
+            if IsEvenInt(k) then
+                ErrorNoReturn("<q> must be odd");
+            fi;
+        fi;
+        if epsilon_0 = 0 then
+            if IsEvenInt(k) then
+                ErrorNoReturn("<k> must be odd");
+            fi;
+            if k = m then
+                ErrorNoReturn("<k> must not be equal to <m>");
+            fi;
+        elif epsilon_0 in [-1, 1] then
+            if IsOddInt(k) then
+                ErrorNoReturn("<k> must be even");
+            fi;
+        fi;
+        if k > m then
+            ErrorNoReturn("<k> must be less than or equal to m");
+        fi;
+
+        epsilon_1 := epsilon_0;
+        epsilon_2 := -epsilon_0;
+
+    fi;
+
+    orthogonal_gens_1 := StandardGeneratorsOfOrthogonalGroup(epsilon_1, k, q);
+    orthogonal_gens_2 := StandardGeneratorsOfOrthogonalGroup(epsilon_2, d - k, q);
+
+    field := GF(q);
+    gens := [];
+
+    for gen_1 in orthogonal_gens_1.generatorsOfOmega do
+        for gen_2 in orthogonal_gens_2.generatorsOfOmega do
+            H := IdentityMat(d, field);
+            H{[1..k]}{[1..k]} := gen_1;
+            H{[k + 1..d]}{[k + 1..d]} := gen_2;
+            Add(gens, H);
+        od;
+    od;
+
+    # Size according to Table 2.3 of [BHR13]
+    size := SizeSO(epsilon_1, k, q) * SizeSO(epsilon_2, d - k, q);
+
+    if IsEvenInt(q) then
+
+        H_5 := IdentityMat(d, field);
+        H_5{[1..k]}{[1..k]} := orthogonal_gens_1.S;
+        H_5{[k + 1..d]}{[k + 1..d]} := orthogonal_gens_2.S;
+        Add(gens, H_5);
+
+        # The constructed group preserves this form matrix.
+        Q := IdentityMat(d, field);
+        Q{[1..k]}{[1..k]} := StandardOrthogonalForm(epsilon_1, k, q).Q;
+        Q{[k + 1..d]}{[k + 1..d]} := StandardOrthogonalForm(epsilon_2, k, q).Q;
+
+        result := MatrixGroupWithSize(field, gens, QuoInt(size, 2));
+        SetInvariantQuadraticForm(result, rec(matrix := Q));
+
+    else
+
+        # The matrices G have spinor norm 1 and determinant -1
+        # respectively, so the result has spinor norm 1 and
+        # determinant 1 and is therefore in SO(epsilon, d, q).
+        H_5 := IdentityMat(d, field);
+        H_5{[1..k]}{[1..k]} := orthogonal_gens_1.G;
+        H_5{[k + 1..d]}{[k + 1..d]} := orthogonal_gens_2.G;
+        Add(gens, H_5);
+
+        if k > 1 then
+            H_6 := IdentityMat(d, field);
+            H_6{[1..k]}{[1..k]} := orthogonal_gens_1.S;
+            H_6{[k + 1..d]}{[k + 1..d]} := orthogonal_gens_2.S;
+            Add(gens, H_6);
+        else
+            size := QuoInt(size, 2);
+        fi;
+
+        # The constructed group preserves this form matrix.
+        F := IdentityMat(d, field);
+        F{[1..k]}{[1..k]} := StandardOrthogonalForm(epsilon_1, k, q).F;
+        F{[k + 1..d]}{[k + 1..d]} := StandardOrthogonalForm(epsilon_2, d - k, q).F;
+
+        result := MatrixGroupWithSize(field, gens, size);
+        SetInvariantBilinearForm(result, rec(matrix := F));
+
+    fi;
+
+    if epsilon = -1 then
+        return ConjugateToStandardForm(result, "O-");
+    elif epsilon = 0 then
+        return ConjugateToStandardForm(result, "O");
+    else
+        return ConjugateToStandardForm(result, "O+");
+    fi;
+
+end);
+
 # Construction as in Lemma 4.4 of [HR10]
 BindGlobal("OmegaStabilizerOfNonSingularVector",
 function(epsilon, d, q)

--- a/gap/ReducibleMatrixGroups.gi
+++ b/gap/ReducibleMatrixGroups.gi
@@ -625,7 +625,7 @@ function(epsilon, d, q, epsilon_0, k)
     else
 
         # The matrices G have spinor norm 1 and determinant -1
-        # respectively, so the matrix H_6 has spinor norm 1 and
+        # respectively, so the matrix H_5 has spinor norm 1 and
         # determinant 1 and is therefore in Omega(epsilon, d, q).
         H_5 := IdentityMat(d, field);
         H_5{[1..k]}{[1..k]} := orthogonal_gens_1.G;

--- a/gap/Utils.gi
+++ b/gap/Utils.gi
@@ -515,6 +515,13 @@ function(epsilon, d, q)
     field := GF(q);
     one := One(field);
     zeta := PrimitiveElement(field);
+
+    # In this case, 1 = Omega = SO, GO = Z_2 and CO = Z_(q - 1)
+    # up to isomorphisms.
+    if d = 1 then
+        return rec( generatorsOfOmega := [IdentityMat(1, field)], S := IdentityMat(1, field), G := [[-one]], D := [[zeta]] );
+    fi;
+
     standardForm := StandardOrthogonalForm(epsilon, d, q);
     Q := standardForm.Q;
     m := QuoInt(d, 2);

--- a/tst/quick/Forms.tst
+++ b/tst/quick/Forms.tst
@@ -98,5 +98,15 @@ gap> TestStandardOrthogonalForm(1, 6, 9);
 gap> TestStandardOrthogonalForm(-1, 6, 9);
 gap> TestStandardOrthogonalForm(-1, 6, 4);
 
+# Test error handling
+gap> StandardOrthogonalForm(2, 5, 5);
+Error, <epsilon> must be one of -1, 0, 1
+gap> StandardOrthogonalForm(0, 6, 5);
+Error, <epsilon> must be one of -1 or 1 if <d> is even
+gap> StandardOrthogonalForm(1, 5, 5);
+Error, <epsilon> must be 0 if <d> is odd
+gap> StandardOrthogonalForm(0, 5, 4);
+Error, <d> must be even if <q> is even
+
 #
 gap> STOP_TEST("Forms.tst", 0);

--- a/tst/quick/Utils.tst
+++ b/tst/quick/Utils.tst
@@ -200,5 +200,15 @@ gap> TestStandardGeneratorsOfOrthogonalGroup(-1, 2, 8);
 gap> TestStandardGeneratorsOfOrthogonalGroup(1, 6, 8);
 gap> TestStandardGeneratorsOfOrthogonalGroup(-1, 6, 8);
 
+# Test error handling
+gap> StandardOrthogonalForm(2, 5, 5);
+Error, <epsilon> must be one of -1, 0, 1
+gap> StandardOrthogonalForm(0, 6, 5);
+Error, <epsilon> must be one of -1 or 1 if <d> is even
+gap> StandardOrthogonalForm(1, 5, 5);
+Error, <epsilon> must be 0 if <d> is odd
+gap> StandardOrthogonalForm(0, 5, 4);
+Error, <d> must be even if <q> is even
+
 #
 gap> STOP_TEST("Utils.tst", 0);

--- a/tst/standard/ReducibleMatrixGroups.tst
+++ b/tst/standard/ReducibleMatrixGroups.tst
@@ -75,6 +75,25 @@ gap> SpStabilizerOfNonDegenerateSubspace(4, 2, 3);
 Error, <k> must be less than <d> / 2
 
 #
+gap> TestOmegaStabilizerOfNonDegenerateSubspace := function(epsilon, d, q, epsilon_0, k)
+>   local G;
+>   G := OmegaStabilizerOfNonDegenerateSubspace(epsilon, d, q, epsilon_0, k);
+>   Assert(0, CheckSize(G));
+>   Assert(0, IsSubset(Omega(epsilon, d, q), GeneratorsOfGroup(G)));
+>   Assert(0, DefaultFieldOfMatrixGroup(G) = GF(q));
+> end;;
+gap> TestOmegaStabilizerOfNonDegenerateSubspace(0, 7, 5, 1, 3);
+gap> TestOmegaStabilizerOfNonDegenerateSubspace(0, 7, 5, -1, 5);
+gap> TestOmegaStabilizerOfNonDegenerateSubspace(1, 8, 5, -1, 2);
+gap> TestOmegaStabilizerOfNonDegenerateSubspace(1, 6, 5, 0, 1);
+#@if IsBound(CLASSICAL_MAXIMALS_RUN_BROKEN_TESTS)
+gap> TestOmegaStabilizerOfNonDegenerateSubspace(1, 6, 8, 1, 2); # `Error, !!!`, may be related to https://github.com/gap-packages/recog/issues/12
+#@fi
+gap> TestOmegaStabilizerOfNonDegenerateSubspace(-1, 8, 5, -1, 4);
+gap> TestOmegaStabilizerOfNonDegenerateSubspace(-1, 6, 7, 0, 1);
+gap> TestOmegaStabilizerOfNonDegenerateSubspace(-1, 6, 8, 1, 2);
+
+#
 gap> TestOmegaStabilizerOfNonSingularVector := function(epsilon, d, q)
 >   local G;
 >   G := OmegaStabilizerOfNonSingularVector(epsilon, d, q);

--- a/tst/standard/ReducibleMatrixGroups.tst
+++ b/tst/standard/ReducibleMatrixGroups.tst
@@ -94,7 +94,7 @@ gap> TestOmegaStabilizerOfNonDegenerateSubspace(-1, 6, 7, 0, 1);
 gap> TestOmegaStabilizerOfNonDegenerateSubspace(-1, 6, 8, 1, 2);
 
 # Test error handling
-gap> OmegaStabilizerOfNonDegenerateSubspace(2, 0, 0, 0, 0);
+gap> OmegaStabilizerOfNonDegenerateSubspace(2, 5, 5, 1, 2);
 Error, <epsilon> must be in [-1, 0, 1]
 gap> OmegaStabilizerOfNonDegenerateSubspace(1, 2, 3, 2, 1);
 Error, <epsilon_0> must be in [-1, 0, 1]

--- a/tst/standard/ReducibleMatrixGroups.tst
+++ b/tst/standard/ReducibleMatrixGroups.tst
@@ -93,6 +93,44 @@ gap> TestOmegaStabilizerOfNonDegenerateSubspace(-1, 8, 5, -1, 4);
 gap> TestOmegaStabilizerOfNonDegenerateSubspace(-1, 6, 7, 0, 1);
 gap> TestOmegaStabilizerOfNonDegenerateSubspace(-1, 6, 8, 1, 2);
 
+# Test error handling
+gap> OmegaStabilizerOfNonDegenerateSubspace(2, 0, 0, 0, 0);
+Error, <epsilon> must be in [-1, 0, 1]
+gap> OmegaStabilizerOfNonDegenerateSubspace(1, 2, 3, 2, 1);
+Error, <epsilon_0> must be in [-1, 0, 1]
+gap> OmegaStabilizerOfNonDegenerateSubspace(0, 5, 4, 1, 2);
+Error, <d> must be even if <q> is even
+gap> OmegaStabilizerOfNonDegenerateSubspace(0, 4, 5, 1, 1);
+Error, <d> must be odd
+gap> OmegaStabilizerOfNonDegenerateSubspace(0, 5, 5, 0, 1);
+Error, <epsilon_0> must be -1 or 1
+gap> OmegaStabilizerOfNonDegenerateSubspace(0, 5, 5, 1, 2);
+Error, <k> must be odd
+gap> OmegaStabilizerOfNonDegenerateSubspace(0, 5, 5, 1, 7);
+Error, <k> must be less than <d>
+gap> OmegaStabilizerOfNonDegenerateSubspace(1, 5, 5, 0, 1);
+Error, <d> must be even
+gap> OmegaStabilizerOfNonDegenerateSubspace(1, 4, 4, 0, 1);
+Error, <q> must be odd if <k> is odd
+gap> OmegaStabilizerOfNonDegenerateSubspace(1, 6, 4, 0, 2);
+Error, <k> must be odd if <epsilon_0> is 0
+gap> OmegaStabilizerOfNonDegenerateSubspace(1, 4, 5, 1, 1);
+Error, <k> must be even if <epsilon_0> is 1 or -1
+gap> OmegaStabilizerOfNonDegenerateSubspace(1, 4, 5, 0, 3);
+Error, <k> must be less than <d> / 2
+gap> OmegaStabilizerOfNonDegenerateSubspace(-1, 5, 5, 0, 1);
+Error, <d> must be even
+gap> OmegaStabilizerOfNonDegenerateSubspace(-1, 4, 4, 0, 1);
+Error, <q> must be odd if <k> is odd
+gap> OmegaStabilizerOfNonDegenerateSubspace(-1, 6, 4, 0, 2);
+Error, <k> must be odd if <epsilon_0> is 0
+gap> OmegaStabilizerOfNonDegenerateSubspace(-1, 6, 5, 0, 3);
+Error, <k> must not be equal to <d> / 2 if <epsilon_0> is 0
+gap> OmegaStabilizerOfNonDegenerateSubspace(-1, 4, 5, 1, 1);
+Error, <k> must be even if <epsilon_0> is 1 or -1
+gap> OmegaStabilizerOfNonDegenerateSubspace(-1, 4, 5, 1, 4);
+Error, <k> must be less than or equal to <d> / 2
+
 #
 gap> TestOmegaStabilizerOfNonSingularVector := function(epsilon, d, q)
 >   local G;


### PR DESCRIPTION
Adds the construction for the stabilizer of the canonical non-degenerate-subspace according to Lemma 4.3 in [HR10] via the function `OmegaStabilizerOfNonDegenerateSubspace` along with some error handling tests for `StandardGeneratorsOfOrthogonalGroup` and `StandardOrthogonalForm` as well as a minor addition to `StandardGeneratorsOfOrthogonalGroup`, see my comment below for details.

## Checklist for the reviewer
### General
- [ ] All functions have unit tests

### Functions constructing generators of maximal subgroups
- [ ] The code which computes and then stores the sizes is correct. To do this one confers to the tables referenced by the code.
- [ ] The test suite checks whether all constructed generators are sensible. That is it tests the generators'
  - [ ] determinants (and if applicable also the spinor norms are correct), and
  - [ ] compatibility with the correct form,
  - [ ] `DefaultFieldOfMatrixGroup` returns the correct field.

### Functions assembling the list of all maximal subgroups of a certain group
- [ ] The code agrees with the tables in section 8.2 of the book "The Maximal Subgroups of the Low-dimensional Finite Classical Groups".

The reviewer doesn't need to compare our results to magma's results. That's the job of the person implementing the code.
