### PR TITLE
Orthogonal C5

### DIFF
--- a/gap/ClassicalMaximals.gi
+++ b/gap/ClassicalMaximals.gi
@@ -1123,10 +1123,15 @@ end);
 #       if numberOfConjugates = 8.
 BindGlobal("ConjugateSubgroupOmega",
 function(epsilon, n, q, G, numberOfConjugates)
-    local elementsToConjugate, result, powerSet, subset, exponent;
+    local elementsToConjugate, result, invariantFormRec,
+    powerSet, subset, exponent, conjugatedGroup;
 
-    if not numberOfConjugates in [2, 4, 8] then
-        ErrorNoReturn("<numberOfConjugates> must be one of 2, 4, 8");
+    if not numberOfConjugates in [1, 2, 4, 8] then
+        ErrorNoReturn("<numberOfConjugates> must be one of 1, 2, 4, 8");
+    fi;
+
+    if numberOfConjugates = 1 then
+        return [G];
     fi;
 
     elementsToConjugate := [SOMinusOmega(epsilon, n, q)];
@@ -1138,13 +1143,16 @@ function(epsilon, n, q, G, numberOfConjugates)
     fi;
 
     result := [];
+    invariantFormRec := InvariantQuadraticForm(G);
     powerSet := Combinations(elementsToConjugate);
     for subset in powerSet do
         if subset = [] then
             Add(result, G);
         else
             exponent := Product(subset);
-            Add(result, G ^ exponent);
+            conjugatedGroup := G ^ exponent;
+            SetInvariantQuadraticForm(conjugatedGroup, invariantFormRec);
+            Add(result, conjugatedGroup);
         fi;
     od;
 
@@ -1210,6 +1218,62 @@ function(epsilon, n, q)
     fi;
 
     return result;
+
+BindGlobal("C5SubgroupsOrthogonalGroupGeneric",
+function(epsilon, n, q)
+    local factorisationOfq, p, e, listOfrs, result,
+    numberOfConjugatesPlus, numberOfConjugatesMinus, r;
+
+    factorisationOfq := PrimePowersInt(q);
+    p := factorisationOfq[1];
+    e := factorisationOfq[2];
+
+    listOfrs := List(PrimeDivisors(e));
+    result := [];
+
+    if epsilon = 0 then
+
+        # number of conjugates according to [KL90] Proposition 4.5.8 (I)
+        if 2 in listOfrs then
+            Append(result, ConjugateSubgroupOmega(epsilon, n, q, SubfieldOmega(0, n, p, e, QuoInt(e, 2), 0), 2));
+            Remove(listOfrs, 1);
+        fi;
+
+    else
+
+        if 2 in listOfrs then
+
+            # number of conjugates according to [KL90] Proposition 4.5.10 (I)
+            if epsilon = 1 then
+                if IsEvenInt(q) then
+                    numberOfConjugatesPlus := 1;
+                    numberOfConjugatesMinus := 1;
+                else
+                    if n mod 4 = 2 and p ^ QuoInt(e, 2) mod 4 = 1 then
+                        numberOfConjugatesPlus := 2;
+                        numberOfConjugatesMinus := 4;
+                    else
+                        numberOfConjugatesPlus := 4;
+                        numberOfConjugatesMinus := 2;
+                    fi;
+                fi;
+                Append(result, ConjugateSubgroupOmega(epsilon, n, q, SubfieldOmega(1, n, p, e, QuoInt(e, 2), 1), numberOfConjugatesPlus));
+                Append(result, ConjugateSubgroupOmega(epsilon, n, q, SubfieldOmega(1, n, p, e, QuoInt(e, 2), -1), numberOfConjugatesMinus));
+            fi;
+            Remove(listOfrs, 1);
+
+        fi;
+
+    fi;
+
+    # The number of conjugates here is 1 according to [KL90] Proposition 4.5.8 (I)
+    # and Proposition 4.5.10 (I) since r must now be odd.
+    for r in listOfrs do
+        Add(result, SubfieldOmega(epsilon, n, p, e, QuoInt(e, r), epsilon));
+    od;
+
+    return result;
+
 end);
 
 BindGlobal("C6SubgroupsOrthogonalGroupGeneric",
@@ -1279,6 +1343,13 @@ function(epsilon, n, q, classes...)
         # 3.9.1 (n = 10), 3.10.1 (n = 11), 3.11.1 (n = 12)
         # and Table 8.50 (n = 8) in [BHR13]
         Append(maximalSubgroups, C1SubgroupsOrthogonalGroupGeneric(epsilon, n, q));
+
+    if 5 in classes then
+        # Class C5 subgroups ######################################################
+        # Cf. Propositions 3.6.3 (n = 7), 3.7.8 (n = 8), 3.8.4 (n = 9),
+        # 3.9.7 (n = 10), 3.10.3 (n = 11), 3.11.9 (n = 12) and Table 8.50 (n = 8)
+        # in [BHR13]
+        Append(maximalSubgroups, C5SubgroupsOrthogonalGroupGeneric(epsilon, n, q));
     fi;
 
     if 6 in classes then

--- a/gap/ClassicalMaximals.gi
+++ b/gap/ClassicalMaximals.gi
@@ -1218,6 +1218,7 @@ function(epsilon, n, q)
     fi;
 
     return result;
+end);
 
 BindGlobal("C5SubgroupsOrthogonalGroupGeneric",
 function(epsilon, n, q)
@@ -1271,7 +1272,6 @@ function(epsilon, n, q)
     od;
 
     return result;
-
 end);
 
 BindGlobal("C6SubgroupsOrthogonalGroupGeneric",
@@ -1341,6 +1341,7 @@ function(epsilon, n, q, classes...)
         # 3.9.1 (n = 10), 3.10.1 (n = 11), 3.11.1 (n = 12)
         # and Table 8.50 (n = 8) in [BHR13]
         Append(maximalSubgroups, C1SubgroupsOrthogonalGroupGeneric(epsilon, n, q));
+    fi;
 
     if 5 in classes then
         # Class C5 subgroups ######################################################

--- a/gap/ClassicalMaximals.gi
+++ b/gap/ClassicalMaximals.gi
@@ -1228,7 +1228,7 @@ function(epsilon, n, q)
     p := factorisationOfq[1];
     e := factorisationOfq[2];
 
-    listOfrs := List(PrimeDivisors(e));
+    listOfrs := PrimeDivisors(e);
     result := [];
 
     if epsilon = 0 then
@@ -1236,7 +1236,7 @@ function(epsilon, n, q)
         # number of conjugates according to [KL90] Proposition 4.5.8 (I)
         if 2 in listOfrs then
             Append(result, ConjugateSubgroupOmega(epsilon, n, q, SubfieldOmega(0, n, p, e, QuoInt(e, 2), 0), 2));
-            Remove(listOfrs, 1);
+            listOfrs := Difference(listOfrs, [2]);
         fi;
 
     else
@@ -1248,19 +1248,17 @@ function(epsilon, n, q)
                 if IsEvenInt(q) then
                     numberOfConjugatesPlus := 1;
                     numberOfConjugatesMinus := 1;
+                elif n mod 4 = 2 and p ^ QuoInt(e, 2) mod 4 = 1 then
+                    numberOfConjugatesPlus := 2;
+                    numberOfConjugatesMinus := 4;
                 else
-                    if n mod 4 = 2 and p ^ QuoInt(e, 2) mod 4 = 1 then
-                        numberOfConjugatesPlus := 2;
-                        numberOfConjugatesMinus := 4;
-                    else
-                        numberOfConjugatesPlus := 4;
-                        numberOfConjugatesMinus := 2;
-                    fi;
+                    numberOfConjugatesPlus := 4;
+                    numberOfConjugatesMinus := 2;
                 fi;
                 Append(result, ConjugateSubgroupOmega(epsilon, n, q, SubfieldOmega(1, n, p, e, QuoInt(e, 2), 1), numberOfConjugatesPlus));
                 Append(result, ConjugateSubgroupOmega(epsilon, n, q, SubfieldOmega(1, n, p, e, QuoInt(e, 2), -1), numberOfConjugatesMinus));
             fi;
-            Remove(listOfrs, 1);
+            listOfrs := Difference(listOfrs, [2]);
 
         fi;
 

--- a/gap/SubfieldMatrixGroups.gi
+++ b/gap/SubfieldMatrixGroups.gi
@@ -437,5 +437,6 @@ function (epsilon, d, p, e, f, epsilon_0)
     gens := List(GeneratorsOfGroup(ConjugateToSesquilinearForm(SO(epsilon_0, d, q0), "O-B", F)));
     Add(gens, A);
     result := MatrixGroupWithSize(field, gens, SizeSO(epsilon, d, q0) * 2);
+    SetInvariantBilinearForm(rec(matrix := F));
     return ConjugateToStandardForm(result, orthogonalType);
 end);

--- a/gap/SubfieldMatrixGroups.gi
+++ b/gap/SubfieldMatrixGroups.gi
@@ -301,7 +301,7 @@ function (d, p, e, f)
     b := QuoInt(e, f);
 
     if not IsPrime(b) then
-        ErrorNoReturn("the quotient of <f> by <e> must be a prime");
+        ErrorNoReturn("the quotient of <e> by <f> must be a prime");
     fi;
 
     field := GF(p ^ e);
@@ -364,13 +364,13 @@ function (epsilon, d, p, e, f, epsilon_0)
     r := QuoInt(e, f);
 
     if not IsPrime(r) then
-        ErrorNoReturn("the quotient of <f> by <e> must be a prime");
+        ErrorNoReturn("the quotient of <e> by <f> must be a prime");
     fi;
 
     if not epsilon_0 in [-1, 0, 1] then
         ErrorNoReturn("<epsilon_0> must be in [-1, 0, 1]");
     elif epsilon_0 ^ r <> epsilon then
-        ErrorNoReturn("<epsilon_0> ^ r must be equal to <epsilon>");
+        ErrorNoReturn("<epsilon_0> ^ (<e> / <f>) must be equal to <epsilon>");
     fi;
 
     q0 := p ^ f;
@@ -393,11 +393,11 @@ function (epsilon, d, p, e, f, epsilon_0)
 
     # from now on we assume r = 2, d even and epsilon = 1
     if epsilon_0 = 1 then
-        if d mod 2 = 0 and q0 mod 4 = 1 then
+        if d mod 4 = 2 and q0 mod 4 = 1 then
             return ConjugateToStandardForm(SO(epsilon_0, d, q0), "O+");
         fi;
     else
-        if not (d mod 2 = 0 and q0 mod 4 = 1) then
+        if not (d mod 4 = 2 and q0 mod 4 = 1) then
             return ConjugateToStandardForm(SO(epsilon_0, d, q0), "O-");
         fi;
     fi;
@@ -434,8 +434,8 @@ function (epsilon, d, p, e, f, epsilon_0)
 
     fi;
 
-    gens := List(GeneratorsOfGroup(ConjugateToSesquilinearForm(SO(epsilon_0, d, q0), F, "O-B")));
+    gens := List(GeneratorsOfGroup(ConjugateToSesquilinearForm(SO(epsilon_0, d, q0), "O-B", F)));
     Add(gens, A);
-    result := MatrixGroupWithSize(field, gens, SizeSO(d, q0) * 2);
+    result := MatrixGroupWithSize(field, gens, SizeSO(epsilon, d, q0) * 2);
     return ConjugateToStandardForm(result, orthogonalType);
 end);

--- a/gap/SubfieldMatrixGroups.gi
+++ b/gap/SubfieldMatrixGroups.gi
@@ -339,7 +339,7 @@ end);
 BindGlobal("SubfieldOmega",
 function (epsilon, d, p, e, f, epsilon_0)
     local r, q0, field, one, zeta, lambda, lambdaInv, m,
-    A, F, ABlock, FBlock, i, orthogonalType, gens, result;
+    A, F, ABlock, FBlock, i, gens, result;
 
     if epsilon = 0 then
         if IsEvenInt(d) then
@@ -414,7 +414,6 @@ function (epsilon, d, p, e, f, epsilon_0)
         A := lambda * IdentityMat(d, field);
         A{[m + 1..d]}{[m + 1..d]} := lambdaInv * IdentityMat(m, field);
         F := StandardOrthogonalForm(epsilon, d, q0).F;
-        orthogonalType := "O+";
 
     else
 
@@ -430,13 +429,12 @@ function (epsilon, d, p, e, f, epsilon_0)
         A[d, d - 1] := lambda;
         F[d - 1, d - 1] := one;
         F[d, d] := lambda ^ 2;
-        orthogonalType := "O-";
 
     fi;
 
     gens := List(GeneratorsOfGroup(ConjugateToSesquilinearForm(SO(epsilon_0, d, q0), "O-B", F)));
     Add(gens, A);
-    result := MatrixGroupWithSize(field, gens, SizeSO(epsilon, d, q0) * 2);
-    SetInvariantBilinearForm(rec(matrix := F));
-    return ConjugateToStandardForm(result, orthogonalType);
+    result := MatrixGroupWithSize(field, gens, SizeSO(epsilon_0, d, q0) * 2);
+    SetInvariantBilinearForm(result, rec(matrix := F));
+    return ConjugateToStandardForm(result, "O+");
 end);

--- a/gap/SubfieldMatrixGroups.gi
+++ b/gap/SubfieldMatrixGroups.gi
@@ -334,3 +334,108 @@ function (d, p, e, f)
 
     return ConjugateToStandardForm(result, "S");
 end);
+
+# Construction as in Proposition 8.1 of [HR10]
+BindGlobal("SubfieldOmega",
+function (epsilon, d, p, e, f, epsilon_0)
+    local r, q0, field, one, zeta, lambda, lambdaInv, m,
+    A, F, ABlock, FBlock, i, orthogonalType, gens, result;
+
+    if epsilon = 0 then
+        if IsEvenInt(d) then
+            ErrorNoReturn("<d> must be odd");
+        fi;
+    elif epsilon in [-1, 1] then
+        if IsOddInt(d) then
+            ErrorNoReturn("<d> must be even");
+        fi;
+    else
+        ErrorNoReturn("<epsilon> must be in [-1, 0, 1]");
+    fi;
+
+    if IsEvenInt(p) and IsOddInt(d) then
+        ErrorNoReturn("<d> must be even if <q> is even");
+    fi;
+
+    if e mod f <> 0 then
+        ErrorNoReturn("<f> must be a divisor of <e>");
+    fi;
+
+    r := QuoInt(e, f);
+
+    if not IsPrime(r) then
+        ErrorNoReturn("the quotient of <f> by <e> must be a prime");
+    fi;
+
+    if not epsilon_0 in [-1, 0, 1] then
+        ErrorNoReturn("<epsilon_0> must be in [-1, 0, 1]");
+    elif epsilon_0 ^ r <> epsilon then
+        ErrorNoReturn("<epsilon_0> ^ r must be equal to <epsilon>");
+    fi;
+
+    q0 := p ^ f;
+
+    if IsOddInt(d) then
+        if r = 2 then
+            return ConjugateToStandardForm(SO(0, d, q0), "O");
+        else
+            return Omega(0, d, q0);
+        fi;
+    fi;
+
+    if IsEvenInt(p) then
+        return Omega(epsilon_0, d, q0);
+    fi;
+
+    if r <> 2 then
+        return Omega(epsilon_0, d, q0);
+    fi;
+
+    # from now on we assume r = 2, d even and epsilon = 1
+    if epsilon_0 = 1 then
+        if d mod 2 = 0 and q0 mod 4 = 1 then
+            return ConjugateToStandardForm(SO(epsilon_0, d, q0), "O+");
+        fi;
+    else
+        if not (d mod 2 = 0 and q0 mod 4 = 1) then
+            return ConjugateToStandardForm(SO(epsilon_0, d, q0), "O-");
+        fi;
+    fi;
+    
+    field := GF(p ^ e);
+    one := One(field);
+    zeta := PrimitiveElement(field);
+    lambda := zeta ^ QuoInt(q0 + 1, 2);
+    lambdaInv := lambda ^ -1;
+    m := QuoInt(d, 2);
+
+    if epsilon_0 = 1 then
+
+        A := lambda * IdentityMat(d, field);
+        A{[m + 1..d]}{[m + 1..d]} := lambdaInv * IdentityMat(m, field);
+        F := StandardOrthogonalForm(epsilon, d, q0).F;
+        orthogonalType := "O+";
+
+    else
+
+        A := NullMat(d, d, field);
+        F := NullMat(d, d, field);
+        ABlock := one * [[lambda, 0], [0, lambdaInv]];
+        FBlock := AntidiagonalMat(2, field);
+        for i in [1..m - 1] do
+            A{[2 * i - 1..2 * i]}{[2 * i - 1..2 * i]} := ABlock;
+            F{[2 * i - 1..2 * i]}{[2 * i - 1..2 * i]} := FBlock;
+        od;
+        A[d - 1, d] := -lambdaInv;
+        A[d, d - 1] := lambda;
+        F[d - 1, d - 1] := one;
+        F[d, d] := lambda ^ 2;
+        orthogonalType := "O-";
+
+    fi;
+
+    gens := List(GeneratorsOfGroup(ConjugateToSesquilinearForm(SO(epsilon_0, d, q0), F, "O-B")));
+    Add(gens, A);
+    result := MatrixGroupWithSize(field, gens, SizeSO(d, q0) * 2);
+    return ConjugateToStandardForm(result, orthogonalType);
+end);

--- a/tst/standard/SubfieldMatrixGroups.tst
+++ b/tst/standard/SubfieldMatrixGroups.tst
@@ -106,6 +106,7 @@ gap> TestSubfieldOmega(-1, 8, 4, 5, 1, -1);
 gap> TestSubfieldOmega(-1, 10, 3, 3, 1, -1);
 gap> TestSubfieldOmega(1, 8, 4, 5, 1, 1);
 gap> TestSubfieldOmega(1, 6, 5, 2, 1, 1);
+gap> TestSubfieldOmega(1, 8, 3, 2, 1, 1);
 gap> TestSubfieldOmega(1, 6, 8, 2, 1, -1);
 gap> TestSubfieldOmega(1, 6, 3, 4, 2, -1);
 gap> TestSubfieldOmega(1, 8, 3, 2, 1, -1);

--- a/tst/standard/SubfieldMatrixGroups.tst
+++ b/tst/standard/SubfieldMatrixGroups.tst
@@ -105,8 +105,10 @@ gap> TestSubfieldOmega(0, 7, 7, 2, 1, 0);
 gap> TestSubfieldOmega(-1, 8, 4, 5, 1, -1);
 gap> TestSubfieldOmega(-1, 10, 3, 3, 1, -1);
 gap> TestSubfieldOmega(1, 8, 4, 5, 1, 1);
-gap> TestSubfieldOmega(1, 6, 3, 4, 2, 1);
+gap> TestSubfieldOmega(1, 6, 5, 2, 1, 1);
 gap> TestSubfieldOmega(1, 6, 8, 2, 1, -1);
+gap> TestSubfieldOmega(1, 6, 3, 4, 2, -1);
+gap> TestSubfieldOmega(1, 8, 3, 2, 1, -1);
 gap> TestSubfieldOmega(1, 10, 3, 2, 1, -1);
 
 # Test error handling

--- a/tst/standard/SubfieldMatrixGroups.tst
+++ b/tst/standard/SubfieldMatrixGroups.tst
@@ -89,7 +89,7 @@ Error, <d> must be even
 gap> SubfieldSp(4, 2, 1, 2);
 Error, <f> must be a divisor of <e>
 gap> SubfieldSp(4, 2, 4, 1);
-Error, the quotient of <f> by <e> must be a prime
+Error, the quotient of <e> by <f> must be a prime
 
 #
 gap> TestSubfieldOmega := function(epsilon, n, p, e, f, epsilon_0)
@@ -121,11 +121,11 @@ Error, <d> must be even if <q> is even
 gap> SubfieldOmega(0, 7, 3, 3, 2, 0);
 Error, <f> must be a divisor of <e>
 gap> SubfieldOmega(0, 7, 3, 4, 1, 0);
-Error, the quotient of <f> by <e> must be a prime
+Error, the quotient of <e> by <f> must be a prime
 gap> SubfieldOmega(0, 7, 3, 2, 1, 2);
 Error, <epsilon_0> must be in [-1, 0, 1]
 gap> SubfieldOmega(-1, 8, 3, 2, 1, 1);
-Error, <epsilon_0> ^ r must be equal to <epsilon>
+Error, <epsilon_0> ^ (<e> / <f>) must be equal to <epsilon>
 
 #
 gap> STOP_TEST("SubfieldMatrixGroups.tst", 0);

--- a/tst/standard/SubfieldMatrixGroups.tst
+++ b/tst/standard/SubfieldMatrixGroups.tst
@@ -92,4 +92,40 @@ gap> SubfieldSp(4, 2, 4, 1);
 Error, the quotient of <f> by <e> must be a prime
 
 #
+gap> TestSubfieldOmega := function(epsilon, n, p, e, f, epsilon_0)
+>   local G;
+>   G := SubfieldOmega(epsilon, n, p, e, f, epsilon_0);
+>   CheckIsSubsetOmega(epsilon, n, p ^ e, G);
+>   CheckSize(G);
+> end;;
+gap> TestSubfieldOmega(0, 7, 3, 5, 1, 0);
+gap> TestSubfieldOmega(0, 5, 3, 4, 2, 0);
+gap> TestSubfieldOmega(0, 7, 5, 3, 1, 0);
+gap> TestSubfieldOmega(0, 7, 7, 2, 1, 0);
+gap> TestSubfieldOmega(-1, 8, 4, 5, 1, -1);
+gap> TestSubfieldOmega(-1, 10, 3, 3, 1, -1);
+gap> TestSubfieldOmega(1, 8, 4, 5, 1, 1);
+gap> TestSubfieldOmega(1, 6, 3, 4, 2, 1);
+gap> TestSubfieldOmega(1, 6, 8, 2, 1, -1);
+gap> TestSubfieldOmega(1, 10, 3, 2, 1, -1);
+
+# Test error handling
+gap> SubfieldOmega(0, 8, 3, 2, 1, 0);
+Error, <d> must be odd
+gap> SubfieldOmega(1, 7, 3, 2, 1, 1);
+Error, <d> must be even
+gap> SubfieldOmega(2, 7, 3, 2, 1, 1);
+Error, <epsilon> must be in [-1, 0, 1]
+gap> SubfieldOmega(0, 7, 4, 2, 1, 0);
+Error, <d> must be even if <q> is even
+gap> SubfieldOmega(0, 7, 3, 3, 2, 0);
+Error, <f> must be a divisor of <e>
+gap> SubfieldOmega(0, 7, 3, 4, 1, 0);
+Error, the quotient of <f> by <e> must be a prime
+gap> SubfieldOmega(0, 7, 3, 2, 1, 2);
+Error, <epsilon_0> must be in [-1, 0, 1]
+gap> SubfieldOmega(-1, 8, 3, 2, 1, 1);
+Error, <epsilon_0> ^ r must be equal to <epsilon>
+
+#
 gap> STOP_TEST("SubfieldMatrixGroups.tst", 0);

--- a/tst/utils.g
+++ b/tst/utils.g
@@ -37,7 +37,7 @@ CheckQuadraticForm := function(G)
   local M, Q;
   M := InvariantBilinearForm(G).matrix;
   Q := InvariantQuadraticForm(G).matrix;
-  if Q+TransposedMat(Q) <> M then
+  if Q + TransposedMat(Q) <> M then
     Error("incompatible quadratic and bilinear form");
   fi;
 
@@ -52,7 +52,7 @@ CheckSesquilinearForm := function(G)
   F := DefaultFieldOfMatrixGroup(G);
   q := RootInt(Size(F));
   if not ForAll(GeneratorsOfGroup(G), g -> g * M * HermitianConjugate(g,q) = M) then
-    Error("not all generators preserve the quadratic form");
+    Error("not all generators preserve the sesquilinear form");
   fi;
 end;
 
@@ -63,7 +63,7 @@ CheckIsSubsetSL := function(n, q, G)
     Error("matrix group: expected degree ", n, " actual degree ", m);
   fi;
   F := DefaultFieldOfMatrixGroup(G);
-  if q mod Size(F) <> 0 then
+  if Characteristic(F) <> PrimePowersInt(q)[1] then
     Error("matrix group: expected field of size ", q, " actual size ", Size(F));
   fi;
   CheckGeneratorsSpecial(G);
@@ -94,6 +94,6 @@ CheckIsSubsetOmega := function(epsilon, n, q, G)
     Error("wrong Witt index");
   fi;
   if not ForAll(GeneratorsOfGroup(G), g -> FancySpinorNorm(InvariantBilinearForm(G).matrix, field, g) = 1) then
-    Error("wrong Spinor norm");
+    Error("wrong spinor norm");
   fi;
 end;

--- a/tst/utils.g
+++ b/tst/utils.g
@@ -28,7 +28,7 @@ end;
 CheckBilinearForm := function(G)
   local M;
   M := InvariantBilinearForm(G).matrix;
-  if not ForAll(GeneratorsOfGroup(G), g -> g*M*TransposedMat(g) = M) then
+  if not ForAll(GeneratorsOfGroup(G), g -> g * M * TransposedMat(g) = M) then
     Error("not all generators preserve the bilinear form");
   fi;
 end;
@@ -51,7 +51,7 @@ CheckSesquilinearForm := function(G)
   M := InvariantSesquilinearForm(G).matrix;
   F := DefaultFieldOfMatrixGroup(G);
   q := RootInt(Size(F));
-  if not ForAll(GeneratorsOfGroup(G), g -> g*M*HermitianConjugate(g,q) = M) then
+  if not ForAll(GeneratorsOfGroup(G), g -> g * M * HermitianConjugate(g,q) = M) then
     Error("not all generators preserve the quadratic form");
   fi;
 end;
@@ -63,7 +63,7 @@ CheckIsSubsetSL := function(n, q, G)
     Error("matrix group: expected degree ", n, " actual degree ", m);
   fi;
   F := DefaultFieldOfMatrixGroup(G);
-  if Size(F) <> q then
+  if q mod Size(F) <> 0 then
     Error("matrix group: expected field of size ", q, " actual size ", Size(F));
   fi;
   CheckGeneratorsSpecial(G);
@@ -75,7 +75,7 @@ CheckIsSubsetSp := function(n, q, G)
 end;
 
 CheckIsSubsetSU := function(n, q, G)
-  CheckIsSubsetSL(n, q^2, G);
+  CheckIsSubsetSL(n, q ^ 2, G);
   CheckSesquilinearForm(G);
 end;
 


### PR DESCRIPTION
All the stuff for the C5 subgroups in case O.

## Checklist for the reviewer
### General
- [ ] All functions have unit tests

### Functions constructing generators of maximal subgroups
- [ ] The code which computes and then stores the sizes is correct. To do this one confers to the tables referenced by the code.
- [ ] The test suite checks whether all constructed generators are sensible. That is it tests the generators'
  - [ ] determinants (and if applicable also the spinor norms are correct), and
  - [ ] compatibility with the correct form,
  - [ ] `DefaultFieldOfMatrixGroup` returns the correct field.

### Functions assembling the list of all maximal subgroups of a certain group
- [ ] The code agrees with the tables in section 8.2 of the book "The Maximal Subgroups of the Low-dimensional Finite Classical Groups".

The reviewer doesn't need to compare our results to magma's results. That's the job of the person implementing the code.
