### PR TITLE
Declare recog as needed package and remove unnecessary dependencies

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -105,11 +105,10 @@ Dependencies := rec(
   GAP := ">= 4.15",
   NeededOtherPackages := [
       ["Forms", "1.2.12"],
+      ["recog", "1.5.0"],
     ],
   SuggestedOtherPackages := [ ],
-  TestPackages := [
-      [ "recog", "1.5.0" ],
-  ],
+  TestPackages := [ ],
   ExternalConditions := [ ],
 ),
 

--- a/gap/AlmostSimpleCrossCharacteristic.gi
+++ b/gap/AlmostSimpleCrossCharacteristic.gi
@@ -64,7 +64,7 @@ function(L, q, opts...)
     w := Z(q);
     for o in OAG do
         i := Representative(o);
-        d := Degree(AC[i]);
+        d := DimensionOfMatrixGroup(AC[i]);
         # test if the group fixes a form, and act accordingly.
         forms := CM_ClassicalForms(AC[i], GF(q));
         if forms.formType = "linear" then

--- a/gap/AlmostSimpleDefiningCharacteristic.gi
+++ b/gap/AlmostSimpleDefiningCharacteristic.gi
@@ -1128,7 +1128,7 @@ function(q)
         g := g^(2^f[1,2]);
     fi;
     H := GroupByGenerators([g, g^PseudoRandom(G)]);
-    while not IsAbsolutelyIrreducible(H) do
+    while not MTX.IsAbsolutelyIrreducible(NaturalGModule(H, GF(q))) do
         H := GroupByGenerators(Concatenation(GeneratorsOfGroup(H), [g^PseudoRandom(G)]));
     od;
     while RecogniseClassical(H).isOmegaContained <> true do

--- a/gap/ClassicalMaximals.gi
+++ b/gap/ClassicalMaximals.gi
@@ -779,7 +779,7 @@ function(n, q, opts...)
             # 3.A7
             LR := ReadAsFunction(Filename(CM_c9lib, "3a7d15b.g"))();
             S := ModularReductionOfIntegralLattice(LR, q, opts);
-            S := Filtered(S, s -> Degree(s) = 9);
+            S := Filtered(S, s -> DimensionOfMatrixGroup(s) = 9);
             if not general then
                 size := 7560;
                 SetSize(S[1], size);
@@ -1546,7 +1546,7 @@ function(n, q, opts...)
             # 3.A7
             LR := ReadAsFunction(Filename(CM_c9lib, "3a7d21b.g"))();
             S := ModularReductionOfIntegralLattice(LR, q * q, opts);
-            S := Filtered(S, s -> Degree(s) = 3);
+            S := Filtered(S, s -> DimensionOfMatrixGroup(s) = 3);
             if not general and not normaliser then
                 size := 7560;
                 SetSize(S[1], size);
@@ -1635,7 +1635,7 @@ function(n, q, opts...)
             # 4_2.L34
             LR := ReadAsFunction(Filename(CM_c9lib, "4bl34d20.g"))();
             S := ModularReductionOfIntegralLattice(LR, q * q, opts);
-            S := Filtered(S, s -> Degree(s) = 4);
+            S := Filtered(S, s -> DimensionOfMatrixGroup(s) = 4);
             if not general and not normaliser then
                 size := 4 * SizePSL(3, 4);
                 SetSize(S[1], size);
@@ -2275,7 +2275,7 @@ function(n, q, opts...)
             # see Proposition 6.3.1 (iii)
             LR := ReadAsFunction(Filename(CM_c9lib, "6a7d24.g"))();
             S := ModularReductionOfIntegralLattice(LR, q * q, opts);
-            S := Filtered(S, s -> Degree(s) = 12);
+            S := Filtered(S, s -> DimensionOfMatrixGroup(s) = 12);
             if not general and not normaliser then
                 size := 15120;
                 SetSize(S[1], size);


### PR DESCRIPTION
During automated package tests for the GAP package distribution ([gap-system/PackageDistro#1376](https://github.com/gap-system/PackageDistro/pull/1376), Run tests with OnlyNeeded), it became apparent that the package relied on functionality from packages that were not listed in `NeededOtherPackages`.

In particular, the package directly uses the following functionality from `recog`:
- `RECOG.BaseChangeForSmallestPossibleField`
- `RECOG.HomTensorFactor`
- `RecogniseClassical`

Therefore, `recog >= 1.5.0` is now added to `NeededOtherPackages` in `PackageInfo.g`.

In addition, other avoidable package dependencies are removed by replacing
- `Degree` with `DimensionOfMatrixGroup`
- `IsAbsolutelyIrreducible` (from `irredsol`) with the underlying MTX-based implementation

(There also remains the separate issue that the test suite takes too long ...)