### PR TITLE
Set quadratic forms

### DIFF
--- a/gap/Forms.gi
+++ b/gap/Forms.gi
@@ -1,3 +1,25 @@
+# Compute the Gram matrix of the quadratic form corresponding to the bilinear
+# form described by <gramMatrix> in odd characteristic.
+BindGlobal("BilinearToQuadraticForm",
+function(gramMatrix)
+    local F, n, i, Q;
+
+    F := DefaultFieldOfMatrix(gramMatrix);
+
+    if Characteristic(F) = 2 then
+        ErrorNoReturn("Characteristic must be odd");
+    fi;
+
+    n := NrRows(gramMatrix);
+    Q := List(gramMatrix, ShallowCopy);
+    for i in [1..n] do
+        Q{[i]}{[i + 1..n]} := NullMat(1, n - i, F);
+        Q[i, i] := 1 / 2 * gramMatrix[i, i];
+    od;
+
+    return Q;
+end);
+
 # One needs to ensure that the attribute DefaultFieldOfMatrixGroup is set
 # correctly for <group>; this can be done, for example, by making the
 # generators used during construction of the group immutable matrices over the
@@ -77,8 +99,10 @@ function(group, type, gramMatrix)
         result := group;
     fi;
 
-    if type = "S" or type = "O-B" then
+    if type = "S" then
         SetInvariantBilinearForm(result, rec(matrix := gramMatrix));
+    elif type = "O-B" then
+        SetInvariantQuadraticFormFromMatrix(result, BilinearToQuadraticForm(gramMatrix));
     elif type = "U" then
         SetInvariantSesquilinearForm(result, rec(matrix := gramMatrix));
     else

--- a/gap/ReducibleMatrixGroups.gi
+++ b/gap/ReducibleMatrixGroups.gi
@@ -503,7 +503,8 @@ end);
 # Construction as in Lemma 4.3 of [HR10]
 BindGlobal("OmegaStabilizerOfNonDegenerateSubspace",
 function(epsilon, d, q, epsilon_0, k)
-    local m, epsilon_1, epsilon_2, orthogonal_gens_1, orthogonal_gens_2, field, gens, gen_1, gen_2, H, size, H_5, H_6, Q, F, result;
+    local m, epsilon_1, epsilon_2, orthogonal_gens_1, orthogonal_gens_2, 
+    field, gens, gen_1, gen_2, H, size, H_5, H_6, Q, result;
 
     # All of the conditions below follow from the general rules of
     # orthogonal groups as well as Table 1 from [HR10], except we
@@ -621,14 +622,7 @@ function(epsilon, d, q, epsilon_0, k)
         H_5{[k + 1..d]}{[k + 1..d]} := orthogonal_gens_2.S;
         Add(gens, H_5);
 
-        # The constructed group preserves this form matrix.
-        Q := IdentityMat(d, field);
-        Q{[1..k]}{[1..k]} := StandardOrthogonalForm(epsilon_1, k, q).Q;
-        Q{[k + 1..d]}{[k + 1..d]} := StandardOrthogonalForm(epsilon_2, d - k, q).Q;
-
-        result := MatrixGroupWithSize(field, gens, QuoInt(size, 2));
-        SetInvariantQuadraticForm(result, rec(matrix := Q));
-
+        size := QuoInt(size, 2);
     else
 
         # The matrices G have spinor norm 1 and determinant -1
@@ -645,16 +639,15 @@ function(epsilon, d, q, epsilon_0, k)
             H_6{[k + 1..d]}{[k + 1..d]} := orthogonal_gens_2.S;
             Add(gens, H_6);
         fi;
-
-        # The constructed group preserves this form matrix.
-        F := IdentityMat(d, field);
-        F{[1..k]}{[1..k]} := StandardOrthogonalForm(epsilon_1, k, q).F;
-        F{[k + 1..d]}{[k + 1..d]} := StandardOrthogonalForm(epsilon_2, d - k, q).F;
-
-        result := MatrixGroupWithSize(field, gens, size);
-        SetInvariantBilinearForm(result, rec(matrix := F));
-
     fi;
+
+    # The constructed group preserves this form matrix.
+    Q := IdentityMat(d, field);
+    Q{[1..k]}{[1..k]} := StandardOrthogonalForm(epsilon_1, k, q).Q;
+    Q{[k + 1..d]}{[k + 1..d]} := StandardOrthogonalForm(epsilon_2, d - k, q).Q;
+
+    result := MatrixGroupWithSize(field, gens, size);
+    SetInvariantQuadraticFormFromMatrix(result, Q);
 
     if epsilon = -1 then
         return ConjugateToStandardForm(result, "O-");


### PR DESCRIPTION
Modify `ConjugateToSesquilinearForm` so that the quadratic form is also set at the end.

## Checklist for the reviewer
### General
- [ ] All functions have unit tests

### Functions constructing generators of maximal subgroups
- [ ] The code which computes and then stores the sizes is correct. To do this one confers to the tables referenced by the code.
- [ ] The test suite checks whether all constructed generators are sensible. That is it tests the generators'
  - [ ] determinants (and if applicable also the spinor norms are correct), and
  - [ ] compatibility with the correct form,
  - [ ] `DefaultFieldOfMatrixGroup` returns the correct field.

### Functions assembling the list of all maximal subgroups of a certain group
- [ ] The code agrees with the tables in section 8.2 of the book "The Maximal Subgroups of the Low-dimensional Finite Classical Groups".

The reviewer doesn't need to compare our results to magma's results. That's the job of the person implementing the code.
