### PR TITLE
Handle low-dimensional cases in orthogonal C1 subgroups construction

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,7 @@ Translation of magma `ClassicalMaximals` to GAP. For resources see
 - **Type L**: Complete for dimensions 2-12
 - **Type U**: Complete for dimensions 3-12
 - **Type S**: Complete for dimensions 4-12
-- **Type O**: Complete for dimensions 5-12
-    - **C2-C8**: Complete for dimensions 3-12
+- **Type O**: Complete for dimensions 3-12
     - **C2 & C4**: Complete for all dimensions
 
 #### Almost simple groups (Class S)
@@ -25,7 +24,7 @@ Translation of magma `ClassicalMaximals` to GAP. For resources see
     - `novelties`: Intersections of novelty maximal subgroups with the quasisimple group
     - `special`: Normalisers in SO(n,q)
     - `general`: Normalisers in GL(n,q), GU(n,q), or GO(n,q)
-    - `normaliser`: Normalizers in the full conformal group (preserving form modulo scalars)
+    - `normaliser`: Normalisers in the full conformal group (preserving form modulo scalars)
         - forms preserved up to scalars are not stored (awaiting full GAP support for conformal groups)
     - all these options complete for dimensions up to 12
     - ... but group sizes for `special`, `general`, `normaliser` are not precomputed and stored
@@ -39,8 +38,6 @@ Translation of magma `ClassicalMaximals` to GAP. For resources see
 ### Roadmap / TODO
 
 #### Geometric maximal subgroups (Aschbacher Classes C1-C8)
-- Finalize **C1** for dimensions 3 and 4
-  ([#155](https://github.com/gap-packages/ClassicalMaximals/issues/155))
 - Generalize other Aschbacher classes to work for all dimensions
 - Implement `all`, `novelties`, `special`, `general`, `normaliser` for all geometric classes
 

--- a/gap/ClassicalMaximals.gd
+++ b/gap/ClassicalMaximals.gd
@@ -32,10 +32,7 @@ DeclareGlobalName("CM_c9lib");
 #! which Aschbacher classes are to be computed.
 #! If omitted, all classes ${\cal C}_1, \dots, {\cal C}_9$ are considered.
 #!
-#! The lists are complete for $n \leq 12$. In dimensions 3 and 4, there is a known
-#! exception in class ${\cal C}_1$ for orthogonal types; in these cases a warning
-#! is issued via the info class `InfoClassicalMaximals`.
-#!
+#! The lists are complete for $n \leq 12$.
 #! For $n > 12$, no completeness guarantee is given. In particular, maximal subgroups
 #! in class ${\cal C}_9$ are not included in these cases.
 #!

--- a/gap/ClassicalMaximals.gi
+++ b/gap/ClassicalMaximals.gi
@@ -3482,13 +3482,6 @@ function(epsilon, n, q)
         if (epsilon = 1 and k = m - 1) or (epsilon = -1 and k = m) then
             continue;
         fi;
-        # The construction in OmegaStabilizerOfIsotropicSubspace fails for n < 5
-        # This affects the quasisimple groups O(3,q) and O^-(4,q)
-        if n < 5 then
-            Info(InfoClassicalMaximals, 1, "List incomplete.",
-                 " Missing subgroup in C1 of isotropic type P_", k);
-            continue;
-        fi;
         G := OmegaStabilizerOfIsotropicSubspace(epsilon, n, q, k);
         if epsilon = 1 and k = m then
             Append(result, ConjugateSubgroupOmega(epsilon, n, q, G, 2));

--- a/gap/ReducibleMatrixGroups.gi
+++ b/gap/ReducibleMatrixGroups.gi
@@ -652,7 +652,7 @@ function(epsilon, d, q, k)
         if IsEvenInt(q) then
             gamma := FindGamma(q);
         else
-            xi := PrimitiveElement(GF(q ^ 2));
+            xi := PrimitiveRoot(GF(q ^ 2));
             gamma := xi ^ (q + 1) * (xi + xi ^ q) ^ -2;
         fi;
         eta := (1 - 4 * gamma) ^ -1;

--- a/gap/ReducibleMatrixGroups.gi
+++ b/gap/ReducibleMatrixGroups.gi
@@ -546,9 +546,8 @@ function(epsilon, d, q, k)
         ErrorNoReturn("<k> must not be equal to <m> for <epsilon> = -1");
     fi;
 
-    # the construction referenced above fails for d < 5
-    if d < 5 then
-        ErrorNoReturn("<d> must be at least 5");
+    if d < 3 then
+        ErrorNoReturn("<d> must be at least 3");
     fi;
 
     field := GF(q);
@@ -561,6 +560,7 @@ function(epsilon, d, q, k)
     if IsEvenInt(q) then
 
         for L in [linearGens.L1, linearGens.L2] do
+            if IsOne(L) then continue; fi;
             H_1or2 := IdentityMat(d, field);
             H_1or2{[1..k]}{[1..k]} := L;
             H_1or2{[d - k + 1..d]}{[d - k + 1..d]} := RotateMat(TransposedMat(L ^ -1));
@@ -586,6 +586,7 @@ function(epsilon, d, q, k)
         if k = m then
             
             for L in [linearGens.L1, linearGens.L2 ^ 2] do
+                if IsOne(L) then continue; fi;
                 H_1or2 := IdentityMat(d, field);
                 H_1or2{[1..k]}{[1..k]} := L;
                 H_1or2{[d - k + 1..d]}{[d - k + 1..d]} := RotateMat(TransposedMat(L ^ -1));
@@ -604,6 +605,7 @@ function(epsilon, d, q, k)
 
             orthogonalGens := StandardGeneratorsOfOrthogonalGroup(epsilon, d - 2 * k, q);
             for matrices in [[linearGens.L1, IdentityMat(d - 2 * k, field)], [linearGens.L2, orthogonalGens.S]] do
+                if IsOne(matrices[1]) and IsOne(matrices[2]) then continue; fi;
                 H_1or2 := IdentityMat(d, field);
                 H_1or2{[1..k]}{[1..k]} := matrices[1];
                 H_1or2{[k + 1..d - k]}{[k + 1..d - k]} := matrices[2];
@@ -625,41 +627,36 @@ function(epsilon, d, q, k)
     fi;
 
     # We now construct the p-core of the stabilizer.
-    if k = 1 then
-
-        Add(gens, IdentityMat(d, field) + MatrixByEntries(field, d, d, [[2, 1, one], [d, d - 1, -one]]));
-
-    elif k < QuoInt(d - 1, 2) then
+    if k > 1 then
 
         Add(gens, IdentityMat(d, field) + MatrixByEntries(field, d, d, [[d - 1, 1, one], [d, 2, -one]]));
+
+    fi;
+
+    if (d > 2*k + 2) or (d = 2*k + 2 and epsilon = 1) then
+
         Add(gens, IdentityMat(d, field) + MatrixByEntries(field, d, d, [[k + 1, 1, one], [d, d - k, -one]]));
-
-    elif IsEvenInt(d) and k = m - 1 then
-
-        Add(gens, IdentityMat(d, field) + MatrixByEntries(field, d, d, [[d - 1, 1, one], [d, 2, -one]]));
-        if epsilon = 1 then
-            Add(gens, IdentityMat(d, field) + MatrixByEntries(field, d, d, [[k + 1, 1, one], [d, d - k, -one]]));
+        if d = 2*k + 2 and epsilon = 1 then
             # [HR10] wants the matrix
             # IdentityMat(d, field) + MatrixByEntries(field, d, d, [[k + 2, 1, one], [d - k - 1, 1, -one]])
             # here, but that just makes no sense. Instead, this works :)
             Add(gens, IdentityMat(d, field) + MatrixByEntries(field, d, d, [[k + 2, 1, one], [d, d - k - 1, -one]]));
-        else
-            if IsEvenInt(q) then
-                gamma := FindGamma(q);
-            else
-                xi := PrimitiveElement(GF(q ^ 2));
-                gamma := xi ^ (q + 1) * (xi + xi ^ q) ^ -2;
-            fi;
-            eta := (1 - 4 * gamma) ^ -1;
-            Add(gens, IdentityMat(d, field) + MatrixByEntries(field, d, d, [[k + 1, 1, one], [d, 1, gamma * eta], [d, k + 1, 2 * gamma * eta], [d, k + 2, -eta]]));
         fi;
-            
-    else
 
-        Add(gens, IdentityMat(d, field) + MatrixByEntries(field, d, d, [[d - 1, 1, one], [d, 2, -one]]));
-        if IsOddInt(d) then
-            Add(gens, IdentityMat(d, field) + MatrixByEntries(field, d, d, [[k + 1, 1, one], [d, d - k, -one], [d, 1, -one / 2]]));
+    elif d = 2*k + 1 then  # odd case
+
+        Add(gens, IdentityMat(d, field) + MatrixByEntries(field, d, d, [[k + 1, 1, one], [d, d - k, -one], [d, 1, -one / 2]]));
+
+    elif d = 2*k + 2 and epsilon = -1 then
+
+        if IsEvenInt(q) then
+            gamma := FindGamma(q);
+        else
+            xi := PrimitiveElement(GF(q ^ 2));
+            gamma := xi ^ (q + 1) * (xi + xi ^ q) ^ -2;
         fi;
+        eta := (1 - 4 * gamma) ^ -1;
+        Add(gens, IdentityMat(d, field) + MatrixByEntries(field, d, d, [[k + 1, 1, one], [d, 1, gamma * eta], [d, k + 1, 2 * gamma * eta], [d, k + 2, -eta]]));
 
     fi;
 

--- a/tst/standard/ClassicalMaximals.tst
+++ b/tst/standard/ClassicalMaximals.tst
@@ -1,6 +1,4 @@
 gap> START_TEST("ClassicalMaximals.tst");
-gap> oldClassicalMaximalsInfoLevel:=InfoLevel(InfoClassicalMaximals);;
-gap> SetInfoLevel(InfoClassicalMaximals, 1);
 
 # Test error handling
 gap> ClassicalMaximalsGeneric("L", 2, 4, [0]);
@@ -548,62 +546,43 @@ gap> Length(ClassicalMaximalsGeneric("S", 12, 19));
 
 #
 gap> Length(ClassicalMaximalsGeneric("O", 3, 5));
-#I  List incomplete. Missing subgroup in C1 of isotropic type P_1
-2
+3
 gap> Length(ClassicalMaximalsGeneric("O", 3, 7));
-#I  List incomplete. Missing subgroup in C1 of isotropic type P_1
-2
+3
 gap> Length(ClassicalMaximalsGeneric("O", 3, 9));
-#I  List incomplete. Missing subgroup in C1 of isotropic type P_1
-4
+5
 gap> Length(ClassicalMaximalsGeneric("O", 3, 11));
-#I  List incomplete. Missing subgroup in C1 of isotropic type P_1
-3
+4
 gap> Length(ClassicalMaximalsGeneric("O", 3, 13));
-#I  List incomplete. Missing subgroup in C1 of isotropic type P_1
-3
+4
 gap> Length(ClassicalMaximalsGeneric("O", 3, 17));
-#I  List incomplete. Missing subgroup in C1 of isotropic type P_1
-4
+5
 gap> Length(ClassicalMaximalsGeneric("O", 3, 19));
-#I  List incomplete. Missing subgroup in C1 of isotropic type P_1
-4
+5
 gap> Length(ClassicalMaximalsGeneric("O-", 4, 2));
-#I  List incomplete. Missing subgroup in C1 of isotropic type P_1
-2
+3
 gap> Length(ClassicalMaximalsGeneric("O-", 4, 3));
-#I  List incomplete. Missing subgroup in C1 of isotropic type P_1
-4
+5
 gap> Length(ClassicalMaximalsGeneric("O-", 4, 4));
-#I  List incomplete. Missing subgroup in C1 of isotropic type P_1
-3
+4
 gap> Length(ClassicalMaximalsGeneric("O-", 4, 5));
-#I  List incomplete. Missing subgroup in C1 of isotropic type P_1
-4
+5
 gap> Length(ClassicalMaximalsGeneric("O-", 4, 7));
-#I  List incomplete. Missing subgroup in C1 of isotropic type P_1
-6
+7
 gap> Length(ClassicalMaximalsGeneric("O-", 4, 8));
-#I  List incomplete. Missing subgroup in C1 of isotropic type P_1
-4
+5
 gap> Length(ClassicalMaximalsGeneric("O-", 4, 9));
-#I  List incomplete. Missing subgroup in C1 of isotropic type P_1
-4
+5
 gap> Length(ClassicalMaximalsGeneric("O-", 4, 11));
-#I  List incomplete. Missing subgroup in C1 of isotropic type P_1
-4
+5
 gap> Length(ClassicalMaximalsGeneric("O-", 4, 13));
-#I  List incomplete. Missing subgroup in C1 of isotropic type P_1
-6
+7
 gap> Length(ClassicalMaximalsGeneric("O-", 4, 16));
-#I  List incomplete. Missing subgroup in C1 of isotropic type P_1
-3
-gap> Length(ClassicalMaximalsGeneric("O-", 4, 17));
-#I  List incomplete. Missing subgroup in C1 of isotropic type P_1
-6
-gap> Length(ClassicalMaximalsGeneric("O-", 4, 19));
-#I  List incomplete. Missing subgroup in C1 of isotropic type P_1
 4
+gap> Length(ClassicalMaximalsGeneric("O-", 4, 17));
+7
+gap> Length(ClassicalMaximalsGeneric("O-", 4, 19));
+5
 gap> Length(ClassicalMaximalsGeneric("O", 5, 3));
 5
 gap> Length(ClassicalMaximalsGeneric("O", 5, 5));
@@ -1630,5 +1609,4 @@ gap> Length(C9SubgroupsOrthogonalGroupGeneric(-1,12,7 : all:=false));
 1
 
 #
-gap> SetInfoLevel(InfoClassicalMaximals, oldClassicalMaximalsInfoLevel);
 gap> STOP_TEST("ClassicalMaximals.tst", 0);

--- a/tst/standard/ReducibleMatrixGroups.tst
+++ b/tst/standard/ReducibleMatrixGroups.tst
@@ -82,6 +82,8 @@ gap> TestOmegaStabilizerOfIsotropicSubspace := function(epsilon, d, q, k)
 >   CheckIsSubsetOmega(epsilon, d, q, G);
 >   CheckSize(G);
 > end;;
+gap> TestOmegaStabilizerOfIsotropicSubspace(0, 3, 5, 1);
+gap> TestOmegaStabilizerOfIsotropicSubspace(-1, 4, 2, 1);
 gap> TestOmegaStabilizerOfIsotropicSubspace(1, 6, 8, 2);
 gap> TestOmegaStabilizerOfIsotropicSubspace(1, 8, 5, 4);
 gap> TestOmegaStabilizerOfIsotropicSubspace(0, 5, 7, 2);
@@ -106,8 +108,8 @@ gap> OmegaStabilizerOfIsotropicSubspace(0, 5, 5, 3);
 Error, <k> must be less than or equal to <m>
 gap> TestOmegaStabilizerOfIsotropicSubspace(-1, 8, 5, 4);
 Error, <k> must not be equal to <m> for <epsilon> = -1
-gap> TestOmegaStabilizerOfIsotropicSubspace(-1, 4, 5, 1);
-Error, <d> must be at least 5
+gap> TestOmegaStabilizerOfIsotropicSubspace(1, 2, 5, 1);
+Error, <d> must be at least 3
 
 #
 gap> TestOmegaStabilizerOfNonDegenerateSubspace := function(epsilon, d, q, epsilon_0, k)


### PR DESCRIPTION
Reorganises the p-core construction in `OmegaStabilizerOfIsotropicSubspace` to correctly handle the low-dimensional orthogonal cases $(\varepsilon,n,k)=(0,3,1)$ and $(-1,4,1)$.

Closes [#155](https://github.com/gap-packages/ClassicalMaximals/issues/155).