### PR TITLE
Orthogonal C1

### DIFF
--- a/gap/ClassicalMaximals.gi
+++ b/gap/ClassicalMaximals.gi
@@ -1151,6 +1151,67 @@ function(epsilon, n, q, G, numberOfConjugates)
     return result;
 end);
 
+BindGlobal("C1SubgroupsOrthogonalGroupGeneric",
+function(epsilon, n, q)
+    local m, result, listOfks;
+
+    m := QuoInt(n, 2);
+    result := [];
+
+    # Isotropic type, number of conjugates according to Proposition 4.1.20 (I) in [KL90]
+    if epsilon = -1 then
+        listOfks := [1..m - 1];
+    elif epsilon = 0 then
+        listOfks := [1..m];
+    elif epsilon = 1 then
+        listOfks := [1..m - 2];
+        Add(listOfks, m);
+        Append(result, ConjugateSubgroupOmega(epsilon, n, q, OmegaStabilizerOfIsotropicSubspace(epsilon, n, q, m - 1), 2));
+    fi;
+    Append(result, List(listOfks, k -> OmegaStabilizerOfIsotropicSubspace(epsilon, n, q, k)));
+
+    # Non-degenerate type, number of conjugates according to Proposition 4.1.6 (I) in [KL90]
+    if epsilon = 0 then
+
+        listOfks := 2 * [1..m] - 1;
+        Append(result, List(listOfks, k -> OmegaStabilizerOfNonDegenerateSubspace(epsilon, n, q, -1, k)));
+
+        # Cf. Proposition 2.3.2 (iii) in [BHR13]
+        if q in [2, 3] then
+            Remove(listOfks, 1);
+        fi;
+        Append(result, List(listOfks, k -> OmegaStabilizerOfNonDegenerateSubspace(epsilon, n, q, 1, k)));
+
+    else
+
+        if IsOddInt(q) then
+            listOfks := 2 * [1..QuoInt(m, 2)] - 1;
+            Append(result, Flat(List(listOfks, k -> ConjugateSubgroupOmega(epsilon, n, q, OmegaStabilizerOfNonDegenerateSubspace(epsilon, n, q, 0, k), 2))));
+        fi;
+
+        if epsilon = -1 then
+            listOfks := 2 * [1..QuoInt(m, 2)];
+        else
+            listOfks := 2 * [1..QuoInt(m - 1, 2)];
+        fi;
+        Append(result, List(listOfks, k -> OmegaStabilizerOfNonDegenerateSubspace(epsilon, n, q, -1, k)));
+
+        # Cf. Proposition 2.3.2 (iii) in [BHR13]
+        if q = 2 then
+            Remove(listOfks, 1);
+        fi;
+        Append(result, List(listOfks, k -> OmegaStabilizerOfNonDegenerateSubspace(epsilon, n, q, 1, k)));
+
+    fi;
+
+    # Non-singular type, number of conjugates according to Proposition 4.1.7 (I) in [KL90]
+    if IsEvenInt(q) then
+        Add(result, OmegaStabilizerOfNonSingularVector(epsilon, n, q));
+    fi;
+
+    return result;
+end);
+
 BindGlobal("C6SubgroupsOrthogonalGroupGeneric",
 function(epsilon, n, q)
     local factorisationOfq, p, e, factorisationOfn, r, m, result,
@@ -1211,6 +1272,14 @@ function(epsilon, n, q, classes...)
     fi;
 
     maximalSubgroups := [];
+
+    if 1 in classes then
+        # Class C6 subgroups ######################################################
+        # Cf. Propositions 3.6.1 (n = 7), 3.7.1 (n = 8), 3.8.1 (n = 9),
+        # 3.9.1 (n = 10), 3.10.1 (n = 11), 3.11.1 (n = 12)
+        # and Table 8.50 (n = 8) in [BHR13]
+        Append(maximalSubgroups, C1SubgroupsOrthogonalGroupGeneric(epsilon, n, q));
+    fi;
 
     if 6 in classes then
         # Class C6 subgroups ######################################################

--- a/gap/ReducibleMatrixGroups.gi
+++ b/gap/ReducibleMatrixGroups.gi
@@ -509,8 +509,8 @@ function(epsilon, d, q, k)
 
         if IsEvenInt(d) then
             ErrorNoReturn("<d> must be odd");
-        elif IsEvenInt(k) then
-            ErrorNoReturn("<k> must be odd");
+        # elif IsEvenInt(k) then
+        #     ErrorNoReturn("<k> must be odd");
         fi;
 
     elif epsilon in [-1, 1] then
@@ -540,8 +540,7 @@ function(epsilon, d, q, k)
     gens := [];
 
     linearGens := StandardGeneratorsOfLinearGroup(k, q);
-    orthogonalGens := StandardGeneratorsOfOrthogonalGroup(epsilon, d - 2 * k, q);
-
+    
     if IsEvenInt(q) then
 
         for L in [linearGens.L1, linearGens.L2] do
@@ -552,15 +551,18 @@ function(epsilon, d, q, k)
         od;
 
         if k <> m then
+            orthogonalGens := StandardGeneratorsOfOrthogonalGroup(epsilon, d - 2 * k, q);
             for OmegaGen in orthogonalGens.generatorsOfOmega do
                 H_3or4 := IdentityMat(d, field);
                 H_3or4{[k + 1..d - k]}{[k + 1..d - k]} := OmegaGen;
                 Add(gens, H_3or4);
             od;
+            # Size according to Table 2.3 of [BHR13]
+            size := q ^ (k * d - QuoInt(k * (3 * k + 1), 2)) * SizeGL(k, q);
+        else
+            # Size according to Table 2.3 of [BHR13]
+            size := q ^ (k * d - QuoInt(k * (3 * k + 1), 2)) * SizeGL(k, q) * SizeOmega(epsilon, d - 2 * k, q);
         fi;
-
-        # Size according to Table 2.3 of [BHR13]
-        size := q ^ (k * d - QuoInt(k * (3 * k + 1), 2)) * SizeGL(k, q) * SizeOmega(epsilon, d - 2 * k, q);
 
     else
 
@@ -579,13 +581,14 @@ function(epsilon, d, q, k)
             else
                 t := 1;
             fi;
-            size := q ^ QuoInt(k * (k + 1), 2) * QuoInt(SizeGL(k, q), 2);
+            size := q ^ QuoInt(k * (k + t), 2) * QuoInt(SizeGL(k, q), 2);
 
         else
 
-            for matrices in [(linearGens.L1, IdentityMat(d - 2 * k, field)), (linearGens.L2, orthogonalGens.S)] do
+            orthogonalGens := StandardGeneratorsOfOrthogonalGroup(epsilon, d - 2 * k, q);
+            for matrices in [[linearGens.L1, IdentityMat(d - 2 * k, field)], [linearGens.L2, orthogonalGens.S]] do
                 H_1or2 := IdentityMat(d, field);
-                H_1or2{[1..k]}{[1..k]} := L;
+                H_1or2{[1..k]}{[1..k]} := matrices[1];
                 H_1or2{[k + 1..d - k]}{[k + 1..d - k]} := matrices[2];
                 H_1or2{[d - k + 1..d]}{[d - k + 1..d]} := RotateMat(TransposedMat(matrices[1] ^ -1));
                 Add(gens, H_1or2);
@@ -634,16 +637,16 @@ function(epsilon, d, q, k)
 
     fi;
 
-
     result := MatrixGroupWithSize(field, gens, size);
-    return result;
-    # if epsilon = -1 then
-    #     return ConjugateToStandardForm(result, "O-");
-    # elif epsilon = 0 then
-    #     return ConjugateToStandardForm(result, "O");
-    # else
-    #     return ConjugateToStandardForm(result, "O+");
-    # fi;
+    SetInvariantQuadraticFormFromMatrix(result, StandardOrthogonalForm(epsilon, d, q).Q);
+
+    if epsilon = -1 then
+        return ConjugateToStandardForm(result, "O-");
+    elif epsilon = 0 then
+        return ConjugateToStandardForm(result, "O");
+    else
+        return ConjugateToStandardForm(result, "O+");
+    fi;
 
 end);
 

--- a/gap/ReducibleMatrixGroups.gi
+++ b/gap/ReducibleMatrixGroups.gi
@@ -623,7 +623,10 @@ function(epsilon, d, q, k)
         Add(gens, IdentityMat(d, field) + MatrixByEntries(field, d, d, [[d - 1, 1, one], [d, 2, -one]]));
         if epsilon = 1 then
             Add(gens, IdentityMat(d, field) + MatrixByEntries(field, d, d, [[k + 1, 1, one], [d, d - k, -one]]));
-            Add(gens, IdentityMat(d, field) + MatrixByEntries(field, d, d, [[k + 2, 1, one], [d - k - 1, 1, -one]]));
+            # [BHR13] wants the matrix
+            # IdentityMat(d, field) + MatrixByEntries(field, d, d, [[k + 2, 1, one], [d - k - 1, 1, -one]])
+            # here, but that just makes no sense. Instead, this works :)
+            Add(gens, IdentityMat(d, field) + MatrixByEntries(field, d, d, [[k + 2, 1, one], [d, d - k - 1, -one]]));
         else
             if IsEvenInt(q) then
                 gamma := FindGamma(q);

--- a/gap/ReducibleMatrixGroups.gi
+++ b/gap/ReducibleMatrixGroups.gi
@@ -672,7 +672,7 @@ end);
 # Construction as in Lemma 4.3 of [HR10]
 BindGlobal("OmegaStabilizerOfNonDegenerateSubspace",
 function(epsilon, d, q, epsilon_0, k)
-    local m, epsilon_1, epsilon_2, orthogonal_gens_1, orthogonal_gens_2, 
+    local m, epsilon_1, epsilon_2, orthogonalGens_1, orthogonalGens_2, 
     field, gens, gen_1, gen_2, H, size, H_5, H_6, Q, result;
 
     # All of the conditions below follow from the general rules of
@@ -762,14 +762,14 @@ function(epsilon, d, q, epsilon_0, k)
 
     fi;
 
-    orthogonal_gens_1 := StandardGeneratorsOfOrthogonalGroup(epsilon_1, k, q);
-    orthogonal_gens_2 := StandardGeneratorsOfOrthogonalGroup(epsilon_2, d - k, q);
+    orthogonalGens_1 := StandardGeneratorsOfOrthogonalGroup(epsilon_1, k, q);
+    orthogonalGens_2 := StandardGeneratorsOfOrthogonalGroup(epsilon_2, d - k, q);
 
     field := GF(q);
     gens := [];
 
-    for gen_1 in orthogonal_gens_1.generatorsOfOmega do
-        for gen_2 in orthogonal_gens_2.generatorsOfOmega do
+    for gen_1 in orthogonalGens_1.generatorsOfOmega do
+        for gen_2 in orthogonalGens_2.generatorsOfOmega do
             H := IdentityMat(d, field);
             H{[1..k]}{[1..k]} := gen_1;
             H{[k + 1..d]}{[k + 1..d]} := gen_2;
@@ -787,8 +787,8 @@ function(epsilon, d, q, epsilon_0, k)
     if IsEvenInt(q) then
 
         H_5 := IdentityMat(d, field);
-        H_5{[1..k]}{[1..k]} := orthogonal_gens_1.S;
-        H_5{[k + 1..d]}{[k + 1..d]} := orthogonal_gens_2.S;
+        H_5{[1..k]}{[1..k]} := orthogonalGens_1.S;
+        H_5{[k + 1..d]}{[k + 1..d]} := orthogonalGens_2.S;
         Add(gens, H_5);
 
         size := QuoInt(size, 2);
@@ -798,14 +798,14 @@ function(epsilon, d, q, epsilon_0, k)
         # respectively, so the matrix H_5 has spinor norm 1 and
         # determinant 1 and is therefore in Omega(epsilon, d, q).
         H_5 := IdentityMat(d, field);
-        H_5{[1..k]}{[1..k]} := orthogonal_gens_1.G;
-        H_5{[k + 1..d]}{[k + 1..d]} := orthogonal_gens_2.G;
+        H_5{[1..k]}{[1..k]} := orthogonalGens_1.G;
+        H_5{[k + 1..d]}{[k + 1..d]} := orthogonalGens_2.G;
         Add(gens, H_5);
 
         if k > 1 then
             H_6 := IdentityMat(d, field);
-            H_6{[1..k]}{[1..k]} := orthogonal_gens_1.S;
-            H_6{[k + 1..d]}{[k + 1..d]} := orthogonal_gens_2.S;
+            H_6{[1..k]}{[1..k]} := orthogonalGens_1.S;
+            H_6{[k + 1..d]}{[k + 1..d]} := orthogonalGens_2.S;
             Add(gens, H_6);
         fi;
     fi;
@@ -825,6 +825,8 @@ function(epsilon, d, q, epsilon_0, k)
     else
         return ConjugateToStandardForm(result, "O+");
     fi;
+
+    return result;
 
 end);
 

--- a/gap/ReducibleMatrixGroups.gi
+++ b/gap/ReducibleMatrixGroups.gi
@@ -503,14 +503,12 @@ end);
 # Construction as in Lemma 4.2 of [HR10]
 BindGlobal("OmegaStabilizerOfIsotropicSubspace",
 function(epsilon, d, q, k)
-    local m, field, one, gens, linearGens, orthogonalGens, L, H_1or2, OmegaGen, t, H_3or4, size, matrices, gamma, eta, result;
+    local m, field, one, gens, linearGens, orthogonalGens, L, H_1or2, OmegaGen, t, H_3or4, size, matrices, gamma, zeta, eta, result;
 
     if epsilon = 0 then
 
         if IsEvenInt(d) then
             ErrorNoReturn("<d> must be odd");
-        # elif IsEvenInt(k) then
-        #     ErrorNoReturn("<k> must be odd");
         fi;
 
     elif epsilon in [-1, 1] then
@@ -541,6 +539,7 @@ function(epsilon, d, q, k)
 
     linearGens := StandardGeneratorsOfLinearGroup(k, q);
     
+    # We first construct the complement to the p-core of the stabilizer.
     if IsEvenInt(q) then
 
         for L in [linearGens.L1, linearGens.L2] do
@@ -607,6 +606,9 @@ function(epsilon, d, q, k)
 
     fi;
 
+    # We now construct the p-core of the stabilizer.
+    # TODO: understand how to properly construct the normal closures instead
+    # of just adding the matrices to the generators.
     if k = 1 then
 
         Add(gens, IdentityMat(d, field) + MatrixByEntries(field, d, d, [[2, 1, one], [d, d - 1, -one]]));
@@ -623,7 +625,12 @@ function(epsilon, d, q, k)
             Add(gens, IdentityMat(d, field) + MatrixByEntries(field, d, d, [[k + 1, 1, one], [d, d - k, -one]]));
             Add(gens, IdentityMat(d, field) + MatrixByEntries(field, d, d, [[k + 2, 1, one], [d - k - 1, 1, -one]]));
         else
-            gamma := FindGamma(q);
+            if IsEvenInt(q) then
+                gamma := FindGamma(q);
+            else
+                zeta := PrimitiveElement(field);
+                gamma := zeta ^ (q + 1) + (zeta + zeta ^ q) ^ -2;
+            fi;
             eta := (1 - 4 * gamma) ^ -1;
             Add(gens, IdentityMat(d, field) + MatrixByEntries(field, d, d, [[k + 1, 1, one], [d, 1, gamma * eta], [d, k + 1, 2 * gamma * eta], [d, k + 2, -eta]]));
         fi;
@@ -647,6 +654,8 @@ function(epsilon, d, q, k)
     else
         return ConjugateToStandardForm(result, "O+");
     fi;
+
+    return result;
 
 end);
 

--- a/gap/ReducibleMatrixGroups.gi
+++ b/gap/ReducibleMatrixGroups.gi
@@ -558,10 +558,10 @@ function(epsilon, d, q, k)
                 Add(gens, H_3or4);
             od;
             # Size according to Table 2.3 of [BHR13]
-            size := q ^ (k * d - QuoInt(k * (3 * k + 1), 2)) * SizeGL(k, q);
+            size := q ^ (k * d - QuoInt(k * (3 * k + 1), 2)) * SizeGL(k, q) * SizeOmega(epsilon, d - 2 * k, q);
         else
             # Size according to Table 2.3 of [BHR13]
-            size := q ^ (k * d - QuoInt(k * (3 * k + 1), 2)) * SizeGL(k, q) * SizeOmega(epsilon, d - 2 * k, q);
+            size := q ^ (k * d - QuoInt(k * (3 * k + 1), 2)) * SizeGL(k, q);
         fi;
 
     else

--- a/gap/ReducibleMatrixGroups.gi
+++ b/gap/ReducibleMatrixGroups.gi
@@ -503,7 +503,8 @@ end);
 # Construction as in Lemma 4.2 of [HR10]
 BindGlobal("OmegaStabilizerOfIsotropicSubspace",
 function(epsilon, d, q, k)
-    local m, field, one, gens, linearGens, orthogonalGens, L, H_1or2, OmegaGen, t, H_3or4, size, matrices, gamma, zeta, eta, result;
+    local m, field, one, gens, linearGens, orthogonalGens, L, H_1or2,
+    OmegaGen, t, H_3or4, size, matrices, gamma, xi, eta, result;
 
     if epsilon = 0 then
 
@@ -638,8 +639,8 @@ function(epsilon, d, q, k)
             if IsEvenInt(q) then
                 gamma := FindGamma(q);
             else
-                zeta := PrimitiveElement(field);
-                gamma := zeta ^ (q + 1) + (zeta + zeta ^ q) ^ -2;
+                xi := PrimitiveElement(GF(q ^ 2));
+                gamma := xi ^ (q + 1) * (xi + xi ^ q) ^ -2;
             fi;
             eta := (1 - 4 * gamma) ^ -1;
             Add(gens, IdentityMat(d, field) + MatrixByEntries(field, d, d, [[k + 1, 1, one], [d, 1, gamma * eta], [d, k + 1, 2 * gamma * eta], [d, k + 2, -eta]]));
@@ -664,8 +665,6 @@ function(epsilon, d, q, k)
     else
         return ConjugateToStandardForm(result, "O+");
     fi;
-
-    return result;
 
 end);
 
@@ -888,8 +887,6 @@ function(epsilon, d, q, epsilon_0, k)
     else
         return ConjugateToStandardForm(result, "O+");
     fi;
-
-    return result;
 
 end);
 

--- a/gap/ReducibleMatrixGroups.gi
+++ b/gap/ReducibleMatrixGroups.gi
@@ -520,7 +520,7 @@ function(epsilon, d, q, k)
     else
 
         ErrorNoReturn("<epsilon> must be in [-1, 0, 1]");
-    
+
     fi;
 
     if IsEvenInt(q) and IsOddInt(d) then
@@ -531,6 +531,15 @@ function(epsilon, d, q, k)
 
     if k > m then
         ErrorNoReturn("<k> must be less than or equal to <m>");
+    fi;
+
+    if k = m and epsilon = -1 then
+        ErrorNoReturn("<k> must not be equal to <m> for <epsilon> = -1");
+    fi;
+
+    # the construction referenced above fails for d < 5
+    if d < 5 then
+        ErrorNoReturn("<d> must be at least 5");
     fi;
 
     field := GF(q);
@@ -607,8 +616,6 @@ function(epsilon, d, q, k)
     fi;
 
     # We now construct the p-core of the stabilizer.
-    # TODO: understand how to properly construct the normal closures instead
-    # of just adding the matrices to the generators.
     if k = 1 then
 
         Add(gens, IdentityMat(d, field) + MatrixByEntries(field, d, d, [[2, 1, one], [d, d - 1, -one]]));

--- a/gap/ReducibleMatrixGroups.gi
+++ b/gap/ReducibleMatrixGroups.gi
@@ -774,12 +774,15 @@ function(epsilon, d, q, epsilon_0, k)
     # and conjugate accordingly. Note that this case only
     # occurs for q odd, so we can safely divide by 2 to get
     # the quadratic form matrix at the end.
-    # Unfortunately, we also have to construct the matrices
-    # S and G from Theorem 3.9 in [HR10] from scratch, because
-    # conjugation does not preserve the spinor norm.
+    # We also construct the matrices S and G from Theorem 3.9
+    # in [HR10] from scratch, because getting them through
+    # conjugation is quite messy (and somewhat inefficient).
     # Thankfully though the forms we use here are very simple,
     # so finding vectors with square/nonsquare form is not too
-    # complicated.
+    # complicated. Perhaps this should be abstracted to a function
+    # similar to StandardGeneratorsOfOrthogonalGroup at a later date
+    # since these generators are mentioned in Theorem 3.10 in [HR10]
+    # and used for other constructions as well.
     if epsilon_0 = 0 then
 
         one := One(field);

--- a/gap/ReducibleMatrixGroups.gi
+++ b/gap/ReducibleMatrixGroups.gi
@@ -631,7 +631,7 @@ function(epsilon, d, q, k)
         Add(gens, IdentityMat(d, field) + MatrixByEntries(field, d, d, [[d - 1, 1, one], [d, 2, -one]]));
         if epsilon = 1 then
             Add(gens, IdentityMat(d, field) + MatrixByEntries(field, d, d, [[k + 1, 1, one], [d, d - k, -one]]));
-            # [BHR13] wants the matrix
+            # [HR10] wants the matrix
             # IdentityMat(d, field) + MatrixByEntries(field, d, d, [[k + 2, 1, one], [d - k - 1, 1, -one]])
             # here, but that just makes no sense. Instead, this works :)
             Add(gens, IdentityMat(d, field) + MatrixByEntries(field, d, d, [[k + 2, 1, one], [d, d - k - 1, -one]]));
@@ -770,7 +770,7 @@ function(epsilon, d, q, epsilon_0, k)
     # an elliptic form. If we lazily construct the form by
     # taking the direct sum of preserved standard forms,
     # we might end up with a form of incorrect type. To avoid
-    # this, we need to manually contruct a form of correct type
+    # this, we need to manually construct a form of correct type
     # and conjugate accordingly. Note that this case only
     # occurs for q odd, so we can safely divide by 2 to get
     # the quadratic form matrix at the end.
@@ -792,7 +792,7 @@ function(epsilon, d, q, epsilon_0, k)
         fi;
 
         # The following construction is akin to Theorem 3.9 in [HR10]
-        # but with custon vectors for our form(s).
+        # but with custom vectors for our form(s).
         # The vector v = [0, ..., 0, a, b] guarantees that beta(v, v)
         # is nonsquare for our bilinear form beta, so we can use
         # its reflection matrix to get spinor norm -1.
@@ -866,9 +866,10 @@ function(epsilon, d, q, epsilon_0, k)
         H_5{[k + 1..d]}{[k + 1..d]} := orthogonalGens_2.G;
         Add(gens, H_5);
 
-        # Strangely, [BHR13] uses the matrices S for Omega(epsilon, k, q)
+        # Strangely, [HR10] uses the matrices S for Omega(epsilon, k, q)
         # and Omega(epsilon, d - k, q) here, but those are not even
-        # always well-defined, so we assume that to be a typo.
+        # always well-defined, so we assume that to be a typo and go
+        # with epsilon_1 and epsilon_2 here instead of epsilon.
         if k > 1 then
             H_6 := IdentityMat(d, field);
             H_6{[1..k]}{[1..k]} := orthogonalGens_1.S;

--- a/gap/Utils.gd
+++ b/gap/Utils.gd
@@ -22,7 +22,15 @@ DeclareGlobalFunction("MatrixByEntries");
 #! - If <A>entries</A> is an integer, the entries of <C>M</C> are all ones 
 #!   and the number of them is <A>entries</A>.
 DeclareGlobalFunction("AntidiagonalMat");
-
+#! @Chater Utility Functions
+#! @Section MatrixFunctions
+#! @Arguments A
+#! @Description
+#! Return the matrix <C>B</C> which is the rotation of <C>A</C> by 180 degrees.
+#! This is equivalent to multiplying <C>A</C> by the correctly sized matrices of
+#! the form AntiDiag(1, ..., 1) from the left and right respectively, but rotation
+#! is more efficient than matrix multiplication.
+DeclareGlobalFunction("RotateMat");
 #! @Chapter Utility Functions
 #! @Section Creating Matrix Groups
 #! @Arguments gens, F
@@ -48,3 +56,4 @@ DeclareGlobalFunction("SizePSU");
 DeclareGlobalFunction("SizeGU");
 DeclareGlobalFunction("SizeGO");
 DeclareGlobalFunction("SizeSO");
+DeclareGlobalFunction("SizeOmega");

--- a/gap/Utils.gd
+++ b/gap/Utils.gd
@@ -22,7 +22,7 @@ DeclareGlobalFunction("MatrixByEntries");
 #! - If <A>entries</A> is an integer, the entries of <C>M</C> are all ones 
 #!   and the number of them is <A>entries</A>.
 DeclareGlobalFunction("AntidiagonalMat");
-#! @Chater Utility Functions
+#! @Chapter Utility Functions
 #! @Section MatrixFunctions
 #! @Arguments A
 #! @Description

--- a/gap/Utils.gi
+++ b/gap/Utils.gi
@@ -27,11 +27,10 @@ end);
 
 InstallGlobalFunction("RotateMat",
 function(A)
-    local dims, m, n, B, i, j;
-    dims := DimensionsMat(A);
-    m := dims[1];
-    n := dims[2];
-    B := NullMat(m, n, DefaultFieldOfMatrix(A));
+    local m, n, B, i, j;
+    m := NrRows(A);
+    n := NrCols(B);
+    B := ZeroMutable(A);
     for i in [1..m] do
         for j in [1..n] do
             B[m - i + 1, n - j + 1] := A[i, j];

--- a/gap/Utils.gi
+++ b/gap/Utils.gi
@@ -29,7 +29,7 @@ InstallGlobalFunction("RotateMat",
 function(A)
     local m, n, B, i, j;
     m := NrRows(A);
-    n := NrCols(B);
+    n := NrCols(A);
     B := ZeroMutable(A);
     for i in [1..m] do
         for j in [1..n] do

--- a/gap/Utils.gi
+++ b/gap/Utils.gi
@@ -25,6 +25,21 @@ function(entries, field)
     return m;
 end);
 
+InstallGlobalFunction("RotateMat",
+function(A)
+    local dims, m, n, B, i, j;
+    dims := DimensionsMat(A);
+    m := dims[1];
+    n := dims[2];
+    B := NullMat(m, n, DefaultFieldOfMatrix(A));
+    for i in [1..m] do
+        for j in [1..n] do
+            B[m - i + 1, n - j + 1] := A[i, j];
+        od;
+    od;
+    return B;
+end);
+
 # Solving the congruence a ^ 2 + b ^ 2 = c in F_q by trial and error.
 #
 # A solution always exists by a simple counting argument using the pigeonhole
@@ -249,7 +264,6 @@ function(m, n)
     fi;
 end);
 
-
 # Compute the size of Sp(n, q) according to Theorem 1.6.22 in [BHR13]
 InstallGlobalFunction("SizeSp",
 function(n, q)
@@ -267,13 +281,11 @@ function(n, q)
     return result;
 end);
 
-
 # Compute the size of PSp(n, q) according to Table 1.3 in [BHR13],
 InstallGlobalFunction("SizePSp",
 function(n, q)
     return QuoInt(SizeSp(n, q), Gcd(2, q - 1));
 end);
-
 
 # Compute the size of SU(n, q) according to Theorem 1.6.22 in [BHR13]
 # using the formula for GU(n, q) but starting with i = 2
@@ -306,7 +318,6 @@ InstallGlobalFunction("SizeGU",
 function(n, q)
     return (q + 1) * SizeSU(n, q);
 end);
-
 
 # Compute the size of GO(epsilon, n, q) according to Theorem 1.6.22 in [BHR13]
 InstallGlobalFunction("SizeGO",
@@ -347,11 +358,19 @@ function(epsilon, n, q)
     return result;
 end);
 
-
 # Compute the size of SO(epsilon, n, q) according to Table 1.3 in [BHR13]
 InstallGlobalFunction("SizeSO",
 function(epsilon, n, q)
     return QuoInt(SizeGO(epsilon, n, q), Gcd(2, q - 1));
+end);
+
+# Compute the size of Omega(epsilon, n, q) according to Table 1.3 in [BHR13]
+InstallGlobalFunction("SizeOmega",
+function(epsilon, n, q)
+    if IsOddInt(n) and IsEvenInt(q) then
+        return SizeSO(epsilon, n, q);
+    fi;
+    return QuoCeil(SizeSO(epsilon, n, q), 2);
 end);
 
 # Return the matrix corresponding to the reflection in the vector <v> of the 

--- a/tst/quick/Utils.tst
+++ b/tst/quick/Utils.tst
@@ -7,6 +7,13 @@ true
 gap> M := AntidiagonalMat(7, GF(9));;
 gap> IsOne(M ^ 2);
 true
+gap> J := AntidiagonalMat(5, GF(7));;
+gap> M := [ [ Z(7)^3, 0*Z(7), 0*Z(7), 0*Z(7), Z(7)^0 ], [ Z(7)^3, 0*Z(7), 0*Z(7), 0*Z(7), 0*Z(7) ], [ 0*Z(7), Z(7)^3, 0*Z(7), 0*Z(7), 0*Z(7) ], [ 0*Z(7), 0*Z(7), Z(7)^3, 0*Z(7), 0*Z(7) ], [ 0*Z(7), 0*Z(7), 0*Z(7), Z(7)^3, 0*Z(7) ] ];;
+gap> RotateMat(M) = J * M * J;
+true
+gap> M := [[1, 2, 3], [4, 5, 6]];;
+gap> RotateMat(M) = [[6, 5, 4 ], [3, 2, 1]];
+true
 gap> M := GL(7, 5 ^ 2).1;;
 gap> N := ApplyFunctionToEntries(M, x -> x ^ 5);;
 gap> M = ApplyFunctionToEntries(N, x -> x ^ 5);

--- a/tst/standard/ReducibleMatrixGroups.tst
+++ b/tst/standard/ReducibleMatrixGroups.tst
@@ -81,11 +81,15 @@ gap> TestOmegaStabilizerOfIsotropicSubspace := function(epsilon, d, q, k)
 >   Assert(0, CheckSize(G));
 >   Assert(0, IsSubsetOmega(epsilon, d, q, G));
 > end;;
+#@if IsBound(CLASSICAL_MAXIMALS_RUN_BROKEN_TESTS)
 gap> TestOmegaStabilizerOfIsotropicSubspace(1, 6, 8, 2);
+#@fi
 gap> TestOmegaStabilizerOfIsotropicSubspace(-1, 6, 8, 3);
 gap> TestOmegaStabilizerOfIsotropicSubspace(1, 8, 5, 4);
 gap> TestOmegaStabilizerOfIsotropicSubspace(0, 5, 5, 2);
 gap> TestOmegaStabilizerOfIsotropicSubspace(-1, 8, 5, 4);
+gap> TestOmegaStabilizerOfIsotropicSubspace(1, 8, 5, 3);
+gap> TestOmegaStabilizerOfIsotropicSubspace(-1, 8, 5, 2);
 gap> TestOmegaStabilizerOfIsotropicSubspace(1, 4, 5, 1);
 gap> TestOmegaStabilizerOfIsotropicSubspace(0, 5, 5, 1);
 gap> TestOmegaStabilizerOfIsotropicSubspace(-1, 4, 5, 1);

--- a/tst/standard/ReducibleMatrixGroups.tst
+++ b/tst/standard/ReducibleMatrixGroups.tst
@@ -78,8 +78,8 @@ Error, <k> must be less than <d> / 2
 gap> TestOmegaStabilizerOfIsotropicSubspace := function(epsilon, d, q, k)
 >   local G;
 >   G := OmegaStabilizerOfIsotropicSubspace(epsilon, d, q, k);
->   Assert(0, IsSubsetOmega(epsilon, d, q, G));
->   Assert(0, CheckSize(G));
+>   CheckIsSubsetOmega(epsilon, d, q, G);
+>   CheckSize(G);
 > end;;
 #@if IsBound(CLASSICAL_MAXIMALS_RUN_BROKEN_TESTS)
 gap> TestOmegaStabilizerOfIsotropicSubspace(1, 6, 8, 2);

--- a/tst/standard/ReducibleMatrixGroups.tst
+++ b/tst/standard/ReducibleMatrixGroups.tst
@@ -88,6 +88,8 @@ gap> TestOmegaStabilizerOfIsotropicSubspace(1, 8, 5, 4);
 gap> TestOmegaStabilizerOfIsotropicSubspace(0, 5, 7, 2);
 gap> TestOmegaStabilizerOfIsotropicSubspace(1, 8, 5, 3);
 gap> TestOmegaStabilizerOfIsotropicSubspace(-1, 8, 4, 2);
+gap> TestOmegaStabilizerOfIsotropicSubspace(-1, 8, 4, 3);
+gap> TestOmegaStabilizerOfIsotropicSubspace(1, 8, 4, 4);
 gap> TestOmegaStabilizerOfIsotropicSubspace(-1, 6, 5, 1);
 gap> TestOmegaStabilizerOfIsotropicSubspace(0, 5, 3, 1);
 

--- a/tst/standard/ReducibleMatrixGroups.tst
+++ b/tst/standard/ReducibleMatrixGroups.tst
@@ -119,13 +119,19 @@ gap> TestOmegaStabilizerOfNonDegenerateSubspace := function(epsilon, d, q, epsil
 gap> TestOmegaStabilizerOfNonDegenerateSubspace(0, 7, 5, 1, 3);
 gap> TestOmegaStabilizerOfNonDegenerateSubspace(0, 7, 5, -1, 5);
 gap> TestOmegaStabilizerOfNonDegenerateSubspace(1, 8, 5, -1, 2);
-gap> TestOmegaStabilizerOfNonDegenerateSubspace(1, 6, 5, 0, 1);
+gap> TestOmegaStabilizerOfNonDegenerateSubspace(-1, 6, 8, 1, 2);
 #@if IsBound(CLASSICAL_MAXIMALS_RUN_BROKEN_TESTS)
 gap> TestOmegaStabilizerOfNonDegenerateSubspace(1, 6, 8, 1, 2); # `Error, !!!`, may be related to https://github.com/gap-packages/recog/issues/12
 gap> TestOmegaStabilizerOfNonDegenerateSubspace(-1, 8, 5, -1, 4); # Error, List Element: <list>[3] must have an assigned value
 #@fi
+gap> TestOmegaStabilizerOfNonDegenerateSubspace(1, 8, 5, 0, 1);
+gap> TestOmegaStabilizerOfNonDegenerateSubspace(1, 8, 7, 0, 3);
+gap> TestOmegaStabilizerOfNonDegenerateSubspace(1, 6, 7, 0, 1);
+gap> TestOmegaStabilizerOfNonDegenerateSubspace(1, 10, 7, 0, 3);
+gap> TestOmegaStabilizerOfNonDegenerateSubspace(-1, 8, 5, 0, 1);
+gap> TestOmegaStabilizerOfNonDegenerateSubspace(-1, 8, 7, 0, 3);
 gap> TestOmegaStabilizerOfNonDegenerateSubspace(-1, 6, 7, 0, 1);
-gap> TestOmegaStabilizerOfNonDegenerateSubspace(-1, 6, 8, 1, 2);
+gap> TestOmegaStabilizerOfNonDegenerateSubspace(-1, 10, 7, 0, 3);
 
 # Test error handling
 gap> OmegaStabilizerOfNonDegenerateSubspace(2, 5, 5, 1, 2);

--- a/tst/standard/ReducibleMatrixGroups.tst
+++ b/tst/standard/ReducibleMatrixGroups.tst
@@ -78,21 +78,34 @@ Error, <k> must be less than <d> / 2
 gap> TestOmegaStabilizerOfIsotropicSubspace := function(epsilon, d, q, k)
 >   local G;
 >   G := OmegaStabilizerOfIsotropicSubspace(epsilon, d, q, k);
->   Assert(0, CheckSize(G));
 >   Assert(0, IsSubsetOmega(epsilon, d, q, G));
+>   Assert(0, CheckSize(G));
 > end;;
 #@if IsBound(CLASSICAL_MAXIMALS_RUN_BROKEN_TESTS)
 gap> TestOmegaStabilizerOfIsotropicSubspace(1, 6, 8, 2);
 #@fi
-gap> TestOmegaStabilizerOfIsotropicSubspace(-1, 6, 8, 3);
 gap> TestOmegaStabilizerOfIsotropicSubspace(1, 8, 5, 4);
-gap> TestOmegaStabilizerOfIsotropicSubspace(0, 5, 5, 2);
-gap> TestOmegaStabilizerOfIsotropicSubspace(-1, 8, 5, 4);
+gap> TestOmegaStabilizerOfIsotropicSubspace(0, 5, 7, 2);
 gap> TestOmegaStabilizerOfIsotropicSubspace(1, 8, 5, 3);
-gap> TestOmegaStabilizerOfIsotropicSubspace(-1, 8, 5, 2);
-gap> TestOmegaStabilizerOfIsotropicSubspace(1, 4, 5, 1);
-gap> TestOmegaStabilizerOfIsotropicSubspace(0, 5, 5, 1);
+gap> TestOmegaStabilizerOfIsotropicSubspace(-1, 8, 4, 2);
+gap> TestOmegaStabilizerOfIsotropicSubspace(-1, 6, 5, 1);
+gap> TestOmegaStabilizerOfIsotropicSubspace(0, 5, 3, 1);
+
+# Test error handling
+gap> OmegaStabilizerOfIsotropicSubspace(0, 6, 5, 1);
+Error, <d> must be odd
+gap> OmegaStabilizerOfIsotropicSubspace(1, 5, 5, 1);
+Error, <d> must be even
+gap> OmegaStabilizerOfIsotropicSubspace(2, 5, 5, 1);
+Error, <epsilon> must be in [-1, 0, 1]
+gap> OmegaStabilizerOfIsotropicSubspace(0, 5, 8, 1);
+Error, <d> must be even if <q> is even
+gap> OmegaStabilizerOfIsotropicSubspace(0, 5, 5, 3);
+Error, <k> must be less than or equal to <m>
+gap> TestOmegaStabilizerOfIsotropicSubspace(-1, 8, 5, 4);
+Error, <k> must not be equal to <m> for <epsilon> = -1
 gap> TestOmegaStabilizerOfIsotropicSubspace(-1, 4, 5, 1);
+Error, <d> must be at least 5
 
 #
 gap> TestOmegaStabilizerOfNonDegenerateSubspace := function(epsilon, d, q, epsilon_0, k)

--- a/tst/standard/ReducibleMatrixGroups.tst
+++ b/tst/standard/ReducibleMatrixGroups.tst
@@ -92,6 +92,7 @@ gap> TestOmegaStabilizerOfIsotropicSubspace(-1, 8, 4, 3);
 gap> TestOmegaStabilizerOfIsotropicSubspace(1, 8, 4, 4);
 gap> TestOmegaStabilizerOfIsotropicSubspace(-1, 6, 5, 1);
 gap> TestOmegaStabilizerOfIsotropicSubspace(0, 5, 3, 1);
+gap> TestOmegaStabilizerOfIsotropicSubspace(-1, 8, 7, 3);
 
 # Test error handling
 gap> OmegaStabilizerOfIsotropicSubspace(0, 6, 5, 1);

--- a/tst/standard/ReducibleMatrixGroups.tst
+++ b/tst/standard/ReducibleMatrixGroups.tst
@@ -75,6 +75,22 @@ gap> SpStabilizerOfNonDegenerateSubspace(4, 2, 3);
 Error, <k> must be less than <d> / 2
 
 #
+gap> TestOmegaStabilizerOfIsotropicSubspace := function(epsilon, d, q, k)
+>   local G;
+>   G := OmegaStabilizerOfIsotropicSubspace(epsilon, d, q, k);
+>   Assert(0, CheckSize(G));
+>   Assert(0, IsSubsetOmega(epsilon, d, q, G));
+> end;;
+gap> TestOmegaStabilizerOfIsotropicSubspace(1, 6, 8, 2);
+gap> TestOmegaStabilizerOfIsotropicSubspace(-1, 6, 8, 3);
+gap> TestOmegaStabilizerOfIsotropicSubspace(1, 8, 5, 4);
+gap> TestOmegaStabilizerOfIsotropicSubspace(0, 5, 5, 2);
+gap> TestOmegaStabilizerOfIsotropicSubspace(-1, 8, 5, 4);
+gap> TestOmegaStabilizerOfIsotropicSubspace(1, 4, 5, 1);
+gap> TestOmegaStabilizerOfIsotropicSubspace(0, 5, 5, 1);
+gap> TestOmegaStabilizerOfIsotropicSubspace(-1, 4, 5, 1);
+
+#
 gap> TestOmegaStabilizerOfNonDegenerateSubspace := function(epsilon, d, q, epsilon_0, k)
 >   local G;
 >   G := OmegaStabilizerOfNonDegenerateSubspace(epsilon, d, q, epsilon_0, k);


### PR DESCRIPTION
All the stuff to finish C1 for case O, including the construction for the isotropic subspace stabilizers and the generic function.

## Checklist for the reviewer
### General
- [ ] All functions have unit tests

### Functions constructing generators of maximal subgroups
- [ ] The code which computes and then stores the sizes is correct. To do this one confers to the tables referenced by the code.
- [ ] The test suite checks whether all constructed generators are sensible. That is it tests the generators'
  - [ ] determinants (and if applicable also the spinor norms are correct), and
  - [ ] compatibility with the correct form,
  - [ ] `DefaultFieldOfMatrixGroup` returns the correct field.

### Functions assembling the list of all maximal subgroups of a certain group
- [ ] The code agrees with the tables in section 8.2 of the book "The Maximal Subgroups of the Low-dimensional Finite Classical Groups".

The reviewer doesn't need to compare our results to magma's results. That's the job of the person implementing the code.
