### PR TITLE
Implement standard generators of groups S and G in cases L, S, U

### DIFF
--- a/doc/ClassicalMaximals.bib
+++ b/doc/ClassicalMaximals.bib
@@ -92,7 +92,10 @@ MRREVIEWER = {Irina Suprunenko},
 
 @article {T87,
     AUTHOR = {Taylor, Donald E.},
-     TITLE = {Conjugacy of subgroups of the general linear group},
+     TITLE = {Pairs of Generators for Matrix Groups, I},
+   JOURNAL = {The Cayley Bulletin},
+    VOLUME = {3},
       YEAR = {1987},
+       URL = {https://www.maths.usyd.edu.au/u/don/papers/genAC.pdf},
 }
 

--- a/doc/ClassicalMaximals.bib
+++ b/doc/ClassicalMaximals.bib
@@ -90,3 +90,9 @@ MRREVIEWER = {Irina Suprunenko},
        URL = {https://doi.org/10.1016/j.jsc.2010.09.003},
 }
 
+@article {T87,
+    AUTHOR = {Taylor, Donald E.},
+     TITLE = {Conjugacy of subgroups of the general linear group},
+      YEAR = {1987},
+}
+

--- a/gap/Utils.gi
+++ b/gap/Utils.gi
@@ -622,12 +622,12 @@ function(d, q)
 
     elif d = 2 and q = 3 then
 
-        L1 := [[-one, one], [-one, 0 * one]];
-        L2 := [[-one, one], [one, 0 * one]];
+        L1 := one * [[-1, 1], [-1, 0]];
+        L2 := one * [[-1, 1], [1, 0]];
 
         # This is precisely L2^2, which is how we ensure that
         # L1 and L2^2 = L3 generate (1 / 2) GL(2, 3) = SL(2, 3).
-        L3 := [[-one, -one], [-one, one]];
+        L3 := one * [[-1, -1], [-1, 1]];
 
     elif q in [2, 3] then
 
@@ -638,9 +638,9 @@ function(d, q)
         # In case q = 2, this matrix is just equal to L3, which
         # makes sense because SL(d, 2) = GL(d, 2).
         # In case q = 3, since L1 and L3 generate SL(d, 3)
-        # and [ GL(d, 3): SL(d, 3) ] = 2, adjoining any matrix 
+        # and [ GL(d, 3): SL(d, 3) ] = 2, adjoining any matrix
         # of determinant -1 to L1 and L2 will give GL(d, 3).
-        # Since we only want 2 generators, this matrix is
+        # Since we only want two generators, this matrix is
         # constructed to be a square root of L3 with determinant -1,
         # so L1 and L2 must already generate GL(d, 3).
         # This differs from the matrix given in [T87] because

--- a/gap/Utils.gi
+++ b/gap/Utils.gi
@@ -597,12 +597,12 @@ function(epsilon, d, q)
     return rec(generatorsOfOmega := generatorsOfOmega, S := S, G := G, D := D);
 end);
 
-# Construct standard generators L1, L2, L3 as used in [HR10] and
-# mentioned by Theorem 2.3 in [R-D13] with the following properties:
+# Construct standard generators L1, L2, L3 as used in [HR10]
+# with the following properties:
 #   * L1 and L2 generate GL(d, q)
 #   * L1 and L3 generate SL(d, q)
 #   * all matrix entries lie in {0, \pm 1, \pm zeta^{\pm 1}} where zeta is
-#       a primitve element of GF(q)
+#       a primitive element of GF(q)
 # Construction as in [T87]
 BindGlobal("StandardGeneratorsOfLinearGroup",
 function(d, q)

--- a/gap/Utils.gi
+++ b/gap/Utils.gi
@@ -594,7 +594,73 @@ function(epsilon, d, q)
         D[m + 1, m] := zeta * (xi + xi ^ q) ^ (-1);
     fi;
 
-    return rec(generatorsOfOmega := generatorsOfOmega, S := S, G := G, D := D);        
+    return rec(generatorsOfOmega := generatorsOfOmega, S := S, G := G, D := D);
+end);
+
+# Construct standard generators L1, L2, L3 as used in [HR10] and
+# mentioned by Theorem 2.3 in [R-D13] with the following properties:
+#   * L1 and L2 generate GL(d, q)
+#   * L1 and L3 generate SL(d, q)
+#   * all matrix entries lie in {0, \pm 1, \pm zeta^{\pm 1}} where zeta is
+#       a primitve element of GF(q)
+# Construction as in [T87]
+BindGlobal("StandardGeneratorsOfLinearGroup",
+function(d, q)
+    local field, one, zeta, L1, L2, L3;
+
+    field := GF(q);
+    one := One(field);
+    zeta := PrimitiveElement(field);
+
+    if d = 1 then
+
+        L1 := [[one]];
+        L2 := [[zeta]];
+        L3 := [[one]];
+
+    elif q in [2, 3] then
+
+        L1 := NullMat(d, d, field);
+        L1[1, d] := one;
+        L1{[2..d]}{[1..d - 1]} := -IdentityMat(d - 1, field);
+
+        # In case q = 2, this matrix is just equal to L3, which
+        # makes sense because SL(d, 2) = GL(d, 2).
+        # In case q = 3, since L1 and L3 generate SL(d, 3)
+        # and [ GL(d, 3): SL(d, 3) ] = 2, adjoining any matrix 
+        # of determinant -1 to L1 and L2 will give GL(d, 3).
+        # Since we only want 2 generators, this matrix is
+        # constructed to be a square root of L3 with determinant -1,
+        # so L1 and L2 must already generate GL(d, 3).
+        # This differs from the matrix given in [T87] because
+        # [T87] does not fulfill our requirements in case q = 3.
+        # TODO: This idea does not work for d = 2, q = 3 because
+        # in then, L3 does not seem to have a square root with
+        # determinant 1, so that case might need hardcoding.
+        L2 := IdentityMat(d, field);
+        L2[1, 2] := -one;
+        L2[d, d] := -one;
+
+        L3 := IdentityMat(d, field);
+        L3[1, 2] := one;
+
+    else
+
+        L1 := NullMat(d, d, field);
+        L1[1, d] := one;
+        L1[1, 1] := -one;
+        L1{[2..d]}{[1..d - 1]} := -IdentityMat(d - 1, field);
+
+        L2 := IdentityMat(d, field);
+        L2[1, 1] := zeta;
+
+        L3 := IdentityMat(d, field);
+        L3[1, 1] := zeta;
+        L3[2, 2] := zeta ^ (-1);
+
+    fi;
+
+    return rec(L1 := L1, L2 := L2, L3 := L3);
 end);
 
 # Compute the spinor norm of an element of an orthogonal group.

--- a/gap/Utils.gi
+++ b/gap/Utils.gi
@@ -635,8 +635,8 @@ function(d, q)
         # This differs from the matrix given in [T87] because
         # [T87] does not fulfill our requirements in case q = 3.
         # TODO: This idea does not work for d = 2, q = 3 because
-        # in then, L3 does not seem to have a square root with
-        # determinant 1, so that case might need hardcoding.
+        # then, L3 does not seem to have a square root with
+        # determinant -1, so that case might need hardcoding.
         L2 := IdentityMat(d, field);
         L2[1, 2] := -one;
         L2[d, d] := -one;

--- a/gap/Utils.gi
+++ b/gap/Utils.gi
@@ -598,11 +598,13 @@ function(epsilon, d, q)
 end);
 
 # Construct standard generators L1, L2, L3 as used in [HR10]
-# with the following properties:
+# with the following properties similar to Theorem 3.11 in [HR10]:
 #   * L1 and L2 generate GL(d, q)
 #   * L1 and L3 generate SL(d, q)
-#   * all matrix entries lie in {0, \pm 1, \pm zeta^{\pm 1}} where zeta is
-#       a primitive element of GF(q)
+#   * all matrix entries lie in {0, \pm 1, \pm zeta^{\pm 1}}, where
+#       zeta is a primitive element of GF(q)
+#   * If q is odd, L1 and L2^2 generate the unique subgroup
+#       of index 2 of GL(d, q), often denoted (1 / 2) GL(d, q).
 # Construction as in [T87]
 BindGlobal("StandardGeneratorsOfLinearGroup",
 function(d, q)
@@ -617,6 +619,15 @@ function(d, q)
         L1 := [[one]];
         L2 := [[zeta]];
         L3 := [[one]];
+
+    elif d = 2 and q = 3 then
+
+        L1 := [[-one, one], [-one, 0 * one]];
+        L2 := [[-one, one], [one, 0 * one]];
+
+        # This is precisely L2^2, which is how we ensure that
+        # L1 and L2^2 = L3 generate (1 / 2) GL(2, 3) = SL(2, 3).
+        L3 := [[-one, -one], [-one, one]];
 
     elif q in [2, 3] then
 
@@ -634,9 +645,10 @@ function(d, q)
         # so L1 and L2 must already generate GL(d, 3).
         # This differs from the matrix given in [T87] because
         # [T87] does not fulfill our requirements in case q = 3.
-        # TODO: This idea does not work for d = 2, q = 3 because
+        # This idea does not work for d = 2, q = 3 because
         # then, L3 does not seem to have a square root with
-        # determinant -1, so that case might need hardcoding.
+        # determinant -1, which is why we handle that case
+        # seperately above.
         L2 := IdentityMat(d, field);
         L2[1, 2] := -one;
         L2[d, d] := -one;

--- a/tst/quick/Utils.tst
+++ b/tst/quick/Utils.tst
@@ -224,15 +224,20 @@ gap> TestStandardGeneratorsOfLinearGroup := function(d, q)
 > end;;
 
 gap> TestStandardGeneratorsOfLinearGroup(1, 2);
+gap> TestStandardGeneratorsOfLinearGroup(1, 3);
+gap> TestStandardGeneratorsOfLinearGroup(1, 4);
 gap> TestStandardGeneratorsOfLinearGroup(1, 5);
 gap> TestStandardGeneratorsOfLinearGroup(2, 2);
 gap> TestStandardGeneratorsOfLinearGroup(2, 3);
+gap> TestStandardGeneratorsOfLinearGroup(2, 4);
 gap> TestStandardGeneratorsOfLinearGroup(2, 5);
 gap> TestStandardGeneratorsOfLinearGroup(4, 2);
 gap> TestStandardGeneratorsOfLinearGroup(4, 3);
+gap> TestStandardGeneratorsOfLinearGroup(4, 4);
 gap> TestStandardGeneratorsOfLinearGroup(4, 5);
 gap> TestStandardGeneratorsOfLinearGroup(5, 2);
 gap> TestStandardGeneratorsOfLinearGroup(5, 3);
+gap> TestStandardGeneratorsOfLinearGroup(5, 4);
 gap> TestStandardGeneratorsOfLinearGroup(5, 5);
 
 # Test error handling

--- a/tst/quick/Utils.tst
+++ b/tst/quick/Utils.tst
@@ -231,6 +231,9 @@ gap> TestStandardGeneratorsOfLinearGroup := function(d, q)
 >   Assert(0, not Determinant(L2) in [0, 1]);
 >   Assert(0, Size(S) = SizeSL(d, q));
 >   Assert(0, Size(G) = SizeGL(d, q));
+>   if IsOddInt(q) then
+>       Assert(0, Size(Group(L1, L2^2)) = QuoInt(SizeGL(d, q), 2));
+>   fi;
 >   Assert(0, ForAll(L1, row -> IsSubset(entrySet, row)));
 >   Assert(0, ForAll(L2, row -> IsSubset(entrySet, row)));
 >   Assert(0, ForAll(L3, row -> IsSubset(entrySet, row)));

--- a/tst/quick/Utils.tst
+++ b/tst/quick/Utils.tst
@@ -200,6 +200,41 @@ gap> TestStandardGeneratorsOfOrthogonalGroup(-1, 2, 8);
 gap> TestStandardGeneratorsOfOrthogonalGroup(1, 6, 8);
 gap> TestStandardGeneratorsOfOrthogonalGroup(-1, 6, 8);
 
+gap> TestStandardGeneratorsOfLinearGroup := function(d, q)
+>   local gens, field, one, zeta, entrySet, L1, L2, L3, S, G;
+>   gens := StandardGeneratorsOfLinearGroup(d, q);
+>   field := GF(q);
+>   one := One(field);
+>   zeta := PrimitiveElement(field);
+>   entrySet := [Zero(field), one, -one, zeta, -zeta, zeta ^ (-1), -zeta ^ (-1)];
+>   L1 := gens.L1;
+>   L2 := gens.L2;
+>   L3 := gens.L3;
+>   S := MatrixGroup(field, [L1, L3]);
+>   G := MatrixGroup(field, [L1, L2]);
+>   Assert(0, IsSubsetSL(d, q, S));
+>   Assert(0, DimensionsMat(L2) = [d, d]);
+>   Assert(0, DefaultFieldOfMatrix(L2) = field);
+>   Assert(0, not Determinant(L2) in [0, 1]);
+>   Assert(0, Size(S) = SizeSL(d, q));
+>   Assert(0, Size(G) = SizeGL(d, q));
+>   Assert(0, ForAll(L1, row -> IsSubset(entrySet, row)));
+>   Assert(0, ForAll(L2, row -> IsSubset(entrySet, row)));
+>   Assert(0, ForAll(L3, row -> IsSubset(entrySet, row)));
+> end;;
+
+gap> TestStandardGeneratorsOfLinearGroup(1, 2);
+gap> TestStandardGeneratorsOfLinearGroup(1, 5);
+gap> TestStandardGeneratorsOfLinearGroup(2, 2);
+gap> TestStandardGeneratorsOfLinearGroup(2, 3);
+gap> TestStandardGeneratorsOfLinearGroup(2, 5);
+gap> TestStandardGeneratorsOfLinearGroup(4, 2);
+gap> TestStandardGeneratorsOfLinearGroup(4, 3);
+gap> TestStandardGeneratorsOfLinearGroup(4, 5);
+gap> TestStandardGeneratorsOfLinearGroup(5, 2);
+gap> TestStandardGeneratorsOfLinearGroup(5, 3);
+gap> TestStandardGeneratorsOfLinearGroup(5, 5);
+
 # Test error handling
 gap> StandardOrthogonalForm(2, 5, 5);
 Error, <epsilon> must be one of -1, 0, 1

--- a/tst/quick/Utils.tst
+++ b/tst/quick/Utils.tst
@@ -40,6 +40,8 @@ true
 gap> x := SolveFrobeniusEquation("P", - Z(7) ^ 0, 7);;
 gap> x * x ^ 7 = - Z(7) ^ 0;
 true
+
+#
 gap> TestFindGamma := function(q)
 >   local gamma, R, x;
 >   gamma := FindGamma(q);
@@ -50,6 +52,8 @@ gap> TestFindGamma := function(q)
 gap> TestFindGamma(8);
 gap> TestFindGamma(2 ^ 7);
 gap> TestFindGamma(2 ^ 13);
+
+#
 gap> TestSolveQuadraticEquation := function(args)
 >   local F, a, b, c;
 >   F := args[1];
@@ -62,6 +66,8 @@ gap> TestSolveQuadraticEquation := function(args)
 gap> TestSolveQuadraticEquation([GF(2), Z(2), 0 * Z(2), Z(2)]);
 gap> TestSolveQuadraticEquation([GF(4), Z(4), Z(4) ^ 3, Z(4) ^ 2]);
 gap> TestSolveQuadraticEquation([GF(2 ^ 19), Z(2 ^ 19) ^ 0, Z(2 ^ 19) ^ 113, Z(2 ^ 19) ^ (-1)]);
+
+#
 gap> TestFancySpinorNorm := function(args)
 >   local epsilon, d, q, GroupOmega, GroupSO;
 >   epsilon := args[1];
@@ -78,6 +84,8 @@ gap> TestFancySpinorNorm([0, 3, 7]);
 gap> TestFancySpinorNorm([1, 4, 5]);
 gap> TestFancySpinorNorm([1, 4, 8]);
 gap> TestFancySpinorNorm([-1, 6, 4]);
+
+#
 gap> TestGeneratorsOfOrthogonalGroup := function(args)
 >   local epsilon, n, q, F, zeta, gen, gens, rightDets, gramMatrix, rightForm;
 >   epsilon := args[1];
@@ -147,6 +155,8 @@ gap> testsMatrixGroup := [[GF(3 ^ 2), Z(3) * IdentityMat(2, GF(3)), 37],
 >                         [GF(5 ^ 2), Z(5) * IdentityMat(2, GF(5)), 73]];;
 gap> ForAll(testsMatrixGroup, TestMatrixGroup);
 true
+
+#
 gap> for n in [2, 4 .. 10] do for q in [2, 3, 4, 5, 7, 8, 9] do if SizeSp(n, q) <> Size(Sp(n, q)) then Error("bad result for Sp(", n, ", ", q, ")"); fi; od; od;
 gap> for n in [2, 4, 6] do for q in [2, 3, 4, 5, 7] do if SizePSp(n, q) <> Size(PSp(n, q)) then Error("bad result for PSp(", n, ", ", q, ")"); fi; od; od;
 gap> for n in [2 .. 10] do for q in [2, 3, 4, 5, 7, 8, 9] do if SizeSU(n, q) <> Size(SU(n, q)) then Error("bad result for SU(", n, ", ", q, ")"); fi; od; od;
@@ -158,6 +168,8 @@ gap> for n in [2, 4 .. 10] do for q in [2, 3, 4, 5, 7, 8, 9] do if SizeGO(-1, n,
 gap> for n in [3, 5 .. 9] do for q in [2, 3, 4, 5, 7, 8, 9] do if SizeSO(0, n, q) <> Size(SO(0, n, q)) then Error("bad result for SO(0, ", n, ", ", q, ")"); fi; od; od;
 gap> for n in [2, 4 .. 10] do for q in [2, 3, 4, 5, 7, 8, 9] do if SizeSO(1, n, q) <> Size(SO(1, n, q)) then Error("bad result for SO(1, ", n, ", ", q, ")"); fi; od; od;
 gap> for n in [2, 4 .. 10] do for q in [2, 3, 4, 5, 7, 8, 9] do if SizeSO(-1, n, q) <> Size(SO(-1, n, q)) then Error("bad result for SO(1, ", n, ", ", q, ")"); fi; od; od;
+
+#
 gap> TestStandardGeneratorsOfOrthogonalGroup := function(epsilon, d, q)
 >   local gens, generatorsOfOmega, S, G, D, standardForms, F, Q, field, one,
 >   e, p, applyDToF, applyDToQ;
@@ -200,6 +212,7 @@ gap> TestStandardGeneratorsOfOrthogonalGroup(-1, 2, 8);
 gap> TestStandardGeneratorsOfOrthogonalGroup(1, 6, 8);
 gap> TestStandardGeneratorsOfOrthogonalGroup(-1, 6, 8);
 
+#
 gap> TestStandardGeneratorsOfLinearGroup := function(d, q)
 >   local gens, field, one, zeta, entrySet, L1, L2, L3, S, G;
 >   gens := StandardGeneratorsOfLinearGroup(d, q);
@@ -222,7 +235,6 @@ gap> TestStandardGeneratorsOfLinearGroup := function(d, q)
 >   Assert(0, ForAll(L2, row -> IsSubset(entrySet, row)));
 >   Assert(0, ForAll(L3, row -> IsSubset(entrySet, row)));
 > end;;
-
 gap> TestStandardGeneratorsOfLinearGroup(1, 2);
 gap> TestStandardGeneratorsOfLinearGroup(1, 3);
 gap> TestStandardGeneratorsOfLinearGroup(1, 4);


### PR DESCRIPTION
Implement standard generators of groups S and G in cases L, S, U with the requirements of Theorem 3.11 in [HR10]. This is needed for future constructions in the O case.
The constructions are given in [T87], which I was not able to cite very well, presumably since according to [Taylor's website](https://www.maths.usyd.edu.au/u/don/publications.html), it is only a technical report and not a research paper (I can't seem to find any fitting URL or doi, I also cannot find it in the library of the TU Kaiserslautern or of the University of Sydney).
This report also does not seem to fit Theorem 3.11 in [HR10] perfectly, so I'm taking some creative liberties to ensure that the generators are suitable for future constructions.

## Checklist for the reviewer
### General
- [ ] All functions have unit tests

### Functions constructing generators of maximal subgroups
- [ ] The code which computes and then stores the sizes is correct. To do this one confers to the tables referenced by the code.
- [ ] The test suite checks whether all constructed generators are sensible. That is it tests the generators'
  - [ ] determinants (and if applicable also the spinor norms are correct), and
  - [ ] compatibility with the correct form,
  - [ ] `DefaultFieldOfMatrixGroup` returns the correct field.

### Functions assembling the list of all maximal subgroups of a certain group
- [ ] The code agrees with the tables in section 8.2 of the book "The Maximal Subgroups of the Low-dimensional Finite Classical Groups".

The reviewer doesn't need to compare our results to magma's results. That's the job of the person implementing the code.
