### PR TITLE
Orthogonal C4

### DIFF
--- a/gap/ClassicalMaximals.gi
+++ b/gap/ClassicalMaximals.gi
@@ -1293,6 +1293,70 @@ function(epsilon, n, q)
     return result;
 end);
 
+# Cf. Tables 3.5.D, 3.5.E, 3.5.F and 3.5.G in [KL90]
+BindGlobal("C3SubgroupsOrthogonalGroupGeneric",
+function(epsilon, n, q)
+    local result, primeDivisorsOfn, s, orthogonalTypeSubgroup, numberOfConjugates,
+    unitaryTypeSubgroup;
+
+    result := [];
+    primeDivisorsOfn := PrimeDivisors(n);
+
+    # type GO(epsilon, n / s, q ^ s)
+    for s in primeDivisorsOfn do
+        if not n / s > 2 then 
+            continue;
+        fi;
+
+        if s = 2 then
+            if not n mod 4 = 0 then
+                continue;
+            else
+                orthogonalTypeSubgroup := OrthogonalSemilinearOmega(epsilon, epsilon, n, q);
+                if epsilon = 1 then
+                    numberOfConjugates := 2;
+                else
+                    numberOfConjugates := 1;
+                fi;
+                result := Concatenation(result, ConjugateSubgroupOmega(epsilon, n, q,
+                                                                       orthogonalTypeSubgroup,
+                                                                       numberOfConjugates));
+            fi;
+        else
+            orthogonalTypeSubgroup := GammaLMeetOmega(epsilon, n, q, s);
+            Add(result, orthogonalTypeSubgroup);
+        fi;
+    od;
+
+    # type GO(0, n / 2, q ^ 2)
+    if n mod 4 = 2 and IsOddInt(q) then
+        orthogonalTypeSubgroup := OrthogonalSemilinearOmega(epsilon, 0, n, q);
+        if q mod 4 = 1 then
+            numberOfConjugates := 1;
+        else    
+            numberOfConjugates := 2;
+        fi;
+        result := Concatenation(result, ConjugateSubgroupOmega(epsilon, n, q,
+                                                               orthogonalTypeSubgroup,
+                                                               numberOfConjugates));
+    fi;
+
+    # type GU(n / 2, q ^ 2)
+    if (n mod 4 = 2 and epsilon = -1) or (n mod 4 = 0 and epsilon = 1) then
+        unitaryTypeSubgroup := UnitarySemilinearOmega(n, q);
+        if epsilon = 1 then
+            numberOfConjugates := 2;
+        else
+            numberOfConjugates := 1;
+        fi;
+        result := Concatenation(result, ConjugateSubgroupOmega(epsilon, n, q,
+                                                               unitaryTypeSubgroup,
+                                                               numberOfConjugates));
+    fi;
+    
+    return result;
+end);
+
 BindGlobal("C4SubgroupsOrthogonalGroupGeneric",
 function(epsilon, n, q)
     local result, listOfn1s, n1, n2, numberOfConjugates, listOfn1sFiltered;
@@ -1383,70 +1447,6 @@ function(epsilon, n, q)
 
     fi;
 
-    return result;
-end);
-
-# Cf. Tables 3.5.D, 3.5.E, 3.5.F and 3.5.G in [KL90]
-BindGlobal("C3SubgroupsOrthogonalGroupGeneric",
-function(epsilon, n, q)
-    local result, primeDivisorsOfn, s, orthogonalTypeSubgroup, numberOfConjugates,
-    unitaryTypeSubgroup;
-
-    result := [];
-    primeDivisorsOfn := PrimeDivisors(n);
-
-    # type GO(epsilon, n / s, q ^ s)
-    for s in primeDivisorsOfn do
-        if not n / s > 2 then 
-            continue;
-        fi;
-
-        if s = 2 then
-            if not n mod 4 = 0 then
-                continue;
-            else
-                orthogonalTypeSubgroup := OrthogonalSemilinearOmega(epsilon, epsilon, n, q);
-                if epsilon = 1 then
-                    numberOfConjugates := 2;
-                else
-                    numberOfConjugates := 1;
-                fi;
-                result := Concatenation(result, ConjugateSubgroupOmega(epsilon, n, q,
-                                                                       orthogonalTypeSubgroup,
-                                                                       numberOfConjugates));
-            fi;
-        else
-            orthogonalTypeSubgroup := GammaLMeetOmega(epsilon, n, q, s);
-            Add(result, orthogonalTypeSubgroup);
-        fi;
-    od;
-
-    # type GO(0, n / 2, q ^ 2)
-    if n mod 4 = 2 and IsOddInt(q) then
-        orthogonalTypeSubgroup := OrthogonalSemilinearOmega(epsilon, 0, n, q);
-        if q mod 4 = 1 then
-            numberOfConjugates := 1;
-        else    
-            numberOfConjugates := 2;
-        fi;
-        result := Concatenation(result, ConjugateSubgroupOmega(epsilon, n, q,
-                                                               orthogonalTypeSubgroup,
-                                                               numberOfConjugates));
-    fi;
-
-    # type GU(n / 2, q ^ 2)
-    if (n mod 4 = 2 and epsilon = -1) or (n mod 4 = 0 and epsilon = 1) then
-        unitaryTypeSubgroup := UnitarySemilinearOmega(n, q);
-        if epsilon = 1 then
-            numberOfConjugates := 2;
-        else
-            numberOfConjugates := 1;
-        fi;
-        result := Concatenation(result, ConjugateSubgroupOmega(epsilon, n, q,
-                                                               unitaryTypeSubgroup,
-                                                               numberOfConjugates));
-    fi;
-    
     return result;
 end);
 

--- a/gap/ClassicalMaximals.gi
+++ b/gap/ClassicalMaximals.gi
@@ -1291,7 +1291,99 @@ function(epsilon, n, q)
     fi;
 
     return result;
+end);
 
+BindGlobal("C4SubgroupsOrthogonalGroupGeneric",
+function(epsilon, n, q)
+    local result, listOfn1s, n1, n2, numberOfConjugates, listOfn1sFiltered;
+
+    result := [];
+
+    # These are the orthogonal type subgroups with epsilon_2 = 0
+    if epsilon = 0 then
+
+        listOfn1s := Filtered(DivisorsInt(n), n1 -> n1 * n1 < n);
+        RemoveSet(listOfn1s, 1);
+
+        # number of conjugates is 1 according to [KL90] Proposition 4.4.18 (I)
+        Append(result, List(listOfn1s, n1 -> OrthogonalTensorProductStabilizerInOmega(0, 0, 0, n1, n2, q)));
+
+    else
+
+        listOfn1s := Filtered(DivisorsInt(n), IsEvenInt);
+        RemoveSet(listOfn1s, 2);
+
+        # This is nonmaximal, see Proposition 2.3.22 (v) in [BHR13]
+        if q = 3 then
+            RemoveSet(listOfn1s, n / 3);
+        fi;
+
+        for n1 in listOfn1s do
+            n2 := QuoInt(n, n1);
+            if IsOddInt(n2) and n2 <> 1 then
+                # number of conjugates is 1 according to [KL90] Proposition 4.4.17 (I)
+                Add(result, OrthogonalTensorProductStabilizerInOmega(epsilon, epsilon, 0, n1, n2, q));
+            fi;
+        od;
+
+    fi;
+
+    
+    if epsilon = 1 and n mod 4 = 0 then
+        
+        listOfn1s := 2 * DivisorsInt(QuoInt(n, 2));
+        listOfn1sFiltered := Filtered(listOfn1s, n1 -> n1 * n1 < n);
+
+        # These are the orthogonal type subgroups with epsilon_i <> 0
+        if IsOddInt(q) then
+
+            # This is epsilon_1 = epsilon_2
+            for n1 in listOfn1sFiltered do
+                n2 := QuoInt(n, n1);
+                if IsEvenInt(n2) and n1 <> 2 and n2 <> 2 then
+                    # number of conjugates according to [KL90] Proposition 4.4.14 (I)
+                    if n mod 8 = 4 or (q mod 4 = 3 and (n1 mod 4 = 2 or n2 mod 4 = 2)) then
+                        numberOfConjugates := 2;
+                    else
+                        numberOfConjugates := 4;
+                    fi;
+                    Append(result, ConjugateSubgroupOmega(1, n, q, OrthogonalTensorProductStabilizerInOmega(1, 1, 1, n1, n2, q), numberOfConjugates));
+                    # number of conjugates according to [KL90] Proposition 4.4.16 (I)
+                    Append(result, ConjugateSubgroupOmega(1, n, q, OrthogonalTensorProductStabilizerInOmega(1, -1, -1, n1, n2, q), 2));
+                fi;
+            od;
+
+            # This is epsilon_1 = 1, epsilon_2 = -1
+            for n1 in listOfn1s do
+                n2 := QuoInt(n, n1);
+                if IsEvenInt(n2) and n1 <> 2 and n2 <> 2 then
+                    # number of conjugates according to [KL90] Proposition 4.4.15 (I)
+                    Append(result, ConjugateSubgroupOmega(1, n, q, OrthogonalTensorProductStabilizerInOmega(1, 1, -1, n1, n2, q),
+                                                          3 - (-1) ^ QuoInt((n1 - 2) * n2 * (q - 1), 8)));
+                fi;
+            od;
+
+        fi;
+
+        # These are the symplectic type subgroups
+        
+        # This is nonmaximal, see Proposition 2.3.22 (iv) in [BHR13]
+        if q = 2 then
+            RemoveSet(listOfn1sFiltered, 2);
+        fi;
+
+        # number of conjugates according to [KL90] Proposition 4.4.12 (I)
+        numberOfConjugates := 3 - (-1) ^ (q * QuoInt(n - 4, 4));
+        for n1 in listOfn1sFiltered do
+            n2 := QuoInt(n, n1);
+            if IsEvenInt(n2) then
+                Append(result, ConjugateSubgroupOmega(1, n, q, SymplecticTensorProductStabilizerInOmega(n1, n2, q), numberOfConjugates));
+            fi;
+        od;
+
+    fi;
+
+    return result;
 end);
 
 # Cf. Tables 3.5.D, 3.5.E, 3.5.F and 3.5.G in [KL90]
@@ -1532,6 +1624,19 @@ function(epsilon, n, q, classes...)
         # Cf. Propositions 3.6.3 (n = 7), 3.7.5 (n = 8), 3.8.3 (n = 9), 
         # 3.9.5 (n = 10), 3.10.3 (n = 11) and 3.11.7 (n = 12) in [BHR13]
         Append(maximalSubgroups, C3SubgroupsOrthogonalGroupGeneric(epsilon, n, q));
+    fi;
+
+    if 4 in classes then
+        # Class C4 subgroups ######################################################
+        # Cf. Propositions 3.7.7 (n = 8), Propositions 3.9.6 (n = 10),
+        # Propositions 3.11.8 (n = 12) and Table 8.50 (n = 8) in [BHR13]
+        # For all other n, class C4 is empty.
+        if n = 12 and epsilon = 1 and q <> 2 then
+            # number of conjugates is 2 according to [KL90] Proposition 4.4.12 (I)
+            Append(maximalSubgroups, ConjugateSubgroupOmega(1, 12, q, SymplecticTensorProductStabilizerInOmega(2, 6, q), 2));
+        elif q <> 2 and not (epsilon = 1 and n = 8) then
+            Append(maximalSubgroups, C4SubgroupsOrthogonalGroupGeneric(epsilon, n, q));
+        fi;
     fi;
 
     if 5 in classes then

--- a/gap/ReducibleMatrixGroups.gi
+++ b/gap/ReducibleMatrixGroups.gi
@@ -949,7 +949,7 @@ function(epsilon, d, q)
 
     # Size according to Table 2.3 of [BHR13]
     result := MatrixGroupWithSize(field, gens, SizeSp(d - 2, q));
-    SetInvariantQuadraticForm(result, rec(matrix := Q));
+    SetInvariantQuadraticFormFromMatrix(result, Q);
 
     if epsilon = 1 then
         return ConjugateToStandardForm(result, "O+");

--- a/gap/TensorProductMatrixGroups.gi
+++ b/gap/TensorProductMatrixGroups.gi
@@ -184,7 +184,7 @@ BindGlobal("OrthogonalTensorProductStabilizerInOmega",
 function(epsilon, epsilon_1, epsilon_2, d1, d2, q)
     local d, field, zeta, gens, size, F1, F2, F, orthogonalGens_1, orthogonalGens_2,
     squareDiscriminant_1, squareDiscriminant_2, G_1, G_2, one, xi, alpha, beta,
-    A, B, E_1, E_2, D, S, gen, result;
+    A, B, E_1, E_2, D, gen, result;
 
     if IsEvenInt(q) then
         ErrorNoReturn("<q> must be odd");
@@ -344,20 +344,20 @@ function(epsilon, epsilon_1, epsilon_2, d1, d2, q)
             # matrices while making sure that they have spinor norm 1'. This
             # monstrosity achieves just that, using the fact that G_i has
             # spinor norm 1 iff squareDiscriminant_{3 - i} by Lemma 7.2 (2) in [HR10].
-            # If exactly one of the 3 matrices has spinor norm -1, it appears that we
-            # can just ignore that one instead of adjoining its square.
+            # A short calculation using the mixed product property of the
+            # Kronecker product shows that G_1 ^ 2, G_2 ^ 2 and D ^ 2 are all in
+            # SO(epsilon_1, d1, q) \otimes SO(epsilon_2, d2, q) already, so if
+            # exactly one of the matrices has spinor norm -1, we do not adjoin its
+            # square and instead just adjoin the other two.
             if squareDiscriminant_2 then
                 Add(gens, G_1);
                 if squareDiscriminant_1 then
                     Add(gens, G_2);
                     if FancySpinorNorm(F, field, D) = 1 then
                         Add(gens, D);
-                    else
-                        # Add(gens, D ^ 2);
                     fi;
                 else
                     if FancySpinorNorm(F, field, D) = 1 then
-                        # Add(gens, G_2 ^ 2);
                         Add(gens, D);
                     else
                         Add(gens, G_2 * D);
@@ -367,7 +367,6 @@ function(epsilon, epsilon_1, epsilon_2, d1, d2, q)
                 if squareDiscriminant_1 then
                     Add(gens, G_2);
                     if FancySpinorNorm(F, field, D) = 1 then
-                        # Add(gens, G_1 ^ 2);
                         Add(gens, D);
                     else
                         Add(gens, G_1 * D);

--- a/gap/TensorProductMatrixGroups.gi
+++ b/gap/TensorProductMatrixGroups.gi
@@ -352,8 +352,11 @@ function(epsilon, epsilon_1, epsilon_2, d1, d2, q)
             if squareDiscriminant_2 then
                 Add(gens, G_1);
                 if squareDiscriminant_1 then
+                    # This case is quite rare, but not impossible:
+                    # It first appears for parameters 1, -1, -1, 6, 10, 3
                     Add(gens, G_2);
                     if FancySpinorNorm(F, field, D) = 1 then
+                        # And this case is probably impossible
                         Add(gens, D);
                     fi;
                 else

--- a/gap/TensorProductMatrixGroups.gi
+++ b/gap/TensorProductMatrixGroups.gi
@@ -244,13 +244,13 @@ function(epsilon, epsilon_1, epsilon_2, d1, d2, q)
     # In this case we use symmetry to restrict the epsilons,
     # the papers also implicitly do this
     if epsilon = 1 and epsilon_1 = -1 and epsilon_2 = 1 then
-        ErrorNoReturn("By symmetry, we disallow this case");
+        ErrorNoReturn("by symmetry, we disallow this case");
     fi;
 
     # In this case we use symmetry to restrict the dimensions,
     # the papers also implicitly do this
     if (epsilon = 0 or (epsilon = 1 and epsilon_1 = epsilon_2)) and d1 >= d2 then
-        ErrorNoReturn("By symmetry, we assume d1 < d2 in this case");
+        ErrorNoReturn("by symmetry, we assume d1 < d2 in this case");
     fi;
 
     if (epsilon = -1) <> (epsilon_1 = -1 and epsilon_2 = 0) then
@@ -374,6 +374,7 @@ function(epsilon, epsilon_1, epsilon_2, d1, d2, q)
                 else
                     Add(gens, G_1 * G_2);
                     if FancySpinorNorm(F, field, D) = 1 then
+                        # This case is probably impossible
                         Add(gens, D);
                     else
                         # choosing G_1 here is arbitrary since both

--- a/tst/standard/TensorProductMatrixGroups.tst
+++ b/tst/standard/TensorProductMatrixGroups.tst
@@ -77,6 +77,7 @@ gap> TestOrthogonalTensorProductStabilizerInOmega(1, 1, -1, 4, 6, 5);
 gap> TestOrthogonalTensorProductStabilizerInOmega(1, 1, -1, 6, 4, 5);
 gap> TestOrthogonalTensorProductStabilizerInOmega(1, -1, -1, 4, 6, 5);
 gap> TestOrthogonalTensorProductStabilizerInOmega(1, 1, 1, 6, 8, 3);
+gap> TestOrthogonalTensorProductStabilizerInOmega(1, -1, -1, 6, 10, 3);
 
 # Test error handling
 gap> OrthogonalTensorProductStabilizerInOmega(1, 1, 1, 4, 6, 2);

--- a/tst/standard/TensorProductMatrixGroups.tst
+++ b/tst/standard/TensorProductMatrixGroups.tst
@@ -59,6 +59,18 @@ gap> TensorProductStabilizerInSp(0, 2, 4, 3);
 Error, <epsilon> must be +1 or -1 since <d2> is even
 
 #
+gap> TestOrthogonalTensorProductStabilizerInOmega := function(epsilon, epsilon_1, epsilon_2, d1, d2, q)
+>   local G;
+>   G := OrthogonalTensorProductStabilizerInOmega(epsilon, epsilon_1, epsilon_2, d1, d2, q);
+>   CheckIsSubsetOmega(epsilon, d1 * d2, q, G);
+>   CheckSize(G);
+> end;;
+gap> TestOrthogonalTensorProductStabilizerInOmega(0, 0, 0, 3, 5, 5);
+gap> TestOrthogonalTensorProductStabilizerInOmega(-1, -1, 0, 4, 3, 5);
+gap> TestOrthogonalTensorProductStabilizerInOmega(1, 1, 0, 4, 3, 5);
+gap> TestOrthogonalTensorProductStabilizerInOmega(1, 1, 1, 4, 6, 3);
+
+#
 gap> TestSymplecticTensorProductStabilizerInOmega := function(d1, d2, q)
 >   local G;
 >   G := SymplecticTensorProductStabilizerInOmega(d1, d2, q);
@@ -71,6 +83,12 @@ gap> TestSymplecticTensorProductStabilizerInOmega(2, 6, 4);
 gap> TestSymplecticTensorProductStabilizerInOmega(2, 6, 5);
 gap> TestSymplecticTensorProductStabilizerInOmega(2, 8, 2);
 gap> TestSymplecticTensorProductStabilizerInOmega(2, 8, 3);
+
+# Test error handling
+gap> SymplecticTensorProductStabilizerInOmega(2, 3, 5);
+Error, <d1> and <d2> must be even
+gap> SymplecticTensorProductStabilizerInOmega(4, 2, 5);
+Error, <d1> must be less than <d2>
 
 #
 gap> STOP_TEST("TensorProductMatrixGroups.tst", 0);

--- a/tst/standard/TensorProductMatrixGroups.tst
+++ b/tst/standard/TensorProductMatrixGroups.tst
@@ -76,6 +76,42 @@ gap> TestOrthogonalTensorProductStabilizerInOmega(1, 1, 1, 4, 6, 5);
 gap> TestOrthogonalTensorProductStabilizerInOmega(1, 1, -1, 4, 6, 5);
 gap> TestOrthogonalTensorProductStabilizerInOmega(1, 1, -1, 6, 4, 5);
 gap> TestOrthogonalTensorProductStabilizerInOmega(1, -1, -1, 4, 6, 5);
+gap> TestOrthogonalTensorProductStabilizerInOmega(1, 1, 1, 6, 8, 3);
+
+# Test error handling
+gap> OrthogonalTensorProductStabilizerInOmega(1, 1, 1, 4, 6, 2);
+Error, <q> must be odd
+gap> OrthogonalTensorProductStabilizerInOmega(0, 0, 0, 5, 5, 3);
+Error, [<epsilon_1>, <d1>] must not be equal to [<epsilon_2>, <d2>]
+gap> OrthogonalTensorProductStabilizerInOmega(1, 1, 1, 2, 4, 3);
+Error, <d1> and <d2> must be at least 3
+gap> OrthogonalTensorProductStabilizerInOmega(0, 0, 0, 4, 5, 3);
+Error, <d1> must be odd
+gap> OrthogonalTensorProductStabilizerInOmega(1, 1, 1, 5, 6, 3);
+Error, <d1> must be even
+gap> OrthogonalTensorProductStabilizerInOmega(1, 2, 1, 4, 6, 3);
+Error, <epsilon_1> must be in [-1, 0, 1]
+gap> OrthogonalTensorProductStabilizerInOmega(0, 0, 0, 5, 6, 3);
+Error, <d2> must be odd
+gap> OrthogonalTensorProductStabilizerInOmega(1, 1, 1, 4, 5, 3);
+Error, <d2> must be even
+gap> OrthogonalTensorProductStabilizerInOmega(1, 1, 2, 4, 6, 3);
+Error, <epsilon_2> must be in [-1, 0, 1]
+gap> OrthogonalTensorProductStabilizerInOmega(0, 1, 1, 4, 6, 3);
+Error, <d> must be odd
+gap> OrthogonalTensorProductStabilizerInOmega(1, 0, 0, 5, 7, 3);
+Error, <d> must be even
+gap> OrthogonalTensorProductStabilizerInOmega(2, 1, 1, 4, 6, 3);
+Error, <epsilon> must be in [-1, 0, 1]
+gap> OrthogonalTensorProductStabilizerInOmega(1, 0, 1, 5, 6, 3);
+Error, <epsilon2> must be 0 if <epsilon_1> is 0]
+gap> OrthogonalTensorProductStabilizerInOmega(1, -1, 1, 4, 6, 3);
+Error, by symmetry, we disallow this case
+gap> OrthogonalTensorProductStabilizerInOmega(1, 1, 1, 6, 4, 3);
+Error, by symmetry, we assume d1 < d2 in this case
+gap> OrthogonalTensorProductStabilizerInOmega(1, -1, 0, 4, 5, 3);
+Error, <epsilon> = -1 must be equivalent to <epsilon_1> = -1 and <epsilon_2> =\
+ 0
 
 #
 gap> TestSymplecticTensorProductStabilizerInOmega := function(d1, d2, q)
@@ -84,7 +120,9 @@ gap> TestSymplecticTensorProductStabilizerInOmega := function(d1, d2, q)
 >   CheckIsSubsetOmega(1, d1 * d2, q, G);
 >   CheckSize(G);
 > end;;
-gap> TestSymplecticTensorProductStabilizerInOmega(2, 4, 8);
+#@if IsBound(CLASSICAL_MAXIMALS_RUN_BROKEN_TESTS)
+gap> TestSymplecticTensorProductStabilizerInOmega(2, 4, 8); # Error, !!!. See ./ReducibleMatrixGroups.tst for more info and examples
+#@fi
 gap> TestSymplecticTensorProductStabilizerInOmega(2, 4, 7);
 gap> TestSymplecticTensorProductStabilizerInOmega(2, 6, 4);
 gap> TestSymplecticTensorProductStabilizerInOmega(2, 6, 5);

--- a/tst/standard/TensorProductMatrixGroups.tst
+++ b/tst/standard/TensorProductMatrixGroups.tst
@@ -59,4 +59,18 @@ gap> TensorProductStabilizerInSp(0, 2, 4, 3);
 Error, <epsilon> must be +1 or -1 since <d2> is even
 
 #
+gap> TestSymplecticTensorProductStabilizerInOmega := function(d1, d2, q)
+>   local G;
+>   G := SymplecticTensorProductStabilizerInOmega(d1, d2, q);
+>   CheckIsSubsetOmega(1, d1 * d2, q, G);
+>   CheckSize(G);
+> end;;
+gap> TestSymplecticTensorProductStabilizerInOmega(2, 4, 8);
+gap> TestSymplecticTensorProductStabilizerInOmega(2, 4, 7);
+gap> TestSymplecticTensorProductStabilizerInOmega(2, 6, 4);
+gap> TestSymplecticTensorProductStabilizerInOmega(2, 6, 5);
+gap> TestSymplecticTensorProductStabilizerInOmega(2, 8, 2);
+gap> TestSymplecticTensorProductStabilizerInOmega(2, 8, 3);
+
+#
 gap> STOP_TEST("TensorProductMatrixGroups.tst", 0);

--- a/tst/standard/TensorProductMatrixGroups.tst
+++ b/tst/standard/TensorProductMatrixGroups.tst
@@ -69,6 +69,13 @@ gap> TestOrthogonalTensorProductStabilizerInOmega(0, 0, 0, 3, 5, 5);
 gap> TestOrthogonalTensorProductStabilizerInOmega(-1, -1, 0, 4, 3, 5);
 gap> TestOrthogonalTensorProductStabilizerInOmega(1, 1, 0, 4, 3, 5);
 gap> TestOrthogonalTensorProductStabilizerInOmega(1, 1, 1, 4, 6, 3);
+gap> TestOrthogonalTensorProductStabilizerInOmega(1, 1, -1, 4, 6, 3);
+gap> TestOrthogonalTensorProductStabilizerInOmega(1, 1, -1, 6, 4, 3);
+gap> TestOrthogonalTensorProductStabilizerInOmega(1, -1, -1, 4, 6, 3);
+gap> TestOrthogonalTensorProductStabilizerInOmega(1, 1, 1, 4, 6, 5);
+gap> TestOrthogonalTensorProductStabilizerInOmega(1, 1, -1, 4, 6, 5);
+gap> TestOrthogonalTensorProductStabilizerInOmega(1, 1, -1, 6, 4, 5);
+gap> TestOrthogonalTensorProductStabilizerInOmega(1, -1, -1, 4, 6, 5);
 
 #
 gap> TestSymplecticTensorProductStabilizerInOmega := function(d1, d2, q)


### PR DESCRIPTION
After some trouble with codecov, this  is all done up to some small mathematical gaps. One or two branches in `OrthogonalTensorProductStabilizerInOmega` are not covered by codecov because I could not find any examples for them and I have good reason to believe that they are impossible, but I have not been able to prove that. The authors of [HR10] hint at having worked through all the cases and calculations according to the Remark after Lemma 7.3, but maybe it's just a Fermat-situation and no one will know for the foreseeable future. The magma-code for this case (epsilon = 1, d1 and d2 even) also suggest that D \in \Omega \iff d \equiv 0 \mod 8, but that's just wrong according to my testing.