### PR TITLE
Improve and extend the package manual

### DIFF
--- a/doc/ClassicalMaximals.bib
+++ b/doc/ClassicalMaximals.bib
@@ -99,3 +99,36 @@ MRREVIEWER = {Irina Suprunenko},
        URL = {https://www.maths.usyd.edu.au/u/don/papers/genAC.pdf},
 }
 
+@article {HM01,
+    AUTHOR = {Hiss, Gerhard and Malle, Gunter},
+     TITLE = {Low-dimensional representations of quasi-simple groups},
+   JOURNAL = {LMS J. Comput. Math.},
+  FJOURNAL = {LMS Journal of Computation and Mathematics},
+    VOLUME = {4},
+      YEAR = {2001},
+     PAGES = {22--63},
+      ISSN = {1461-1570},
+   MRCLASS = {20C20},
+  MRNUMBER = {1835851},
+MRREVIEWER = {Roderick Gow},
+       DOI = {10.1112/S1461157000000796},
+       URL = {https://doi.org/10.1112/S1461157000000796},
+}
+
+@article {L01,
+    AUTHOR = {Lübeck, Frank},
+     TITLE = {Small degree representations of finite {C}hevalley groups in
+              defining characteristic},
+   JOURNAL = {LMS J. Comput. Math.},
+  FJOURNAL = {LMS Journal of Computation and Mathematics},
+    VOLUME = {4},
+      YEAR = {2001},
+     PAGES = {135--169},
+      ISSN = {1461-1570},
+   MRCLASS = {20C33 (20G05)},
+  MRNUMBER = {1901354},
+MRREVIEWER = {Meinolf Geck},
+       DOI = {10.1112/S1461157000000838},
+       URL = {https://doi.org/10.1112/S1461157000000838},
+}
+

--- a/doc/intro.autodoc
+++ b/doc/intro.autodoc
@@ -1,17 +1,66 @@
 @Chapter Introduction
 
-This package implements functions for producing the
-maximal subgroups of classical matrix groups.
+@Section Philosophy
+The package &ClassicalMaximals; provides functionality for computing maximal subgroups 
+of finite classical quasisimple groups in their natural matrix representations
+(as returned by the &GAP; functions `SL`, `SU`, `Sp` and `Omega`).
+Its primary purpose is to return a list of representatives of the conjugacy classes
+of maximal subgroups of a given classical group defined over a finite field.
 
-The code is based on descriptions in
-<Cite Key="BHR13" />,
-<Cite Key="HR05" />,
-<Cite Key="KL90" />,
-<Cite Key="HR10" />.
+The implementation follows the classification given in the book by
+Bray, Holt and Roney-Dougal <Cite Key="BHR13" />.
+The maximal subgroups of finite classical groups are divided, according to
+Aschbacher's theorem, into nine classes. The subgroups in the first eight classes
+are referred to as **geometric subgroups**.
+These admit a uniform description, which is developed in detail in the literature
+(see, for example, <Cite Key="KL90" />).
+In particular, their construction can be implemented in a systematic way,
+which is done in this package by directly implementing algorithms from the papers
+<Cite Key="HR05" /> and <Cite Key="HR10" />.
 
+In contrast, subgroups in the ninth class ${\cal S}$ do not admit such a
+uniform description and must be determined separately for each dimension.
+The lists given in <Cite Key="HM01" /> and <Cite Key="L01" /> contain,
+in principle, sufficient information to determine these subgroups up to dimension 250.
+However, explicit computations have so far only been carried out up to dimension 17,
+<Cite Key="BHR13" /> does so up to dimension 12 and for these dimensions our returned
+lists should therefore be complete.
+For higher dimensions we give no completeness guarantee; in particular,
+all subgroups in class ${\cal S}$ are missing in these cases.
 
-@Chapter Maximal Subgroups of Classical Groups
+For the maximal subgroups in class ${\cal S}$, our code is in several parts
+— and in some cases almost entirely — a translation of Magma's `ClassicalMaximals`
+function (written by Derek Holt and Colva Roney-Dougal).
+The package therefore benefits from the extensive prior work done in Magma
+while attempting to adapt it to the &GAP; system.
 
-@Section The Main function
+The central entry point of &ClassicalMaximals; is the function
+<Ref Func="ClassicalMaximalsGeneric"/>.
+This function takes parameters that define a classical group, together with options
+controlling the type of subgroups to compute, and returns representatives of
+maximal subgroups organised according to the classification arising from Aschbacher's theorem.
+An illustrive call looks as follows:
+@BeginLogSession
+gap> ClassicalMaximalsGeneric("L", 3, 4, [1..8]);
+[ <matrix group of size 2880 with 5 generators>, <matrix group of size 2880 with 5 generators>,
+  <matrix group of size 504 with 3 generators>, <matrix group of size 504 with 3 generators>,
+  <matrix group of size 504 with 3 generators>, <matrix group of size 216 with 3 generators> ]
+@EndLogSession
 
-@Section Groups in Class S: cross characteristic
+@Section Overview over this manual
+Chapter <Ref Chap="Chapter_Theory"/> provides a brief theoretical introduction
+to classical groups and Aschbacher's theorem, focusing on the concepts essential
+for this package.
+
+Chapter <Ref Chap="Chapter_MaximalSubgroups"/> documents the package's core
+functionality, specifically the main function <Ref Func="ClassicalMaximalsGeneric"/>.
+
+Chapter <Ref Chap="Chapter_Examples"/> contains examples illustrating the typical
+use of the main function.
+
+Chapter <Ref Chap="Chapter_Utils"/> lists utility functions that, while auxiliary,
+may be of independent interest to the user.
+
+@Section Feedback and Support
+Report bugs, questions and issues on the &ClassicalMaximals; issue tracker:
+<URL>https://github.com/gap-packages/ClassicalMaximals/issues</URL>

--- a/doc/intro.autodoc
+++ b/doc/intro.autodoc
@@ -42,9 +42,12 @@ maximal subgroups organised according to the classification arising from Aschbac
 An illustrive call looks as follows:
 @BeginLogSession
 gap> ClassicalMaximalsGeneric("L", 3, 4, [1..8]);
-[ <matrix group of size 2880 with 5 generators>, <matrix group of size 2880 with 5 generators>,
-  <matrix group of size 504 with 3 generators>, <matrix group of size 504 with 3 generators>,
-  <matrix group of size 504 with 3 generators>, <matrix group of size 216 with 3 generators> ]
+[ <matrix group of size 2880 with 5 generators>,
+  <matrix group of size 2880 with 5 generators>,
+  <matrix group of size 504 with 3 generators>,
+  <matrix group of size 504 with 3 generators>,
+  <matrix group of size 504 with 3 generators>,
+  <matrix group of size 216 with 3 generators> ]
 @EndLogSession
 
 @Section Overview over this manual

--- a/doc/theory.autodoc
+++ b/doc/theory.autodoc
@@ -51,14 +51,14 @@ Gram matrices in Subsection
 @Subsection Non-degeneracy
 @SubsectionLabel Theory:ClassicalGroups:NonDegeneracy
 A sesquilinear form $\beta$ is **non-degenerate** if its radical
-$${\rm Rad}(\beta) = \{v \in V : \beta(u, v) = 0 \,\forall u \in V\}$$
+$${\rm Rad}(\beta) = \{v \in V : \beta(u, v) = 0 \,\text{ for all } u \in V\}$$
 is trivial. A quadratic form is non-degenerate if its polar form is
 non-degenerate.
 
 @Subsection Isometries and similarities
 @SubsectionLabel Theory:ClassicalGroups:Isometries
 Let $g \in {\rm GL}(V)$. Then $g$ is an **isometry of $\beta$** if
-$$\beta(ug, vg) = \beta(u, v) \,\forall u, v \in V$$
+$$\beta(ug, vg) = \beta(u, v) \,\text{ for all } u, v \in V$$
 and an isometry of $Q$ if $Q(vg) = Q(v)$ for all $v$.
 If instead equality holds up to a non-zero scalar $\lambda \in K^\times$,
 $g$ is a **similarity**.

--- a/doc/theory.autodoc
+++ b/doc/theory.autodoc
@@ -51,14 +51,14 @@ Gram matrices in Subsection
 @Subsection Non-degeneracy
 @SubsectionLabel Theory:ClassicalGroups:NonDegeneracy
 A sesquilinear form $\beta$ is **non-degenerate** if its radical
-$${\rm Rad}(\beta) = \{v \in V : \beta(u, v) = 0 \,\text{ for all } u \in V\}$$
+$${\rm Rad}(\beta) = \{v \in V \mid \forall u \in V: \beta(u, v) = 0 \}$$
 is trivial. A quadratic form is non-degenerate if its polar form is
 non-degenerate.
 
 @Subsection Isometries and similarities
 @SubsectionLabel Theory:ClassicalGroups:Isometries
 Let $g \in {\rm GL}(V)$. Then $g$ is an **isometry of $\beta$** if
-$$\beta(ug, vg) = \beta(u, v) \,\text{ for all } u, v \in V$$
+$$\forall u, v \in V: \beta(ug, vg) = \beta(u, v)$$
 and an isometry of $Q$ if $Q(vg) = Q(v)$ for all $v$.
 If instead equality holds up to a non-zero scalar $\lambda \in K^\times$,
 $g$ is a **similarity**.

--- a/doc/theory.autodoc
+++ b/doc/theory.autodoc
@@ -150,7 +150,7 @@ In odd characteristic, we specify quadratic forms via the matrix of their
 associated polar form rather than the quadratic form itself.
 We use the notation $\nu=Z(q^2)$ and $\xi=Z(q)$.
 
-<Table Not="LaTeX" Align="c|c|c|c|c">
+<Table Align="c|c|c|c|c">
   <Caption>Standard classical forms</Caption>
   <HorLine/>
   <Row>
@@ -203,11 +203,16 @@ We use the notation $\nu=Z(q^2)$ and $\xi=Z(q)$.
   <HorLine/>
   <Row>
     <Item>${\bf O}^-$</Item>
-    <Item>$q$ odd, $n$ even<Br/>$n>2$</Item>
+    <Item>
+      <Alt Not="LaTeX">$q$ odd, $n$ even<Br/>$n>2$</Alt>
+      <Alt Only="LaTeX">\begin{tabular}[c]{c}$q$ odd, $n$ even \\ $n>2$\end{tabular}</Alt>
+    </Item>
     <Item>symmetric</Item>
     <Item>${\rm GO}^-_n(q)$</Item>
-    <Item>${\rm antidiag}(1,\dots,1,-\nu-\nu^q,-\nu-\nu^q,1,\dots,1)$
-          <Br/>$-2E_{m,m}-2\xi E_{m+1,m+1}$</Item>
+    <Item>
+      <Alt Not="LaTeX">${\rm antidiag}(1,\dots,1,-\nu-\nu^q,-\nu-\nu^q,1,\dots,1)$<Br/>$-2E_{m,m}-2\xi E_{m+1,m+1}$</Alt>
+      <Alt Only="LaTeX">\begin{tabular}[c]{c}${\rm antidiag}(1,\dots,1,-\nu-\nu^q,-\nu-\nu^q,1,\dots,1)$ \\ $-2E_{m,m}-2\xi E_{m+1,m+1}$\end{tabular}</Alt>
+    </Item>
   </Row>
   <HorLine/>
   <Row>
@@ -220,85 +225,19 @@ We use the notation $\nu=Z(q^2)$ and $\xi=Z(q)$.
   <HorLine/>
   <Row>
     <Item>${\bf O}^-$</Item>
-    <Item>$q$ even, $n$ even<Br/>$n>2$</Item>
+    <Item>
+      <Alt Not="LaTeX">$q$ even, $n$ even<Br/>$n>2$</Alt>
+      <Alt Only="LaTeX">\begin{tabular}[c]{c}$q$ even, $n$ even \\ $n>2$\end{tabular}</Alt>
+    </Item>
     <Item>quadratic</Item>
     <Item>${\rm GO}^-_n(q)$</Item>
-    <Item>${\rm antidiag}(1,\dots,1,-\nu-\nu^q,0,0,\dots,0)$
-          <Br/>$-E_{m,m}-\xi E_{m+1,m+1}$</Item>
+    <Item>
+      <Alt Not="LaTeX">${\rm antidiag}(1,\dots,1,-\nu-\nu^q,0,0,\dots,0)$<Br/>$-E_{m,m}-\xi E_{m+1,m+1}$</Alt>
+      <Alt Only="LaTeX">\begin{tabular}[c]{c}${\rm antidiag}(1,\dots,1,-\nu-\nu^q,0,0,\dots,0)$ \\ $-E_{m,m}-\xi E_{m+1,m+1}$\end{tabular}</Alt>
+    </Item>
   </Row>
   <HorLine/>
 </Table>
-
-@BeginLatexOnly
-\mbox{}\begin{center}
-\begin{tabular}{c|c|c|c|c}
-\hline
-Case & conditions & form type & isom.\ grp. & form \\
-\hline
-${\bf L}$ &
---- &
-zero &
-${\rm GL}_n(q)$ &
-$0_{n \times n}$ \\
-\hline
-${\bf U}$ &
---- &
-hermitian &
-${\rm GU}_n(q)$ &
-${\rm antidiag}(1,\dots,1)$ \\
-\hline
-${\bf S}$ &
-$n$ even &
-alternating &
-${\rm Sp}_n(q)$ &
-${\rm antidiag}(1,\dots,1,-1,\dots,-1)$ \\
-\hline
-${\bf O}$ &
-$q$ odd, $n$ odd &
-symmetric &
-${\rm GO}_n(q)$ &
-${\rm antidiag}(1,\dots,1,\frac{1}{2},1,\dots,1)$ \\
-\hline
-${\bf O}^+$ &
-$q$ odd, $n$ even &
-symmetric &
-${\rm GO}^+_n(q)$ &
-${\rm antidiag}(1,\dots,1)$ \\
-\hline
-${\bf O}^-$ &
-\begin{tabular}[c]{c}
-$q$ odd, $n$ even \\
-$n>2$
-\end{tabular} &
-symmetric &
-${\rm GO}^-_n(q)$ &
-\begin{tabular}[c]{c}
-${\rm antidiag}(1,\dots,1,-\nu-\nu^q,-\nu-\nu^q,1,\dots,1)$ \\
-$-2E_{m,m}-2\xi E_{m+1,m+1}$
-\end{tabular} \\
-\hline
-${\bf O}^+$ &
-$q$ even, $n$ even &
-quadratic &
-${\rm GO}^+_n(q)$ &
-${\rm antidiag}(1,\dots,1,0,\dots,0)$ \\
-\hline
-${\bf O}^-$ &
-\begin{tabular}[c]{c}
-$q$ even, $n$ even \\
-$n>2$
-\end{tabular} &
-quadratic &
-${\rm GO}^-_n(q)$ &
-\begin{tabular}[c]{c}
-${\rm antidiag}(1,\dots,1,-\nu-\nu^q,0,0,\dots,0)$ \\
-$-E_{m,m}-\xi E_{m+1,m+1}$
-\end{tabular} \\
-\hline
-\end{tabular}\\[2mm]
-\textbf{Table: }Standard classical forms
-\end{center}
-@EndLatexOnly
 
 These are exactly the forms preserved by the groups returned by &GAP;'s
 constructors `SL`, `SU`, `Sp`, and `Omega`.
@@ -333,7 +272,7 @@ Let $H$ be a maximal subgroup of $G$. Then one of the following holds:
 The following table gives a rough description of the eight geometric Aschbacher classes,
 based on <Cite Key="KL90" Where="Table 1.2.A" />.
 
-<Table Not="LaTeX" Align="c|c|c">
+<Table Align="c|c|c">
   <Caption>Rough descriptions of geometric Aschbacher classes</Caption>
   <HorLine/>
   <Row>
@@ -374,8 +313,14 @@ based on <Cite Key="KL90" Where="Table 1.2.A" />.
   <HorLine/>
   <Row>
     <Item>${\cal C}_6$</Item>
-    <Item>**extraspecial normaliser**<Br/>**groups**</Item>
-    <Item>normalisers of symplectic-type or extraspecial groups<Br/>in absolutely irreducible representations</Item>
+    <Item>
+      <Alt Not="LaTeX">**extraspecial normaliser**<Br/>**groups**</Alt>
+      <Alt Only="LaTeX">\begin{tabular}[c]{c}\textit{extraspecial normaliser} \\ \textit{groups}\end{tabular}</Alt>
+    </Item>
+    <Item>
+      <Alt Not="LaTeX">normalisers of symplectic-type or extraspecial groups<Br/>in absolutely irreducible representations</Alt>
+      <Alt Only="LaTeX">\begin{tabular}[c]{c}normalisers of symplectic-type or extraspecial groups \\ in absolutely irreducible representations\end{tabular}</Alt>
+    </Item>
   </Row>
   <HorLine/>
   <Row>
@@ -391,57 +336,3 @@ based on <Cite Key="KL90" Where="Table 1.2.A" />.
   </Row>
   <HorLine/>
 </Table>
-
-@BeginLatexOnly
-\mbox{}\begin{center}
-\begin{tabular}{c|c|c}
-\hline
-Class & Type & Rough description \\
-\hline
-${\cal C}_1$ &
-\textit{reducible groups} &
-stabilisers of totally singular or non-singular subspaces \\
-\hline
-${\cal C}_2$ &
-\textit{imprimitive groups} &
-stabilisers of decompositions
-$V=\bigoplus_{i=1}^t V_i,\ {\rm dim}(V_i)=n/t$ \\
-\hline
-${\cal C}_3$ &
-\textit{semilinear groups} &
-stabilisers of extension fields of $\mathbb{F}_q$
-of prime index dividing $n$ \\
-\hline
-${\cal C}_4$ &
-\textit{tensor product groups} &
-stabilisers of tensor product decompositions
-$V=V_1 \otimes V_2$ \\
-\hline
-${\cal C}_5$ &
-\textit{subfield groups} &
-stabilisers of subfields of $\mathbb{F}_q$
-of prime index \\
-\hline
-${\cal C}_6$ &
-\begin{tabular}[c]{c}
-\textit{extraspecial normaliser} \\
-\textit{groups}
-\end{tabular} &
-\begin{tabular}[c]{c}
-normalisers of symplectic-type or extraspecial groups \\
-in absolutely irreducible representations
-\end{tabular} \\
-\hline
-${\cal C}_7$ &
-\textit{tensor induced groups} &
-stabilisers of decompositions
-$V=\bigotimes_{i=1}^t V_i,\ {\rm dim}(V_i)=a,\ n=a^t$ \\
-\hline
-${\cal C}_8$ &
-\textit{classical normaliser groups} &
-groups of similarities of non-degenerate classical forms \\
-\hline
-\end{tabular}\\[2mm]
-\textbf{Table: }Rough descriptions of geometric Aschbacher classes
-\end{center}
-@EndLatexOnly

--- a/doc/theory.autodoc
+++ b/doc/theory.autodoc
@@ -135,7 +135,7 @@ is of plus-type if it is isometric to our standard form matrix
 ${\rm antidiag}(1,\dots,1,0,\dots,0)$ and of minus-type otherwise.
 We denote the isometry group of a standard quadratic or bilinear form of plus-type
 by ${\rm GO}_n^+(q)$ and the isometry group of a standard form of minus-type
-(see <Ref Label="tab:standardclassicalforms"/>) by ${\rm GO}_n^-(q)$.
+(see <Ref Sect="Subsection_Theory:ClassicalGroups:StandardForms"/>) by ${\rm GO}_n^-(q)$.
 
 @Subsection Standard forms in &ClassicalMaximals;
 @SubsectionLabel Theory:ClassicalGroups:StandardForms
@@ -150,7 +150,7 @@ In odd characteristic, we specify quadratic forms via the matrix of their
 associated polar form rather than the quadratic form itself.
 We use the notation $\nu=Z(q^2)$ and $\xi=Z(q)$.
 
-<Table Label="tab:standardclassicalforms" Align="c|c|c|c|c">
+<Table Not="LaTeX" Align="c|c|c|c|c">
   <Caption>Standard classical forms</Caption>
   <HorLine/>
   <Row>
@@ -228,6 +228,78 @@ We use the notation $\nu=Z(q^2)$ and $\xi=Z(q)$.
   </Row>
   <HorLine/>
 </Table>
+
+@BeginLatexOnly
+\mbox{}\begin{center}
+\begin{tabular}{c|c|c|c|c}
+\hline
+Case & conditions & form type & isom.\ grp. & form \\
+\hline
+${\bf L}$ &
+--- &
+zero &
+${\rm GL}_n(q)$ &
+$0_{n \times n}$ \\
+\hline
+${\bf U}$ &
+--- &
+hermitian &
+${\rm GU}_n(q)$ &
+${\rm antidiag}(1,\dots,1)$ \\
+\hline
+${\bf S}$ &
+$n$ even &
+alternating &
+${\rm Sp}_n(q)$ &
+${\rm antidiag}(1,\dots,1,-1,\dots,-1)$ \\
+\hline
+${\bf O}$ &
+$q$ odd, $n$ odd &
+symmetric &
+${\rm GO}_n(q)$ &
+${\rm antidiag}(1,\dots,1,\frac{1}{2},1,\dots,1)$ \\
+\hline
+${\bf O}^+$ &
+$q$ odd, $n$ even &
+symmetric &
+${\rm GO}^+_n(q)$ &
+${\rm antidiag}(1,\dots,1)$ \\
+\hline
+${\bf O}^-$ &
+\begin{tabular}[c]{c}
+$q$ odd, $n$ even \\
+$n>2$
+\end{tabular} &
+symmetric &
+${\rm GO}^-_n(q)$ &
+\begin{tabular}[c]{c}
+${\rm antidiag}(1,\dots,1,-\nu-\nu^q,-\nu-\nu^q,1,\dots,1)$ \\
+$-2E_{m,m}-2\xi E_{m+1,m+1}$
+\end{tabular} \\
+\hline
+${\bf O}^+$ &
+$q$ even, $n$ even &
+quadratic &
+${\rm GO}^+_n(q)$ &
+${\rm antidiag}(1,\dots,1,0,\dots,0)$ \\
+\hline
+${\bf O}^-$ &
+\begin{tabular}[c]{c}
+$q$ even, $n$ even \\
+$n>2$
+\end{tabular} &
+quadratic &
+${\rm GO}^-_n(q)$ &
+\begin{tabular}[c]{c}
+${\rm antidiag}(1,\dots,1,-\nu-\nu^q,0,0,\dots,0)$ \\
+$-E_{m,m}-\xi E_{m+1,m+1}$
+\end{tabular} \\
+\hline
+\end{tabular}\\[2mm]
+\textbf{Table: }Standard classical forms
+\end{center}
+@EndLatexOnly
+
 These are exactly the forms preserved by the groups returned by &GAP;'s
 constructors `SL`, `SU`, `Sp`, and `Omega`.
 
@@ -260,7 +332,8 @@ Let $H$ be a maximal subgroup of $G$. Then one of the following holds:
 
 The following table gives a rough description of the eight geometric Aschbacher classes,
 based on <Cite Key="KL90" Where="Table 1.2.A" />.
-<Table Label="tab:geometricclasses" Align="c|c|c">
+
+<Table Not="LaTeX" Align="c|c|c">
   <Caption>Rough descriptions of geometric Aschbacher classes</Caption>
   <HorLine/>
   <Row>
@@ -301,7 +374,7 @@ based on <Cite Key="KL90" Where="Table 1.2.A" />.
   <HorLine/>
   <Row>
     <Item>${\cal C}_6$</Item>
-    <Item>**extraspecial normaliser<Br/>groups**</Item>
+    <Item>**extraspecial normaliser**<Br/>**groups**</Item>
     <Item>normalisers of symplectic-type or extraspecial groups<Br/>in absolutely irreducible representations</Item>
   </Row>
   <HorLine/>
@@ -318,3 +391,57 @@ based on <Cite Key="KL90" Where="Table 1.2.A" />.
   </Row>
   <HorLine/>
 </Table>
+
+@BeginLatexOnly
+\mbox{}\begin{center}
+\begin{tabular}{c|c|c}
+\hline
+Class & Type & Rough description \\
+\hline
+${\cal C}_1$ &
+\textit{reducible groups} &
+stabilisers of totally singular or non-singular subspaces \\
+\hline
+${\cal C}_2$ &
+\textit{imprimitive groups} &
+stabilisers of decompositions
+$V=\bigoplus_{i=1}^t V_i,\ {\rm dim}(V_i)=n/t$ \\
+\hline
+${\cal C}_3$ &
+\textit{semilinear groups} &
+stabilisers of extension fields of $\mathbb{F}_q$
+of prime index dividing $n$ \\
+\hline
+${\cal C}_4$ &
+\textit{tensor product groups} &
+stabilisers of tensor product decompositions
+$V=V_1 \otimes V_2$ \\
+\hline
+${\cal C}_5$ &
+\textit{subfield groups} &
+stabilisers of subfields of $\mathbb{F}_q$
+of prime index \\
+\hline
+${\cal C}_6$ &
+\begin{tabular}[c]{c}
+\textit{extraspecial normaliser} \\
+\textit{groups}
+\end{tabular} &
+\begin{tabular}[c]{c}
+normalisers of symplectic-type or extraspecial groups \\
+in absolutely irreducible representations
+\end{tabular} \\
+\hline
+${\cal C}_7$ &
+\textit{tensor induced groups} &
+stabilisers of decompositions
+$V=\bigotimes_{i=1}^t V_i,\ {\rm dim}(V_i)=a,\ n=a^t$ \\
+\hline
+${\cal C}_8$ &
+\textit{classical normaliser groups} &
+groups of similarities of non-degenerate classical forms \\
+\hline
+\end{tabular}\\[2mm]
+\textbf{Table: }Rough descriptions of geometric Aschbacher classes
+\end{center}
+@EndLatexOnly

--- a/doc/theory.autodoc
+++ b/doc/theory.autodoc
@@ -1,0 +1,320 @@
+@Chapter Classical Groups and Aschbacher's Theorem
+@ChapterLabel Theory
+
+@Section Classical Groups
+@SectionLabel Theory:ClassicalGroups
+Classical groups in this package are realized as matrix groups over finite
+fields that preserve a specific form on a vector space. These forms are
+represented explicitly by their Gram matrices (with respect to a standard
+basis), and all constructions in the package are carried out relative to
+fixed choices of such matrices.
+
+Let $V$ be an $n$-dimensional vector space over a finite field $K=\mathbb{F}_q$.
+A classical form on $V$ is either a $\sigma$-sesquilinear form
+$\beta: V \times V \to K$ (for some field automorphism
+$\sigma \in {\rm Aut}(K)$) or a quadratic form $Q: V \to K$.
+
+@Subsection Sesquilinear forms
+@SubsectionLabel Theory:ClassicalGroups:SesquilinearForms
+A map $\beta: V \times V \to K$ is a $\sigma$-sesquilinear form if it is
+additive in both arguments and satisfies
+$$\beta(\lambda u, \mu v) = \lambda \mu^\sigma \beta(u, v)$$
+for all $u, v \in V$ and $\lambda, \mu \in K$.
+When $\sigma = 1$ (the identity automorphism), $\beta$ is simply called
+**bilinear**.
+The form is **symmetric** if $\beta(u, v) = \beta(v, u)$ for all $u, v$.
+
+@Subsection Quadratic forms
+@SubsectionLabel Theory:ClassicalGroups:QuadraticForms
+A map $Q: V \to K$ is a **quadratic form** if $Q(\lambda v) = \lambda^2 Q(v)$
+for all $v \in V$ and $\lambda \in K$, and the associated **polar form**
+$$\beta(u, v) := Q(u + v) - Q(u) - Q(v)$$
+is a symmetric bilinear form. Note that $Q$ and $\beta$ uniquely determine
+each other if ${\rm char}(K) \neq 2$.
+
+@Subsection Matrix realizations of classical forms
+@SubsectionLabel Theory:ClassicalGroups:MatrixRealizations
+In this package, classical forms on $V$
+are realized as (Gram) matrices.
+
+For a $\sigma$-sesquilinear form $\beta$, the Gram matrix $B$ satisfies
+$$\beta(u, v) = u B v^{\sigma {\rm T}}$$
+for all column vectors $u, v \in V$.
+For a quadratic form $Q$, the Gram matrix $A$ satisfies
+$$Q(v) = v A v^{\rm T}$$
+for all column vectors $v \in V$.
+
+For relevant classical forms, the package fixes a standard choice of
+Gram matrices in Subsection
+<Ref Sect="Subsection_Theory:ClassicalGroups:StandardForms"/>.
+
+@Subsection Non-degeneracy
+@SubsectionLabel Theory:ClassicalGroups:NonDegeneracy
+A sesquilinear form $\beta$ is **non-degenerate** if its radical
+$${\rm Rad}(\beta) = \{v \in V : \beta(u, v) = 0 \,\forall u \in V\}$$
+is trivial. A quadratic form is non-degenerate if its polar form is
+non-degenerate.
+
+@Subsection Isometries and similarities
+@SubsectionLabel Theory:ClassicalGroups:Isometries
+Let $g \in {\rm GL}(V)$. Then $g$ is an **isometry of $\beta$** if
+$$\beta(ug, vg) = \beta(u, v) \,\forall u, v \in V$$
+and an isometry of $Q$ if $Q(vg) = Q(v)$ for all $v$.
+If instead equality holds up to a non-zero scalar $\lambda \in K^\times$,
+$g$ is a **similarity**.
+
+@Subsection Classification of sesquilinear forms
+@SubsectionLabel Theory:ClassicalGroups:FormsClassification
+By the following fundamental result (<Cite Key="BHR13" Where="Theorem 1.5.13" />)
+the $\sigma$-sesquilinear forms fall into a small number of types
+(up to similarity):
+
+Let $\beta$ be a $\sigma$-sesquilinear form on $V$, and let
+$\lambda \in K^\times$, $\tau \in {\rm Aut}(K)$ satisfy
+$\lambda \beta(u, v)^\tau = \beta(u, v)$ for all $u, v$. Then, up to
+similarity, one of the following holds.
+<Enum>
+ <Item>$\beta = 0$.</Item>
+ <Item>$\sigma = 1$, $\lambda = -1$ and $\beta(v, v) = 0$ for all $v$.
+       $\beta$ is called **alternating** or **symplectic**.</Item>
+ <Item>$\sigma^2 = 1 \neq \sigma$, $\lambda = 1$
+       (i.e. $\beta(v, u) = \beta(u, v)^\sigma$).
+       $\beta$ is called **$\sigma$-Hermitian** or **unitary**.</Item>
+ <Item>$\sigma = 1$, $\lambda = 1$ (i.e. $\beta(v, u) = \beta(u, v)$).
+       $\beta$ is **symmetric bilinear**.</Item>
+</Enum>
+In characteristic 2 the symplectic and symmetric cases overlap.
+Otherwise all cases are mutually exclusive.
+
+@Subsection Linear Groups (Case <M>{\bf L}</M>)
+@SubsectionLabel Theory:ClassicalGroups:L 
+Linear groups preserve the zero form. We will denote the isometry group by ${\rm GL}_n(q)$.
+
+@Subsection Unitary Groups (Case <M>{\bf U}</M>)
+@SubsectionLabel Theory:ClassicalGroups:U
+Unitary groups preserve non-degenerate unitary forms, where $\sigma$ is
+a field automorphism of order 2. So they are only defined over $\mathbb{F}_{q^2}$
+with $\sigma: x\mapsto x^q$. We will use ${\rm antidiag}(1,\dots,1)$
+as our standard unitary form matrix and denote the isometry group by ${\rm GU}_n(q)$.
+
+@Subsection Symplectic Groups (Case <M>{\bf S}</M>)
+@SubsectionLabel Theory:ClassicalGroups:S
+Symplectic groups preserve non-degenerate symplectic forms. We will use
+${\rm antidiag}(1,\dots,1,-1,\dots,-1)$ as our standard symplectic form matrix and
+denote the isometry group by ${\rm Sp}_n(q)$. Note that $n$ must be even.
+
+@Subsection Orthogonal groups in odd dimension (Case <M>{\bf O}</M>)
+@SubsectionLabel Theory:ClassicalGroups:Oodd
+If $Q$ is a quadratic form on $\mathbb{F}_q^n$ with $q$ even and $n$ odd,
+then the isometry group of $Q$ is isomorphic to a symplectic group of dimension $n-1$.
+
+For this reason, we restrict attention to orthogonal groups of odd dimension over fields
+of odd characteristic.
+It is sufficient to define the polar form of $Q$.
+We will use ${\rm antidiag}(1,\dots,1,\frac{1}{2},1,\dots,1)$ as our standard non-degenerate
+symmetric bilinear form matrix and denote the isometry group by ${\rm GO}_n(q)$.
+In odd dimension, there are two isometry classes of non-degenerate symmetric bilinear forms,
+distinguished by whether the determinant of the form matrix is a square or a non-square in
+$\mathbb{F}_q^\times$.
+These two isometry classes, however, belong to the same similarity class.
+
+@Subsection Orthogonal groups in even dimension (Cases <M>{\bf O}^+</M> and <M>{\bf O}^-</M>)
+@SubsectionLabel Theory:ClassicalGroups:Oeven
+In even dimension, non-degenerate quadratic forms fall into two distinct isometry classes,
+which also correspond to two different similarity classes.
+Let $\beta$ denote the polar form associated with a quadratic form $Q$.
+Over a field of odd characteristic, $\beta$ and $Q$ uniquely determine each other.
+
+Assume that $q$ is odd, let $\beta$ be a non-degenerate symmetric bilinear form on
+$\mathbb{F}_q^n$ with $n$ even.
+Then $\beta$ is of **plus-type** if it is isometric to our standard form matrix
+${\rm antidiag}(1,\dots,1)$, and otherwise of **minus-type**.
+
+In even characteristic, a non-degenerate quadratic form $Q$ in even dimension
+is of plus-type if it is isometric to our standard form matrix
+${\rm antidiag}(1,\dots,1,0,\dots,0)$ and of minus-type otherwise.
+We denote the isometry group of a standard quadratic or bilinear form of plus-type
+by ${\rm GO}_n^+(q)$ and the isometry group of a standard form of minus-type
+(see <Ref Label="tab:standardclassicalforms"/>) by ${\rm GO}_n^-(q)$.
+
+@Subsection Standard forms in &ClassicalMaximals;
+@SubsectionLabel Theory:ClassicalGroups:StandardForms
+Let $G$ be the isometry group of one of the following forms on $\mathbb{F}_q^n$:
+the zero form, a unitary form, a symplectic form, a symmetric bilinear form,
+or a quadratic form, as described above.
+
+The following table lists the corresponding form matrices preserved by $G$,
+which we adopt as our **standard form matrices**.
+
+In odd characteristic, we specify quadratic forms via the matrix of their
+associated polar form rather than the quadratic form itself.
+We use the notation $\nu=Z(q^2)$ and $\xi=Z(q)$.
+
+<Table Label="tab:standardclassicalforms" Align="c|c|c|c|c">
+  <Caption>Standard classical forms</Caption>
+  <HorLine/>
+  <Row>
+    <Item>Case</Item>
+    <Item>conditions</Item>
+    <Item>form type</Item>
+    <Item>isom. grp.</Item>
+    <Item>form</Item>
+  </Row>
+  <HorLine/>
+  <Row>
+    <Item>${\bf L}$</Item>
+    <Item>—</Item>
+    <Item>zero</Item>
+    <Item>${\rm GL}_n(q)$</Item>
+    <Item>$0_{n \times n}$</Item>
+  </Row>
+  <HorLine/>
+  <Row>
+    <Item>${\bf U}$</Item>
+    <Item>—</Item>
+    <Item>hermitian</Item>
+    <Item>${\rm GU}_n(q)$</Item>
+    <Item>${\rm antidiag}(1,\dots,1)$</Item>
+  </Row>
+  <HorLine/>
+  <Row>
+    <Item>${\bf S}$</Item>
+    <Item>$n$ even</Item>
+    <Item>alternating</Item>
+    <Item>${\rm Sp}_n(q)$</Item>
+    <Item>${\rm antidiag}(1,\dots,1,-1,\dots,-1)$</Item>
+  </Row>
+  <HorLine/>
+  <Row>
+    <Item>${\bf O}$</Item>
+    <Item>$q$ odd, $n$ odd</Item>
+    <Item>symmetric</Item>
+    <Item>${\rm GO}_n(q)$</Item>
+    <Item>${\rm antidiag}(1,\dots,1,\frac{1}{2},1,\dots,1)$</Item>
+  </Row>
+  <HorLine/>
+  <Row>
+    <Item>${\bf O}^+$</Item>
+    <Item>$q$ odd, $n$ even</Item>
+    <Item>symmetric</Item>
+    <Item>${\rm GO}^+_n(q)$</Item>
+    <Item>${\rm antidiag}(1,\dots,1)$</Item>
+  </Row>
+  <HorLine/>
+  <Row>
+    <Item>${\bf O}^-$</Item>
+    <Item>$q$ odd, $n$ even<Br/>$n>2$</Item>
+    <Item>symmetric</Item>
+    <Item>${\rm GO}^-_n(q)$</Item>
+    <Item>${\rm antidiag}(1,\dots,1,-\nu-\nu^q,-\nu-\nu^q,1,\dots,1)$
+          <Br/>$-2E_{m,m}-2\xi E_{m+1,m+1}$</Item>
+  </Row>
+  <HorLine/>
+  <Row>
+    <Item>${\bf O}^+$</Item>
+    <Item>$q$ even, $n$ even</Item>
+    <Item>quadratic</Item>
+    <Item>${\rm GO}^+_n(q)$</Item>
+    <Item>${\rm antidiag}(1,\dots,1,0,\dots,0)$</Item>
+  </Row>
+  <HorLine/>
+  <Row>
+    <Item>${\bf O}^-$</Item>
+    <Item>$q$ even, $n$ even<Br/>$n>2$</Item>
+    <Item>quadratic</Item>
+    <Item>${\rm GO}^-_n(q)$</Item>
+    <Item>${\rm antidiag}(1,\dots,1,-\nu-\nu^q,0,0,\dots,0)$
+          <Br/>$-E_{m,m}-\xi E_{m+1,m+1}$</Item>
+  </Row>
+  <HorLine/>
+</Table>
+These are exactly the forms preserved by the groups returned by &GAP;'s
+constructors `SL`, `SU`, `Sp`, and `Omega`.
+
+@Section Aschbacher's Theorem
+@SectionLabel Theory:Aschbacher
+Aschbacher's theorem is the organising principle behind the entire package.
+It says that maximal subgroups of finite classical groups fall into nine broad families:
+
+Let $G$ be a quasisimple classical group acting naturally
+on a vector space $V$ of dimension $n \geq 2$ over $\mathbb{F}_q$
+and one of ${\rm SL}_n(q)$, ${\rm SU}_n(q)$, ${\rm Sp}_n(q)$ or $\Omega^\varepsilon_n(q)$.
+
+Let $H$ be a maximal subgroup of $G$. Then one of the following holds:
+<Enum>
+ <Item>$H$ is a **geometric subgroup** and
+  belongs to one of the **geometric** Aschbacher classes
+  ${\cal C}_1,\dots,{\cal C}_8$. These classes consist roughly of
+  groups that preserve some kind of geometric structure on $V$.</Item>
+ <Item>$H$ belongs to the **non-geometric** class ${\cal S}$
+  (sometimes called ${\cal C}_9$). In this case,
+  <List>
+   <Item>$H$ is almost simple modulo scalars,</Item>
+   <Item>$H^\infty$ acts absolutely irreducibly,</Item>
+   <Item>there does not exist a $g \in {\rm GL}_n(q)$ such that
+    $(H^\infty)^g$ is defined over a proper subfield of $\mathbb{F}_q$,</Item>
+   <Item>$H^\infty$ does not preserve a non-zero classical form on $V$
+    other than those already preserved by $G$.</Item>
+  </List></Item>
+</Enum>
+
+The following table gives a rough description of the eight geometric Aschbacher classes,
+based on <Cite Key="KL90" Where="Table 1.2.A" />.
+<Table Label="tab:geometricclasses" Align="c|c|c">
+  <Caption>Rough descriptions of geometric Aschbacher classes</Caption>
+  <HorLine/>
+  <Row>
+    <Item>Class</Item>
+    <Item>Type</Item>
+    <Item>Rough description</Item>
+  </Row>
+  <HorLine/>
+  <Row>
+    <Item>${\cal C}_1$</Item>
+    <Item>**reducible groups**</Item>
+    <Item>stabilisers of totally singular or non-singular subspaces</Item>
+  </Row>
+  <HorLine/>
+  <Row>
+    <Item>${\cal C}_2$</Item>
+    <Item>**imprimitive groups**</Item>
+    <Item>stabilisers of decompositions $V=\bigoplus_{i=1}^t V_i, {\rm dim}(V_i)=n/t$</Item>
+  </Row>
+  <HorLine/>
+  <Row>
+    <Item>${\cal C}_3$</Item>
+    <Item>**semilinear groups**</Item>
+    <Item>stabilisers of extension fields of $\mathbb{F}_q$ of prime index dividing $n$</Item>
+  </Row>
+  <HorLine/>
+  <Row>
+    <Item>${\cal C}_4$</Item>
+    <Item>**tensor product groups**</Item>
+    <Item>stabilisers of tensor product decompositions $V=V_1 \otimes V_2$</Item>
+  </Row>
+  <HorLine/>
+  <Row>
+    <Item>${\cal C}_5$</Item>
+    <Item>**subfield groups**</Item>
+    <Item>stabilisers of subfields of $\mathbb{F}_q$ of prime index</Item>
+  </Row>
+  <HorLine/>
+  <Row>
+    <Item>${\cal C}_6$</Item>
+    <Item>**extraspecial normaliser<Br/>groups**</Item>
+    <Item>normalisers of symplectic-type or extraspecial groups<Br/>in absolutely irreducible representations</Item>
+  </Row>
+  <HorLine/>
+  <Row>
+    <Item>${\cal C}_7$</Item>
+    <Item>**tensor induced groups**</Item>
+    <Item>stabilisers of decompositions $V=\bigotimes_{i=1}^t V_i, {\rm dim}(V_i)=a, n=a^t$</Item>
+  </Row>
+  <HorLine/>
+  <Row>
+    <Item>${\cal C}_8$</Item>
+    <Item>**classical normaliser groups**</Item>
+    <Item>groups of similarities of non-degenerate classical forms</Item>
+  </Row>
+  <HorLine/>
+</Table>

--- a/gap/AlmostSimpleCrossCharacteristic.gd
+++ b/gap/AlmostSimpleCrossCharacteristic.gd
@@ -1,7 +1,4 @@
-#! @Chapter Maximal Subgroups of Classical Groups
-
-#! @Section Groups in Class S: cross characteristic
-
+#! @BeginChunk ModularReductionOfIntegralLattice
 #! @Arguments LR, q : special := false, general := false, normaliser := false
 #! @Returns
 #!  A list of matrix groups over $\mathrm{GF}(q)$, one for each orbit of irreducible
@@ -82,4 +79,5 @@
 #! gap> ModularReductionOfIntegralLattice(LR, 11);
 #! [ <matrix group with 2 generators> ]
 #! @EndExampleSession
+#! @EndChunk
 DeclareGlobalFunction("ModularReductionOfIntegralLattice");

--- a/gap/ClassicalMaximals.gd
+++ b/gap/ClassicalMaximals.gd
@@ -7,19 +7,42 @@ SetInfoLevel(InfoClassicalMaximals, 1);
 DeclareGlobalName("CM_c9lib");
 
 #! @Chapter Maximal Subgroups of Classical Groups
+#! @ChapterLabel MaximalSubgroups
 
 #! @Section The Main function
 
 #! @Arguments type, n, q[, classes]
 #! @Description
-#! Return representatives of the conjugacy classes of maximal subgroups of
-#! the classical group with the given parameters. Here, <A>type</A> must be
-#! a string equal to one of <C>"L"</C>, <C>"U"</C>, <C>"S"</C>, <C>"O-"</C>,
-#! <C>"O"</C>, or <C>"O+"</C>.
+#! Returns a list of representatives of the conjugacy classes of maximal subgroups
+#! of the quasisimple classical group of the specified type in dimension <A>n</A>
+#! over the finite field $\mathbb{F}_q$.
 #!
-#! The optional argument <A>classes</A> must be a subset of the range <C>[1..9]</C>,
-#! corresponding to the Aschbacher classes C1 to C9. If given, it restricts
-#! which classes of maximal subgroups are computed.
+#! The parameter <A>type</A> must be one of the strings
+#! `"L"`, `"U"`, `"O"`, `"O+"`, `"O-"`, corresponding to the quasisimple groups
+#! ${\rm SL}_n(q)$, ${\rm SU}_n(q)$, ${\rm Sp}_n(q)$, $\Omega_n(q)$,
+#! $\Omega^+_n(q)$ and $\Omega^-_n(q)$, respectively
+#! (see Chapter <Ref Chap="Chapter_Theory"/>).
+#!
+#! The returned subgroups are realized as subgroups of the standard classical group
+#! (as returned by the corresponding &GAP; functions), so in particular they preserve
+#! our standard classical form
+#! (see <Ref Sect="Subsection_Theory:ClassicalGroups:StandardForms"/>).
+#!
+#! The optional argument <A>classes</A> must be a subset of `[1..9]` and specifies
+#! which Aschbacher classes are to be computed.
+#! If omitted, all classes ${\cal C}_1, \dots, {\cal C}_9$ are considered.
+#!
+#! The lists are complete for $n \leq 12$. In dimensions 3 and 4, there is a known
+#! exception in class ${\cal C}_1$ for orthogonal types; in these cases a warning
+#! is issued via the info class `InfoClassicalMaximals`.
+#!
+#! For $n > 12$, no completeness guarantee is given. In particular, maximal subgroups
+#! in class ${\cal C}_9$ are not included in these cases.
+#!
+#! The orders of the returned subgroups are precomputed and stored with the groups.
+#!
+#! Section <Ref Chap="Chapter_Examples"/> provides some illustrations
+#! of this function's usage.
 DeclareGlobalFunction("ClassicalMaximalsGeneric");
 # TODO: gap-system/gap has a ClassicalMaximals function. That one should be
 # renamed to something like ClassicalMaximalsFromStoredData, then here we
@@ -30,9 +53,170 @@ DeclareGlobalFunction("MaximalSubgroupClassRepsSpecialUnitaryGroup");
 DeclareGlobalFunction("MaximalSubgroupClassRepsSymplecticGroup");
 DeclareGlobalFunction("MaximalSubgroupClassRepsOrthogonalGroup");
 
+#! @Section Conjugating elements in the ambient classical group
+#! In several constructions it is necessary to pass between a classical group
+#! and larger groups in which it is naturally embedded, such as the corresponding
+#! general linear, unitary, or orthogonal groups, or their normalisers in the
+#! general linear group. In particular, one often needs explicit elements that lie
+#! outside a given subgroup but still preserve the relevant form (possibly up to scalars).
+#! Such elements can be used to conjugate subgroups and to obtain representatives from
+#! different conjugacy classes inside the ambient group.
+#! The following functions provide explicit elements in the various overgroups
+#! of the classical groups considered in this package.
+
+#! @Arguments n q
+#! @Returns an element of ${\rm GL}_n(q) \setminus {\rm SL}_n(q)$.
 DeclareGlobalFunction("GLMinusSL");
+
+#! @Arguments n q
+#! @Returns an element of ${\rm GU}_n(q) \setminus {\rm SU}_n(q)$.
 DeclareGlobalFunction("GUMinusSU");
+
+#! @Arguments n q
+#! @Returns an element of
+#! ${\rm N}_{{\rm GL}_n(q)}({\rm Sp}_n(q)) \setminus {\rm Sp}_n(q)$
+#! which preserves our standard symplectic form modulo a scalar.
 DeclareGlobalFunction("NormSpMinusSp");
+
+#! @Arguments epsilon n q
+#! @Returns an element of
+#! ${\rm SO}^\varepsilon_n(q) \setminus \Omega^\varepsilon_n(q)$
+#! which preserves our standard orthogonal form
+#! (see <Ref Label="tab:standardclassicalforms"/>).
 DeclareGlobalFunction("SOMinusOmega");
+
+#! @Arguments epsilon n q
+#! @Returns an element of
+#! ${\rm GO}^\varepsilon_n(q) \setminus {\rm SO}^\varepsilon_n(q)$
+#! which preserves our standard orthogonal form
+#! (see <Ref Label="tab:standardclassicalforms"/>).
 DeclareGlobalFunction("GOMinusSO");
+
+#! @Arguments epsilon n q
+#! @Returns an element of
+#! ${\rm N}_{{\rm GL}_n(q)}({\rm GO}^\varepsilon_n(q)) \setminus {\rm GO}^\varepsilon_n(q)$
+#! which preserves our standard orthogonal form
+#! (see <Ref Label="tab:standardclassicalforms"/>)
+#! modulo a scalar.
 DeclareGlobalFunction("NormGOMinusGO");
+
+#! @Subsection Warning concerning orthogonal groups of minus type
+#! <Ref Func="SOMinusOmega"/>, <Ref Func="GOMinusSO"/> and <Ref Func="NormGOMinusGO"/>
+#! are affected by a historical inconsistency in the choice of the
+#! invariant bilinear form for orthogonal groups of minus type.
+#!
+#! For $\varepsilon = -1$ the forms kept invariant by
+#! `Omega(-1,n,q)` and `SO(-1,n,q)` need not coincide.
+#!
+#! Consequently the element returned by `GOMinusSO(-1,n,q)`
+#! preserves the form associated with `Omega(-1,n,q)`
+#! (our standard orthogonal form, see <Ref Label="tab:standardclassicalforms"/>)
+#! but does **not** necessarily preserve the form associated with `SO(-1,n,q)`
+#! (as one would expect from the name).
+#!
+#! The element returned by `NormGOMinusGO(-1,n,q)` is guaranteed
+#! to normalise a group preserving the `Omega` form (our standard orthogonal form).
+#!
+#! @BeginLogSession
+#! gap> q := 5;;
+#! gap> G := Omega(-1, 8, q);;
+#! gap> H := SO(-1, 8, q);;
+#! gap> Display(InvariantBilinearForm(G).matrix);
+#!  . . . . . . . 1
+#!  . . . . . . 1 .
+#!  . . . . . 1 . .
+#!  . . . 3 4 . . .
+#!  . . . 4 1 . . .
+#!  . . 1 . . . . .
+#!  . 1 . . . . . .
+#!  1 . . . . . . .
+#! gap> Display(InvariantBilinearForm(H).matrix);
+#!  . 1 . . . . . .
+#!  1 . . . . . . .
+#!  . . 4 . . . . .
+#!  . . . 2 . . . .
+#!  . . . . 2 . . .
+#!  . . . . . 2 . .
+#!  . . . . . . 2 .
+#!  . . . . . . . 2
+#! gap> MG := InvariantBilinearForm(G).matrix;;
+#! gap> MH := InvariantBilinearForm(H).matrix;;
+#! gap> a := GOMinusSO(-1, 8, q);;
+#! gap> b := NormGOMinusGO(-1, 8, q);
+#! gap> a*MG*TransposedMat(a) = MG;
+#! true
+#! gap> a*MH*TransposedMat(a) = MH;
+#! false
+#! gap> (G.1^b)*MG*TransposedMat(G.1^b) = MG;
+#! true
+#! gap> (G.2^b)*MG*TransposedMat(G.2^b) = MG;
+#! true
+#! @EndLogSession
+
+#! @Chapter Examples
+#! The following examples illustrate the use of
+#! <Ref Func="ClassicalMaximalsGeneric"/>.
+#!
+#! Consider the maximal subgroups of ${\rm SU}_5(7)$.
+#! These can be obtained directly as follows:
+#! @BeginLogSession
+#! gap> L := ClassicalMaximalsGeneric("U", 5, 7);
+#! [ <matrix group of size 223883102951424 with 6 generators>,
+#!   <matrix group of size 32541148684800 with 6 generators>,
+#!   <matrix group of size 37298309529600 with 4 generators>,
+#!   <matrix group of size 15223799808 with 5 generators>,
+#!   <matrix group of size 491520 with 4 generators>,
+#!   <matrix group of size 10505 with 2 generators>,
+#!   <matrix group of size 276595200 with 4 generators>,
+#!   <matrix group of size 660 with 2 generators> ]
+#! gap> DefaultFieldOfMatrixGroup(L[1]);
+#! GF(7^2)
+#! @EndLogSession
+#! Note that unitary groups are defined over
+#! $\mathbb{F}_{q^2}$, even though they are parametrised by $q$
+#! (see <Ref Sect="Subsection_Theory:ClassicalGroups:U"/>).
+#!
+#! It is often useful to restrict attention to certain Aschbacher classes.
+#! For example, the reducible and imprimitive maximal subgroups of
+#! ${\rm Sp}_6(9)$ (that is, classes ${\cal C}_1$ and ${\cal C}_2$) can be
+#! obtained by specifying the optional argument <A>classes</A>:
+#! @BeginLogSession
+#! gap> ClassicalMaximalsGeneric("S", 6, 9, [1, 2]);
+#! [ <matrix group of size 1626546181017600 with 6 generators>,
+#!   <matrix group of size 19835929036800 with 6 generators>,
+#!   <matrix group of size 180506954234880 with 3 generators>,
+#!   <matrix group of size 2479113216000 with 4 generators>,
+#!   <matrix group of size 2239488000 with 4 generators>,
+#!   <matrix group of size 679311360 with 3 generators> ]
+#! @EndLogSession
+#!
+#! The groups returned by <Ref Func="ClassicalMaximalsGeneric"/> are
+#! realised as subgroups of the corresponding standard classical group
+#! and therefore preserve the standard form. This can be verified using
+#! the stored invariant forms. For example, consider a maximal subgroup
+#! of ${\rm \Omega}^-_8(5)$ in class ${\cal C}_9$:
+#!
+#! @BeginLogSession
+#! gap> G := ClassicalMaximalsGeneric("O-", 8, 5, [9])[1];
+#! <matrix group of size 372000 with 2 generators>
+#! gap> Display(InvariantBilinearForm(G).matrix);
+#!  . . . . . . . 1
+#!  . . . . . . 1 .
+#!  . . . . . 1 . .
+#!  . . . 3 4 . . .
+#!  . . . 4 1 . . .
+#!  . . 1 . . . . .
+#!  . 1 . . . . . .
+#!  1 . . . . . . .
+#! gap> Display(InvariantBilinearForm(Omega(-1, 8, 5)).matrix);
+#!  . . . . . . . 1
+#!  . . . . . . 1 .
+#!  . . . . . 1 . .
+#!  . . . 3 4 . . .
+#!  . . . 4 1 . . .
+#!  . . 1 . . . . .
+#!  . 1 . . . . . .
+#!  1 . . . . . . .
+#! @EndLogSession
+#! The two matrices coincide, confirming that the subgroup preserves our
+#! standard orthogonal form.

--- a/gap/ClassicalMaximals.gd
+++ b/gap/ClassicalMaximals.gd
@@ -82,21 +82,21 @@ DeclareGlobalFunction("NormSpMinusSp");
 #! @Returns an element of
 #! ${\rm SO}^\varepsilon_n(q) \setminus \Omega^\varepsilon_n(q)$
 #! which preserves our standard orthogonal form
-#! (see <Ref Label="tab:standardclassicalforms"/>).
+#! (see <Ref Sect="Subsection_Theory:ClassicalGroups:StandardForms"/>).
 DeclareGlobalFunction("SOMinusOmega");
 
 #! @Arguments epsilon n q
 #! @Returns an element of
 #! ${\rm GO}^\varepsilon_n(q) \setminus {\rm SO}^\varepsilon_n(q)$
 #! which preserves our standard orthogonal form
-#! (see <Ref Label="tab:standardclassicalforms"/>).
+#! (see <Ref Sect="Subsection_Theory:ClassicalGroups:StandardForms"/>).
 DeclareGlobalFunction("GOMinusSO");
 
 #! @Arguments epsilon n q
 #! @Returns an element of
 #! ${\rm N}_{{\rm GL}_n(q)}({\rm GO}^\varepsilon_n(q)) \setminus {\rm GO}^\varepsilon_n(q)$
 #! which preserves our standard orthogonal form
-#! (see <Ref Label="tab:standardclassicalforms"/>)
+#! (see <Ref Sect="Subsection_Theory:ClassicalGroups:StandardForms"/>)
 #! modulo a scalar.
 DeclareGlobalFunction("NormGOMinusGO");
 
@@ -110,7 +110,8 @@ DeclareGlobalFunction("NormGOMinusGO");
 #!
 #! Consequently the element returned by `GOMinusSO(-1,n,q)`
 #! preserves the form associated with `Omega(-1,n,q)`
-#! (our standard orthogonal form, see <Ref Label="tab:standardclassicalforms"/>)
+#! (our standard orthogonal form, see
+#! <Ref Sect="Subsection_Theory:ClassicalGroups:StandardForms"/>)
 #! but does **not** necessarily preserve the form associated with `SO(-1,n,q)`
 #! (as one would expect from the name).
 #!

--- a/gap/Forms.gd
+++ b/gap/Forms.gd
@@ -5,8 +5,7 @@ DeclareGlobalFunction("CM_UnitaryForm");
 DeclareGlobalFunction("CM_BilinearForm");
 DeclareGlobalFunction("CM_QuadraticForm");
 
-#! @Chapter Group Recognition
-#! @Section Classical Forms
+#! @BeginChunk CM_ClassicalForms
 #! @Arguments G field
 #! @Description
 #!  Assuming that the matrix group <A>G</A> is acting absolutely irreducibly on a vector
@@ -44,5 +43,7 @@ DeclareGlobalFunction("CM_QuadraticForm");
 #!  * <C>"unitary"</C>: <A>G</A> fixes a unitary form. The form matrix is given in
 #!    <C>sesquilinearForm</C>.
 #!  * <C>"linear"</C>: <A>G</A> does not fix any classical form.
+#! @EndChunk
 DeclareGlobalFunction("CM_ClassicalForms");
+
 DeclareGlobalFunction("ConjugateToStandardFormAutoType");

--- a/gap/Utils.gd
+++ b/gap/Utils.gd
@@ -1,4 +1,5 @@
 #! @Chapter Utility Functions
+#! @ChapterLabel Utils
 
 #! @Section Matrix Functions
 
@@ -39,7 +40,6 @@ DeclareGlobalFunction("AntidiagonalHalfOneMat");
 #! is more efficient than matrix multiplication.
 DeclareGlobalFunction("RotateMat");
 
-
 #! @Section Creating Matrix Groups
 
 #! @Arguments F, gens
@@ -61,13 +61,111 @@ DeclareGlobalFunction("MatrixGroup");
 #! setting the group's size, this does the same as <Ref Func="MatrixGroup"/>.
 DeclareGlobalFunction("MatrixGroupWithSize");
 
+#! @Section Special generators for classical groups
+#! This section provides functions to construct explicit generating sets for
+#! classical groups, namely orthogonal and linear groups over finite fields,
+#! as used in <Cite Key="HR05" /> and <Cite Key="HR10" />.
+
+#! @Arguments epsilon n q
+#! @Returns a record with components `generatorsOfSO`, `D` and `E`.
+#! @Description
+#! Constructs generators for the orthogonal groups with the properties listed
+#! in <Cite Key="HR05" Where="Lemma 2.4" />.
+#! Construction as in <Cite Key="R-D13" Where="Lemma 2.4" />.
+DeclareGlobalFunction("GeneratorsOfOrthogonalGroup");
+
+#! @Arguments epsilon n q
+#! @Returns a record with components `generatorsOfOmega`, `S`, `G` and `D`.
+#! @Description
+#! Constructs standard generators `generatorsOfOmega`, `S`,
+#! `G`, `D` for the orthogonal groups with respect to our standard
+#! form as used in <Cite Key="HR10" />, with the following properties:
+#! * `generatorsOfOmega` generate $\Omega^\varepsilon_n(q)$
+#! * `generatorsOfOmega` and `S` generate ${\rm SO}_n(q)$
+#! * `generatorsOfOmega` and `G` generate ${\rm GO}_n(q)$
+#! * the spinor norm of `G` is $1$
+#! * `D` generates ${\rm CO}^\varepsilon_n(q)$ modulo ${\rm GO}^\varepsilon_n(q)$.
+#!
+#! Construction as in Theorem 3.9 loc. cit.
+DeclareGlobalFunction("StandardGeneratorsOfOrthogonalGroup");
+
+#! @Arguments n q squareDiscriminant
+#! @Returns a record with components `generatorsOfOmega`, `S`, `G` and `D`.
+#! @Description
+#! Constructs standard generators `generatorsOfOmega`, `S`,
+#! `G`, `D` for the orthogonal groups with respect to our
+#! **diagonal form** of given discriminant as used in <Cite Key="HR10" />.
+#!
+#! The generators satisfy exactly the same properties as those returned
+#! by <Ref Func="StandardGeneratorsOfOrthogonalGroup"/>, except that
+#! they are constructed with respect to a diagonal form (rather than the
+#! standard form used there).
+#!
+#! Note that the parameter $\varepsilon$ is uniquely determined by
+#! <A>n</A>, <A>q</A> and <A>squareDiscriminant</A>.
+#!
+#! Construction as in Theorem 3.9 loc. cit.
+#!
+#! <A>q</A> must be odd.
+DeclareGlobalFunction("AlternativeGeneratorsOfOrthogonalGroup");
+
+#! @Arguments n q
+#! @Returns a record with components `L1`, `L2` and `L3`.
+#! @Description
+#! Constructs standard generators `L1`, `L2`, `L3` as
+#! used in <Cite Key="HR10" /> with the following properties (analogous to
+#! Theorem 3.11 loc. cit.):
+#! * `L1` and `L2` generate ${\rm GL}_n(q)$.
+#! * `L1` and `L3` generate ${\rm SL}_n(q)$.
+#! * all matrix entries lie in $\{0, \pm 1, \pm \zeta^{\pm 1}\}$, where
+#!   $\zeta$ is a primitive element of $\mathbb{F}_q$.
+#! * If `q` is odd, `L1` and `L2^2` generate the unique subgroup of
+#!   index 2 in ${\rm GL}_n(q)$, often denoted $\frac{1}{2} {\rm GL}_n(q)$.
+#! The construction is taken from <Cite Key="T87" />.
+DeclareGlobalFunction("StandardGeneratorsOfLinearGroup");
+
+#! @Section Sizes of classical groups
+#! This section provides functions to compute the orders of various classical groups
+#! over finite fields, using the information collected in <Cite Key="BHR13" />.
+
+#! @Arguments n q
+#! @Returns the size of the group <C>Sp</C>( <A>n</A> , <A>q</A> ),
+#! according to <Cite Key="BHR13" Where="Theorem 1.6.22"/>.
 DeclareGlobalFunction("SizeSp");
+
+#! @Arguments n q
+#! @Returns the size of the group <C>PSp</C>( <A>n</A> , <A>q</A> ),
+#! according to <Cite Key="BHR13" Where="Table 1.3"/>.
 DeclareGlobalFunction("SizePSp");
+
+#! @Arguments n q
+#! @Returns the size of the group <C>SU</C>( <A>n</A> , <A>q</A> ),
+#! according to <Cite Key="BHR13" Where="Theorem 1.6.22"/>.
 DeclareGlobalFunction("SizeSU");
+
+#! @Arguments n q
+#! @Returns the size of the group <C>PSU</C>( <A>n</A> , <A>q</A> ),
+#! according to <Cite Key="BHR13" Where="Table 1.3"/>.
 DeclareGlobalFunction("SizePSU");
+
+#! @Arguments n q
+#! @Returns the size of the group <C>GU</C>( <A>n</A> , <A>q</A> ),
+#! according to <Cite Key="BHR13" Where="Table 1.3"/>.
 DeclareGlobalFunction("SizeGU");
+
+#! @Arguments epsilon n q
+#! @Returns the size of the group <C>GO</C>( <A>epsilon</A>, <A>n</A> , <A>q</A> ),
+#! according to <Cite Key="BHR13" Where="Theorem 1.6.22"/>.
 DeclareGlobalFunction("SizeGO");
+
+#! @Arguments epsilon n q
+#! @Returns the size of the group <C>SO</C>( <A>epsilon</A>, <A>n</A> , <A>q</A> ),
+#! according to <Cite Key="BHR13" Where="Table 1.3"/>.
 DeclareGlobalFunction("SizeSO");
+
+#! @Arguments epsilon n q
+#! @Returns the size of the group <C>Omega</C>( <A>epsilon</A>, <A>n</A> , <A>q</A> ),
+#! according to <Cite Key="BHR13" Where="Table 1.3"/>.
 DeclareGlobalFunction("SizeOmega");
 
 DeclareGlobalFunction("CM_InOmega");

--- a/gap/Utils.gi
+++ b/gap/Utils.gi
@@ -244,7 +244,6 @@ function(m, n)
     fi;
 end);
 
-# Compute the size of Sp(n, q) according to Theorem 1.6.22 in [BHR13]
 InstallGlobalFunction("SizeSp",
 function(n, q)
     local m, result, powerOfq, i;
@@ -261,15 +260,11 @@ function(n, q)
     return result;
 end);
 
-# Compute the size of PSp(n, q) according to Table 1.3 in [BHR13],
 InstallGlobalFunction("SizePSp",
 function(n, q)
     return QuoInt(SizeSp(n, q), Gcd(2, q - 1));
 end);
 
-# Compute the size of SU(n, q) according to Theorem 1.6.22 in [BHR13]
-# using the formula for GU(n, q) but starting with i = 2
-# because Table 1.3 gives [GU(n, q):SU(n, q)] = q + 1.
 InstallGlobalFunction("SizeSU",
 function(n, q)
     local result, powerOfq, sign, i;
@@ -284,22 +279,16 @@ function(n, q)
     return result;
 end);
 
-# Compute the size of PSU(n, q) according to Table 1.3 in [BHR13]
-# Namely, we have | G / Z(G) : S / Z(S) | = | G : S | * |Z(S)| / |Z(G)| so due
-# to | G : S | = q + 1, |Z(G)| = q + 1 and | G / Z(G) : S / Z(S) | = (q + 1, n), 
-# which are given in said table, this gives |Z(S)| = (q + 1, n). 
 InstallGlobalFunction("SizePSU",
 function(n, q)
     return SizeSU(n, q) / Gcd(n, q + 1);
 end);
 
-# Compute the size of GU(n, q) according to Table 1.3 in [BHR13]
 InstallGlobalFunction("SizeGU",
 function(n, q)
     return (q + 1) * SizeSU(n, q);
 end);
 
-# Compute the size of GO(epsilon, n, q) according to Theorem 1.6.22 in [BHR13]
 InstallGlobalFunction("SizeGO",
 function(epsilon, n, q)
     local m, result, powerOfq, i;
@@ -338,13 +327,11 @@ function(epsilon, n, q)
     return result;
 end);
 
-# Compute the size of SO(epsilon, n, q) according to Table 1.3 in [BHR13]
 InstallGlobalFunction("SizeSO",
 function(epsilon, n, q)
     return QuoInt(SizeGO(epsilon, n, q), Gcd(2, q - 1));
 end);
 
-# Compute the size of Omega(epsilon, n, q) according to Table 1.3 in [BHR13]
 InstallGlobalFunction("SizeOmega",
 function(epsilon, n, q)
     if IsOddInt(n) and IsEvenInt(q) then
@@ -399,13 +386,7 @@ function(n, q, gramMatrix, type, v)
     return reflectionMatrix;
 end);
 
-# Construct generators for the orthogonal groups with the properties listed in
-# Lemma 2.4 of [HR05].
-# Construction as in: C. M. Roney-Dougal. "Conjugacy of Subgroups of the
-# General Linear Group." Experimental Mathematics, vol. 13 no. 2, 2004, pp.
-# 151-163. Lemma 2.4.
-# We take the notation from [HR05].
-BindGlobal("GeneratorsOfOrthogonalGroup",
+InstallGlobalFunction("GeneratorsOfOrthogonalGroup",
 function(epsilon, n, q)
     local F, gramMatrix, generatorsOfSO, vectorOfSquareNorm, D, E, zeta, a, b,
     solutionOfQuadraticCongruence;
@@ -489,16 +470,7 @@ function(epsilon, n, q)
     return rec(generatorsOfSO := generatorsOfSO, D := D, E := E);
 end);
 
-# Construct standard generators generatorsOfOmega, S, G, D for the orthogonal
-# groups with respect to our standard form as used in [HR10], with the
-# following properties:
-#   * generatorsOfOmega generate Omega(epsilon, d, q)
-#   * generatorsOfOmega and S generate SO(epsilon, d, q)
-#   * generatorsOfOmega, S and G generate GO(epsilon, d, q)
-#   * the spinor norm of G is 1
-#   * D generates CO(epsilon, d, q) mod GO(epsilon, d, q)
-# Construction as in Theorem 3.9 loc. cit.
-BindGlobal("StandardGeneratorsOfOrthogonalGroup",
+InstallGlobalFunction("StandardGeneratorsOfOrthogonalGroup",
 function(epsilon, d, q)
     local field, one, zeta, standardForm, Q, m, conjugatedOmega, 
     generatorsOfOmega, e, p, R0, R1, S, G, D, xi;
@@ -601,18 +573,7 @@ function(epsilon, d, q)
     return rec(generatorsOfOmega := generatorsOfOmega, S := S, G := G, D := D);
 end);
 
-# Construct standard generators generatorsOfOmega, S, G, D for the orthogonal
-# groups with respect to our diagonal form of given discriminant as used in [HR10],
-# with the following properties (note that epsilon is uniquely determined by
-# the given parameters):
-#   * generatorsOfOmega generate Omega(epsilon, d, q)
-#   * generatorsOfOmega and S generate SO(epsilon, d, q)
-#   * generatorsOfOmega, S and G generate GO(epsilon, d, q)
-#   * the spinor norm of G is 1
-#   * D generates CO(epsilon, d, q) mod GO(epsilon, d, q)
-# Construction as in Theorem 3.9 loc. cit., but with different vectors.
-# Recall that q must be odd in this case.
-BindGlobal("AlternativeGeneratorsOfOrthogonalGroup",
+InstallGlobalFunction("AlternativeGeneratorsOfOrthogonalGroup",
 function(d, q, squareDiscriminant)
     local field, one, zeta, epsilon, F, nonZeroEntries, vectorOfNonSquareForm,
     vectorOfSquareForm, R0, R1, generatorsOfOmega, S, G, D;
@@ -662,16 +623,7 @@ function(d, q, squareDiscriminant)
     return rec(generatorsOfOmega := generatorsOfOmega, S := S, G := G, D := D);
 end);
 
-# Construct standard generators L1, L2, L3 as used in [HR10]
-# with the following properties similar to Theorem 3.11 in [HR10]:
-#   * L1 and L2 generate GL(d, q)
-#   * L1 and L3 generate SL(d, q)
-#   * all matrix entries lie in {0, \pm 1, \pm zeta^{\pm 1}}, where
-#       zeta is a primitive element of GF(q)
-#   * If q is odd, L1 and L2^2 generate the unique subgroup
-#       of index 2 of GL(d, q), often denoted (1 / 2) GL(d, q).
-# Construction as in [T87]
-BindGlobal("StandardGeneratorsOfLinearGroup",
+InstallGlobalFunction("StandardGeneratorsOfLinearGroup",
 function(d, q)
     local field, one, zeta, L1, L2, L3;
 

--- a/makedoc.g
+++ b/makedoc.g
@@ -8,6 +8,7 @@ if fail = LoadPackage("AutoDoc", "2018.02.14") then
 fi;
 
 AutoDoc( rec(
-    autodoc := rec( files := [ "doc/intro.autodoc" ] ),
+    autodoc := rec( files := [ "doc/intro.autodoc",
+                               "doc/theory.autodoc" ] ),
     scaffold := true,
 ) );


### PR DESCRIPTION
This PR extends the package manual, which is now organized as follows:
- Chapter 1: Introduction
- Chapter 2: Background on classical groups and Aschbacher's theorem
- Chapter 3: Documentation of `ClassicalMaximalsGeneric`
- Chapter 4: Examples illustrating typical usage
- Chapter 5: Documentation of some utility functions (including selected generating elements and size-related functions)

In particular, the documentation of `ClassicalMaximalsGeneric` has been expanded, including:
- description of the preserved forms (our "standard forms"),
- clarification of the group-theoretic setting (we consider *quasisimple* classical groups),
- discussion of completeness up to dimension 12 ...

Addresses issue [#122](https://github.com/gap-packages/ClassicalMaximals/issues/122), but does not fully resolve it, a complete list of missing features is still pending (done in [#160](https://github.com/gap-packages/ClassicalMaximals/pull/160)).