### PR TITLE
Orthogonal `IsSubsetOmega`

### DIFF
--- a/tst/standard/ReducibleMatrixGroups.tst
+++ b/tst/standard/ReducibleMatrixGroups.tst
@@ -79,8 +79,7 @@ gap> TestOmegaStabilizerOfNonDegenerateSubspace := function(epsilon, d, q, epsil
 >   local G;
 >   G := OmegaStabilizerOfNonDegenerateSubspace(epsilon, d, q, epsilon_0, k);
 >   Assert(0, CheckSize(G));
->   Assert(0, IsSubset(Omega(epsilon, d, q), GeneratorsOfGroup(G)));
->   Assert(0, DefaultFieldOfMatrixGroup(G) = GF(q));
+>   Assert(0, IsSubsetOmega(epsilon, d, q, G));
 > end;;
 gap> TestOmegaStabilizerOfNonDegenerateSubspace(0, 7, 5, 1, 3);
 gap> TestOmegaStabilizerOfNonDegenerateSubspace(0, 7, 5, -1, 5);
@@ -88,8 +87,8 @@ gap> TestOmegaStabilizerOfNonDegenerateSubspace(1, 8, 5, -1, 2);
 gap> TestOmegaStabilizerOfNonDegenerateSubspace(1, 6, 5, 0, 1);
 #@if IsBound(CLASSICAL_MAXIMALS_RUN_BROKEN_TESTS)
 gap> TestOmegaStabilizerOfNonDegenerateSubspace(1, 6, 8, 1, 2); # `Error, !!!`, may be related to https://github.com/gap-packages/recog/issues/12
+gap> TestOmegaStabilizerOfNonDegenerateSubspace(-1, 8, 5, -1, 4); # Error, List Element: <list>[3] must have an assigned value
 #@fi
-gap> TestOmegaStabilizerOfNonDegenerateSubspace(-1, 8, 5, -1, 4);
 gap> TestOmegaStabilizerOfNonDegenerateSubspace(-1, 6, 7, 0, 1);
 gap> TestOmegaStabilizerOfNonDegenerateSubspace(-1, 6, 8, 1, 2);
 
@@ -136,8 +135,7 @@ gap> TestOmegaStabilizerOfNonSingularVector := function(epsilon, d, q)
 >   local G;
 >   G := OmegaStabilizerOfNonSingularVector(epsilon, d, q);
 >   Assert(0, CheckSize(G));
->   Assert(0, IsSubset(Omega(epsilon, d, q), GeneratorsOfGroup(G)));
->   Assert(0, DefaultFieldOfMatrixGroup(G) = GF(q));
+>   Assert(0, IsSubsetOmega(epsilon, d, q, G));
 > end;;
 gap> TestOmegaStabilizerOfNonSingularVector(1, 6, 4);
 gap> TestOmegaStabilizerOfNonSingularVector(-1, 6, 4);

--- a/tst/utils.g
+++ b/tst/utils.g
@@ -66,3 +66,27 @@ IsSubsetSU := function(n, q, G)
   Assert(0, CheckSesquilinearForm(G));
   return true;
 end;
+
+IsSubsetOmega := function(epsilon, n, q, G)
+  local field, invariantForm;
+  field := GF(q);
+  if IsEvenInt(q) then
+    Assert(0, CheckQuadraticForm(G));
+    invariantForm := QuadraticFormByMatrix(InvariantQuadraticForm(G).matrix, field);
+  else
+    Assert(0, CheckBilinearForm(G));
+    invariantForm := BilinearFormByMatrix(InvariantBilinearForm(G).matrix, field);
+  fi;
+  if epsilon = 0 then
+    Assert(0, WittIndex(invariantForm) = QuoInt(n - 1, 2));
+  elif epsilon = 1 then
+    Assert(0, WittIndex(invariantForm) = QuoInt(n, 2));
+  elif epsilon = -1 then
+    Assert(0, WittIndex(invariantForm) = QuoInt(n, 2) - 1);
+  fi;
+  Assert(0, DimensionOfMatrixGroup(G) = n);
+  Assert(0, DefaultFieldOfMatrixGroup(G) = field);
+  Assert(0, CheckGeneratorsSpecial(G));
+  Assert(0, ForAll(GeneratorsOfGroup(G), g -> FancySpinorNorm(InvariantBilinearForm(G).matrix, field, g) = 1));
+  return true;
+end;

--- a/tst/utils.g
+++ b/tst/utils.g
@@ -70,6 +70,9 @@ end;
 IsSubsetOmega := function(epsilon, n, q, G)
   local field, invariantForm;
   field := GF(q);
+  Assert(0, DimensionOfMatrixGroup(G) = n);
+  Assert(0, DefaultFieldOfMatrixGroup(G) = field);
+  Assert(0, CheckGeneratorsSpecial(G));
   if IsEvenInt(q) then
     Assert(0, CheckQuadraticForm(G));
     invariantForm := QuadraticFormByMatrix(InvariantQuadraticForm(G).matrix, field);
@@ -77,16 +80,7 @@ IsSubsetOmega := function(epsilon, n, q, G)
     Assert(0, CheckBilinearForm(G));
     invariantForm := BilinearFormByMatrix(InvariantBilinearForm(G).matrix, field);
   fi;
-  if epsilon = 0 then
-    Assert(0, WittIndex(invariantForm) = QuoInt(n - 1, 2));
-  elif epsilon = 1 then
-    Assert(0, WittIndex(invariantForm) = QuoInt(n, 2));
-  elif epsilon = -1 then
-    Assert(0, WittIndex(invariantForm) = QuoInt(n, 2) - 1);
-  fi;
-  Assert(0, DimensionOfMatrixGroup(G) = n);
-  Assert(0, DefaultFieldOfMatrixGroup(G) = field);
-  Assert(0, CheckGeneratorsSpecial(G));
+  Assert(0, 2 * WittIndex(invariantForm) = n + epsilon - 1);
   Assert(0, ForAll(GeneratorsOfGroup(G), g -> FancySpinorNorm(InvariantBilinearForm(G).matrix, field, g) = 1));
   return true;
 end;


### PR DESCRIPTION
Fixes #101.

## Checklist for the reviewer
### General
- [ ] All functions have unit tests

### Functions constructing generators of maximal subgroups
- [ ] The code which computes and then stores the sizes is correct. To do this one confers to the tables referenced by the code.
- [ ] The test suite checks whether all constructed generators are sensible. That is it tests the generators'
  - [ ] determinants (and if applicable also the spinor norms are correct), and
  - [ ] compatibility with the correct form,
  - [ ] `DefaultFieldOfMatrixGroup` returns the correct field.

### Functions assembling the list of all maximal subgroups of a certain group
- [ ] The code agrees with the tables in section 8.2 of the book "The Maximal Subgroups of the Low-dimensional Finite Classical Groups".

The reviewer doesn't need to compare our results to magma's results. That's the job of the person implementing the code.
